### PR TITLE
fix(map): accept ATAK-style {$z}/{$x}/{$y} tile URL placeholders

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -642,9 +642,41 @@ val TACTICAL_STYLE_DARK_MATTER = buildTacticalStyle(
 )
 
 /**
+ * Normalize tile-URL placeholder syntax to MapLibre/Mapbox convention.
+ *
+ * CivTAK / ATAK and a handful of WMTS docs use `{$z}/{$y}/{$x}` (dollar
+ * inside braces). MapLibre's raster source spec only understands plain
+ * `{z}/{y}/{x}` (and `{bbox-epsg-3857}`, `{quadkey}`). Without this
+ * rewrite the literal `{$z}` text gets requested → 404 and the tile
+ * layer renders empty.
+ *
+ * Applied once at the boundary, in [styleJsonForProvider], so call
+ * sites don't have to remember to normalize. We also strip whitespace
+ * — operators paste from chat and frequently get a stray newline.
+ */
+internal fun normalizeTileUrlPlaceholders(raw: String): String {
+    if (raw.isEmpty()) return raw
+    var out = raw.trim()
+    // Common ATAK / WMTS variants. Order matters only insofar as we
+    // want the longest match first; ${z} → {z} happens before {$z} → {z}
+    // even though Kotlin's replace is exact-match (no overlap).
+    val tokens = listOf("z", "x", "y", "s", "q", "r")
+    for (t in tokens) {
+        out = out
+            .replace("\${$t}", "{$t}")  // ${z}
+            .replace("{\$$t}", "{$t}")  // {$z}
+    }
+    return out
+}
+
+/**
  * Map a [MapProvider] preference to its style JSON. For WMTS_CUSTOM,
  * the operator-supplied XYZ URL is wrapped in a fresh tactical style.
  * Falls back to OSM if WMTS_CUSTOM is selected with an empty/invalid URL.
+ *
+ * Accepts both `{z}/{x}/{y}` (MapLibre / OSM) and `{$z}/{$x}/{$y}`
+ * (CivTAK / ATAK) placeholder conventions — the latter is normalized
+ * before the URL is handed to MapLibre.
  */
 fun styleJsonForProvider(
     provider: MapProvider,
@@ -654,7 +686,7 @@ fun styleJsonForProvider(
     MapProvider.TOPO_HINT -> TACTICAL_STYLE_TOPO
     MapProvider.SATELLITE_HINT -> TACTICAL_STYLE_SATELLITE
     MapProvider.WMTS_CUSTOM -> {
-        val url = customTileUrl.trim()
+        val url = normalizeTileUrlPlaceholders(customTileUrl)
         if (url.startsWith("http") && url.contains("{z}") && url.contains("{x}") && url.contains("{y}")) {
             buildTacticalStyle("OmniTAK Custom WMTS", url, "Custom tile source")
         } else {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -167,7 +167,7 @@ fun SettingsScreen() {
                     modifier = Modifier.fillMaxWidth(),
                 )
                 Text(
-                    "Must be an XYZ-style URL with {z}, {x}, {y} placeholders. WMTS endpoints from agency / private servers usually expose this. Falls back to OSM if invalid.",
+                    "Must be an XYZ-style URL with {z}, {x}, {y} placeholders (ATAK-style {\$z}/{\$x}/{\$y} also works). WMTS endpoints from agency / private servers usually expose this. Falls back to OSM if invalid.",
                     color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
                     style = MaterialTheme.typography.bodySmall,
                 )

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/TileUrlPlaceholderTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/TileUrlPlaceholderTest.kt
@@ -1,0 +1,46 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TileUrlPlaceholderTest {
+
+    @Test fun maplibre_xyz_url_is_unchanged() {
+        val url = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+        assertEquals(url, normalizeTileUrlPlaceholders(url))
+    }
+
+    @Test fun atak_brace_dollar_form_is_normalized() {
+        val input = "https://server.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{\$z}/{\$y}/{\$x}"
+        val expected = "https://server.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{z}/{y}/{x}"
+        assertEquals(expected, normalizeTileUrlPlaceholders(input))
+    }
+
+    @Test fun shell_dollar_brace_form_is_normalized() {
+        val input = "https://example.org/\${z}/\${x}/\${y}.png"
+        val expected = "https://example.org/{z}/{x}/{y}.png"
+        assertEquals(expected, normalizeTileUrlPlaceholders(input))
+    }
+
+    @Test fun wmts_query_string_with_dollar_braces_is_normalized() {
+        val input = "https://data.geopf.fr/wmts?SERVICE=WMTS&request=GetTile&layer=L&TileMatrix={\$z}&TileRow={\$y}&TileCol={\$x}"
+        val expected = "https://data.geopf.fr/wmts?SERVICE=WMTS&request=GetTile&layer=L&TileMatrix={z}&TileRow={y}&TileCol={x}"
+        assertEquals(expected, normalizeTileUrlPlaceholders(input))
+    }
+
+    @Test fun whitespace_is_trimmed() {
+        val input = "  https://t.example/{\$z}/{\$x}/{\$y}.png\n"
+        val expected = "https://t.example/{z}/{x}/{y}.png"
+        assertEquals(expected, normalizeTileUrlPlaceholders(input))
+    }
+
+    @Test fun empty_string_passes_through() {
+        assertEquals("", normalizeTileUrlPlaceholders(""))
+    }
+
+    @Test fun mixed_token_set_is_normalized() {
+        val input = "https://t.example/{\$s}/{\$z}/{\$q}/{\$x}/{\$y}.png"
+        val expected = "https://t.example/{s}/{z}/{q}/{x}/{y}.png"
+        assertEquals(expected, normalizeTileUrlPlaceholders(input))
+    }
+}


### PR DESCRIPTION
## Summary
- Custom map tile URLs from CivTAK / ATAK use `{$z}/{$y}/{$x}` (dollar inside braces). MapLibre raster sources only understand plain `{z}/{y}/{x}`, so the literal `{$z}` text was getting requested and 404'ing silently — operators saw an empty layer.
- New `normalizeTileUrlPlaceholders()` rewrites both `{$token}` and `${token}` forms (z/x/y/s/q/r) at the boundary in `styleJsonForProvider`, and trims pasted whitespace. 7-case unit test covers both conventions, query-string WMTS, and edge cases.
- Settings help text updated to mention ATAK-style placeholders.

Reported by P-E in closed test (Discord, 2026-05-08) for ArcGIS USA_Topo_Maps and IGN data.geopf.fr WMTS URLs that work in CivTAK.

## Follow-ups (not in this PR)
- The IGN WMTS URL has `format=image/png` for an `IGNF_LIDAR-HD_MNS_ELEVATION...SHADOW` layer. Placeholder fix lets MapLibre actually request tiles, but if MapLibre rejects the response (CORS, content-type, projection mismatch) the layer may still appear empty. Worth confirming on hardware with a real WMTS endpoint before declaring this class of bug fully closed.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests "...TileUrlPlaceholderTest"` — green
- [x] `./gradlew :app:assembleDebug` — green
- [ ] Manual: paste both reporter URLs into Settings → Custom WMTS, confirm tiles render on emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)