### PR TITLE
fix(map): UTM coord format on callsign card and Add@ toast

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoordFormatter.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoordFormatter.kt
@@ -24,8 +24,16 @@ object CoordFormatter {
         CoordFormat.MGRS -> runCatching { MGRS.from(Point.point(lon, lat)).coordinate() }
             .getOrElse { latLonDecimal(lat, lon) }
         CoordFormat.UTM -> runCatching {
-            val u = UTM.from(Point.point(lon, lat))
-            "%dZ %.0fE %.0fN".format(u.zone, u.easting, u.northing)
+            val p = Point.point(lon, lat)
+            val u = UTM.from(p)
+            // Band letter (C..X, omitting I and O) comes from the MGRS
+            // grid-zone designator — UTM proper only carries zone + hemisphere,
+            // but the standard "11T 471845mE 5269313mN" readout users expect
+            // includes the latitude band. Falls through to hemisphere if the
+            // band lookup fails (poles / UPS regions outside MGRS coverage).
+            val band: String = runCatching { MGRS.from(p).band.toString() }
+                .getOrElse { if (u.hemisphere.name == "NORTH") "N" else "S" }
+            "%d%s %.0fmE %.0fmN".format(u.zone, band, u.easting, u.northing)
         }.getOrElse { latLonDecimal(lat, lon) }
     }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -379,7 +379,14 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                     "drop" -> if (ll != null) markerSheetLatLng = ll
                     "layers" -> layersSheetOpen = true
                     else -> {
-                        val coord = ll?.let { "%.5f, %.5f".format(it.latitude, it.longitude) } ?: ""
+                        // Respect the operator's coordinate-format pref (Lat/Lon,
+                        // DMS, MGRS, UTM) so the "Add @ …" toast matches the
+                        // SelfPositionCard readout instead of always lat/lon.
+                        val coord = ll?.let {
+                            soy.engindearing.omnitak.mobile.data.CoordFormatter.position(
+                                it.latitude, it.longitude, userPrefs.coordFormat,
+                            )
+                        } ?: ""
                         toast("${action.label}${if (coord.isNotEmpty()) " @ $coord" else ""}")
                     }
                 }

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/CoordFormatterTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/CoordFormatterTest.kt
@@ -1,0 +1,44 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks in the closed-test fix for the May-8 coord-format report (#13):
+ * the SelfPositionCard and "Add @ …" toast both show MGRS-style numbers
+ * even after the operator picked UTM in Settings. The formatter now
+ * emits the canonical `<zone><band> <easting>mE <northing>mN` shape so
+ * MGRS and UTM are visibly different to the operator.
+ */
+class CoordFormatterTest {
+
+    @Test fun utm_includes_band_letter_and_meter_suffix() {
+        // Spokane WA — reporter's location.
+        val s = CoordFormatter.position(47.57662, -117.37438, CoordFormat.UTM)
+        // "<zone><band> <easting>mE <northing>mN" e.g. "11T 471845mE 5269313mN"
+        assertTrue("UTM should start with `11T`, got: $s", s.startsWith("11T "))
+        assertTrue("UTM should carry mE/mN suffixes, got: $s",
+            s.contains("mE") && s.contains("mN"))
+        // Sanity: must NOT look like MGRS (no 100km square letters glued in).
+        assertTrue("UTM must not look like MGRS, got: $s",
+            !s.matches(Regex("\\d+[A-Z] ?[A-Z]{2}.*")))
+    }
+
+    @Test fun mgrs_round_trip_keeps_known_format() {
+        val s = CoordFormatter.position(47.57662, -117.37438, CoordFormat.MGRS)
+        // mil.nga.mgrs returns e.g. "11TMN7184569312"
+        assertTrue("MGRS should be `11TMN…`, got: $s", s.startsWith("11TMN"))
+    }
+
+    @Test fun latlon_decimal_keeps_five_places() {
+        val s = CoordFormatter.position(47.57662, -117.37438, CoordFormat.LATLON_DECIMAL)
+        assertEquals("47.57662, -117.37438", s)
+    }
+
+    @Test fun utm_southern_hemisphere_zone_boundary() {
+        // Just south of the equator, near zone 30/31 boundary at 0° longitude.
+        val s = CoordFormatter.position(-0.5, -0.5, CoordFormat.UTM)
+        assertTrue("UTM south should start `30M`, got: $s", s.startsWith("30M "))
+    }
+}


### PR DESCRIPTION
## Summary
- **Callsign card** already routed through `CoordFormatter` and observed `userPrefs` via `collectAsState`, but the UTM branch produced `"11Z 471845E 5269313N"` — literal `Z`, no band letter, no meter suffix. Operators reading that didn't recognize it as UTM. Now emits canonical `"11T 471845mE 5269313mN"` by looking up the latitude band via `MGRS.getBand()` (NGA `mgrs-android` is already a dependency for MGRS rendering).
- **"Add @" radial-menu toast** in `MapScreen` was hardcoded to `"%.5f, %.5f".format(lat, lon)` and never consulted `userPrefs.coordFormat`, even though `userPrefs` is already in scope from the same Flow collection. Now routed through `CoordFormatter.position(...)`.
- New `CoordFormatterTest` covers UTM band, MGRS shape, lat/lon decimal, and zone-30M southern-hemisphere boundary.

Reported by P-E in closed test (Discord, 2026-05-08): set coord format to UTM, but callsign card still showed MGRS and Add@ still showed lat/lon.

## Edge cases punted (not in this PR)
- Norway zone-32V exception, Svalbard zone-31X/33X/35X/37X overrides, UPS polar caps (>84°N / <80°S). The NGA `mgrs-android` lib handles these internally; just no explicit asserts.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests CoordFormatterTest` — green
- [x] `./gradlew :app:assembleDebug` — green
- [ ] Manual: Settings → coord format → UTM. Confirm callsign card and Add@ toast both reflect change without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)