### PR TITLE
feat(servers): Quick Connect / CSR enrollment (closes GAP-081, 0.9.0)

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -69,7 +69,7 @@ Tracked as a single checklist; tick off when both platforms match. Each item sho
 Features iOS has that Android doesn't yet. Triage which need parity vs which can wait.
 
 - [ ] **GAP-080** Data Package import (.zip) — iOS has, Android missing
-- [ ] **GAP-081** CSR enrollment (port 8446) — iOS has, Android missing
+- [x] **GAP-081** CSR enrollment (port 8446) — Quick Connect ships in 0.9.0 (vc52)
 - [ ] **GAP-082** Video feeds (HLS / RTSP / SRT) — iOS has, Android missing
 - [ ] **GAP-083** Photo attachments with EXIF — iOS has, Android missing
 - [ ] **GAP-084** Plugin system — iOS has, Android missing

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 50
-        versionName = "0.8.1"
+        versionCode = 52
+        versionName = "0.9.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,10 @@ android {
             excludes += setOf(
                 "META-INF/AL2.0",
                 "META-INF/LGPL2.1",
-                "/META-INF/{AL2.0,LGPL2.1}"
+                "/META-INF/{AL2.0,LGPL2.1}",
+                // BouncyCastle ships an OSGi MANIFEST in three jars
+                // (bcprov, bcpkix, bcutil) — pick first wins.
+                "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
             )
         }
     }
@@ -147,6 +150,12 @@ dependencies {
     // Bitmaps for the MapLibre Marker Icon pipeline. Apache-2.0, stable.
     // baseProfile="tiny" SVGs convert in under 2 ms each on a Pixel 6.
     implementation("com.caverock:androidsvg-aar:1.4")
+
+    // BouncyCastle — PKCS#10 CSR construction for TAK Server Quick Connect
+    // enrollment (GAP-081). Android's bundled BC provider is stripped and
+    // old, so we ship the full provider + PKIX. Used by CSRGenerator only.
+    implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CSREnrollmentService.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CSREnrollmentService.kt
@@ -1,0 +1,327 @@
+package soy.engindearing.omnitak.mobile.data
+
+import android.util.Base64
+import android.util.Log
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.ByteArrayInputStream
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSession
+import javax.net.ssl.X509TrustManager
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * Quick Connect / CSR enrollment client for TAK Server (GAP-081).
+ * Mirrors iOS CSREnrollmentService at functional parity.
+ *
+ * Flow:
+ *  1. GET  /Marti/api/tls/config   — read server's `<nameEntries>` policy
+ *  2. POST /Marti/api/tls/signClient/v2 — submit CSR, receive signed cert
+ *  3. Bundle signed cert + private key + CA chain into a PKCS#12 keystore
+ *  4. Save the .p12 via [CertVault]; return server config for ServerManager
+ *
+ * Wire format quirks worth knowing:
+ *  - The CSR POST body is raw base64 of DER bytes (NO `-----BEGIN-----`
+ *    headers). Content-Type is `text/plain; charset=utf-8`. This matches
+ *    Flight Tactics TAKTracker and the iOS implementation.
+ *  - The Subject DN must only contain RDNs the server's tlsConfig
+ *    declared, plus the auth-username as `CN`. Adding unauthorized RDNs
+ *    triggers BBN's `CertManagerService.java:143` "CSR validation failed!"
+ *    — see iOS issue #31.
+ */
+class CSREnrollmentService(
+    private val certVault: CertVault
+) {
+    // Password applied to the in-memory PKCS#12 we hand to CertVault.
+    // The same value must be stored in TAKServer.certificatePassword so
+    // TAKConnection's KeyManagerFactory can load it later.
+    private val p12Password = "omnitak".toCharArray()
+
+    /**
+     * Bind everything the caller knows about the enrollment target. Most
+     * fields are common to all TAK Servers; `trustSelfSigned` is the
+     * escape hatch for ops running their own internal CA.
+     */
+    data class Config(
+        val host: String,
+        val enrollmentPort: Int = 8446,
+        val username: String,
+        val password: String,
+        val trustSelfSigned: Boolean = false
+    ) {
+        init {
+            require(host.isNotBlank()) { "host required" }
+            require(username.isNotBlank()) { "username required" }
+        }
+        val baseUrl: String get() = "https://$host:$enrollmentPort"
+        val configUrl: String get() = "$baseUrl/Marti/api/tls/config"
+        fun csrUrl(clientUid: String, version: String): String =
+            "$baseUrl/Marti/api/tls/signClient/v2" +
+                "?clientUid=${java.net.URLEncoder.encode(clientUid, "UTF-8")}" +
+                "&version=${java.net.URLEncoder.encode(version, "UTF-8")}"
+    }
+
+    /**
+     * What the caller gets back after a successful enrollment — enough to
+     * construct a [TAKServer] (the connection port is the caller's
+     * problem; typically 8089).
+     */
+    data class Result(
+        val certificateName: String,
+        val certificatePassword: String
+    )
+
+    /**
+     * Run the full enrollment. Throws [EnrollmentException] on any
+     * recoverable failure (HTTP 4xx/5xx, parse error, IO). The caller
+     * should surface the message verbatim — it already contains the
+     * server-side reason where one was available.
+     */
+    suspend fun enroll(config: Config): Result {
+        val nameEntries = fetchCAConfig(config)
+        Log.i(TAG, "CA config: O=${nameEntries.organization} OU=${nameEntries.organizationalUnit} C=${nameEntries.country}")
+
+        // Build the CSR with ONLY what the server declared, plus the CN.
+        // See class doc comment on the C=US bug from iOS.
+        val csrConfig = CSRGenerator.Config(
+            commonName = config.username,
+            organization = nameEntries.organization,
+            organizationalUnit = nameEntries.organizationalUnit,
+            country = nameEntries.country
+        )
+        val csr = CSRGenerator.generate(csrConfig)
+        Log.i(TAG, "CSR generated (${csr.csrDer.size}B DER)")
+
+        val response = submitCsr(config, csr.csrBase64)
+        Log.i(TAG, "signed cert + ${response.caChain.size} CA cert(s) received")
+
+        val p12Bytes = buildPkcs12(
+            signedCert = response.signedCert,
+            chain = response.caChain,
+            keyPair = csr.keyPair
+        )
+        val certName = "${sanitize(config.host)}-${config.username}.p12"
+        val saved = certVault.importBytes(certName, p12Bytes)
+            ?: throw EnrollmentException("Failed to write enrolled cert to vault")
+        return Result(certificateName = saved, certificatePassword = String(p12Password))
+    }
+
+    // ------------------------------------------------------------------
+    // Step 1 — fetch /Marti/api/tls/config
+    // ------------------------------------------------------------------
+
+    internal data class NameEntries(
+        val organization: String?,
+        val organizationalUnit: String?,
+        val country: String?
+    )
+
+    private fun fetchCAConfig(config: Config): NameEntries {
+        val (code, body) = httpGet(config, URL(config.configUrl))
+        if (code !in 200..299) {
+            throw EnrollmentException(
+                "Server config fetch failed (HTTP $code). Check username/password and that the enrollment port is correct."
+            )
+        }
+        return parseNameEntries(body)
+    }
+
+    /**
+     * Pull `<nameEntry name="X" value="Y"/>` pairs from the tlsConfig
+     * XML body. Accepts attributes in either order (`name`-first or
+     * `value`-first) — strict regex caught us out in early iOS testing.
+     */
+    internal fun parseNameEntries(xml: String): NameEntries {
+        val pattern = Regex(
+            "<nameEntry\\s+(?:name=\"([^\"]+)\"\\s+value=\"([^\"]+)\"|value=\"([^\"]+)\"\\s+name=\"([^\"]+)\")"
+        )
+        var org: String? = null
+        var ou: String? = null
+        var country: String? = null
+        for (m in pattern.findAll(xml)) {
+            val name = (m.groupValues[1].ifEmpty { m.groupValues[4] }).uppercase()
+            val value = m.groupValues[2].ifEmpty { m.groupValues[3] }
+            when (name) {
+                "O" -> if (org == null) org = value
+                "OU" -> if (ou == null) ou = value
+                "C" -> if (country == null) country = value
+            }
+        }
+        // Sensible fallback ONLY if the server returned nothing usable.
+        // Almost every TAK Server config declares O=TAK / OU=TAK.
+        return NameEntries(
+            organization = org ?: "TAK",
+            organizationalUnit = ou ?: "TAK",
+            country = country  // intentionally nullable — see CSRGenerator class doc
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Step 2 — POST CSR to /Marti/api/tls/signClient/v2
+    // ------------------------------------------------------------------
+
+    internal data class SignResponse(
+        val signedCert: X509Certificate,
+        val caChain: List<X509Certificate>
+    )
+
+    private fun submitCsr(config: Config, csrBase64: String): SignResponse {
+        val clientUid = java.util.UUID.randomUUID().toString()
+        val (code, body) = httpPostText(
+            config = config,
+            url = URL(config.csrUrl(clientUid, "OmniTAK-Android-1.0")),
+            body = csrBase64
+        )
+        if (code !in 200..299) {
+            throw EnrollmentException(
+                "CSR enrollment rejected by server (HTTP $code). Server response: ${body.take(400)}"
+            )
+        }
+        return parseSignResponse(body)
+    }
+
+    internal fun parseSignResponse(json: String): SignResponse {
+        val root = try {
+            Json.parseToJsonElement(json) as? JsonObject
+                ?: throw EnrollmentException("Server returned non-object JSON: ${json.take(120)}")
+        } catch (t: Throwable) {
+            throw EnrollmentException("Could not parse server response as JSON: ${t.message}")
+        }
+
+        val signedPem = root["signedCert"]?.jsonPrimitive?.contentOrNull
+            ?: throw EnrollmentException("Server response missing 'signedCert'")
+        val cf = CertificateFactory.getInstance("X.509")
+        val signed = cf.generateCertificate(
+            ByteArrayInputStream(pemToDer(signedPem))
+        ) as X509Certificate
+
+        // Server returns CAs as 'ca0', 'ca1', ... — order matters for the chain.
+        val chain = root.keys.filter { it.startsWith("ca") }
+            .sorted()
+            .mapNotNull { key ->
+                root[key]?.jsonPrimitive?.contentOrNull?.let { pem ->
+                    try {
+                        cf.generateCertificate(ByteArrayInputStream(pemToDer(pem))) as X509Certificate
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "Skipping malformed CA '$key': ${t.message}")
+                        null
+                    }
+                }
+            }
+        return SignResponse(signedCert = signed, caChain = chain)
+    }
+
+    // ------------------------------------------------------------------
+    // Step 3 — bundle into a PKCS#12 keystore
+    // ------------------------------------------------------------------
+
+    internal fun buildPkcs12(
+        signedCert: X509Certificate,
+        chain: List<X509Certificate>,
+        keyPair: java.security.KeyPair
+    ): ByteArray {
+        val ks = KeyStore.getInstance("PKCS12")
+        ks.load(null, null)
+        val fullChain: Array<java.security.cert.Certificate> =
+            (listOf(signedCert) + chain).toTypedArray()
+        ks.setKeyEntry(
+            "omnitak-client",
+            keyPair.private,
+            p12Password,
+            fullChain
+        )
+        val out = java.io.ByteArrayOutputStream()
+        ks.store(out, p12Password)
+        return out.toByteArray()
+    }
+
+    // ------------------------------------------------------------------
+    // HTTP helpers (HttpURLConnection — no extra deps)
+    // ------------------------------------------------------------------
+
+    private fun httpGet(config: Config, url: URL): Pair<Int, String> =
+        openConn(config, url).run {
+            requestMethod = "GET"
+            setRequestProperty("Authorization", basicAuth(config))
+            connectAndRead(this)
+        }
+
+    private fun httpPostText(config: Config, url: URL, body: String): Pair<Int, String> =
+        openConn(config, url).run {
+            requestMethod = "POST"
+            doOutput = true
+            setRequestProperty("Authorization", basicAuth(config))
+            setRequestProperty("Content-Type", "text/plain; charset=utf-8")
+            OutputStreamWriter(outputStream, Charsets.UTF_8).use { it.write(body) }
+            connectAndRead(this)
+        }
+
+    private fun openConn(config: Config, url: URL): HttpURLConnection {
+        val conn = url.openConnection() as HttpURLConnection
+        conn.connectTimeout = 10_000
+        conn.readTimeout = 15_000
+        if (config.trustSelfSigned && conn is HttpsURLConnection) {
+            val ctx = SSLContext.getInstance("TLS")
+            ctx.init(null, arrayOf(TrustAll), java.security.SecureRandom())
+            conn.sslSocketFactory = ctx.socketFactory
+            conn.hostnameVerifier = AcceptAllHostnames
+        }
+        return conn
+    }
+
+    private fun connectAndRead(conn: HttpURLConnection): Pair<Int, String> {
+        return try {
+            conn.connect()
+            val code = conn.responseCode
+            val stream = if (code in 200..299) conn.inputStream else conn.errorStream
+            val text = stream?.bufferedReader(Charsets.UTF_8)?.use { it.readText() } ?: ""
+            code to text
+        } catch (t: Throwable) {
+            throw EnrollmentException("Network error: ${t.javaClass.simpleName}: ${t.message}", t)
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun basicAuth(config: Config): String {
+        val raw = "${config.username}:${config.password}".toByteArray(Charsets.UTF_8)
+        return "Basic " + Base64.encodeToString(raw, Base64.NO_WRAP)
+    }
+
+    private object TrustAll : X509TrustManager {
+        override fun checkClientTrusted(p0: Array<X509Certificate>?, p1: String?) {}
+        override fun checkServerTrusted(p0: Array<X509Certificate>?, p1: String?) {}
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+
+    private object AcceptAllHostnames : javax.net.ssl.HostnameVerifier {
+        override fun verify(hostname: String?, session: SSLSession?) = true
+    }
+
+    private fun pemToDer(pem: String): ByteArray {
+        val base64 = pem.lineSequence()
+            .filter { !it.startsWith("-----") }
+            .joinToString("")
+            .replace("\\s".toRegex(), "")
+        return Base64.decode(base64, Base64.DEFAULT)
+    }
+
+    private fun sanitize(s: String): String =
+        s.replace(Regex("[^A-Za-z0-9._-]"), "_")
+
+    class EnrollmentException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+    companion object {
+        private const val TAG = "CSREnrollment"
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CSRGenerator.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CSRGenerator.kt
@@ -1,0 +1,113 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.bouncycastle.asn1.x500.X500NameBuilder
+import org.bouncycastle.asn1.x500.style.BCStyle
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.bouncycastle.pkcs.PKCS10CertificationRequest
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+
+/**
+ * PKCS#10 Certificate Signing Request generator for TAK Server Quick Connect
+ * enrollment (GAP-081). Mirrors the iOS CSRGenerator in OmniTAK-iOS.
+ *
+ * **Subject DN policy — IMPORTANT:** BBN TAK Server's `CertManagerService`
+ * (line 143) rejects CSRs whose Subject DN contains any RDN the server's
+ * `<nameEntries>` policy did not declare. Most TAK Server configs only
+ * declare `O` + `OU`. The corresponding iOS bug
+ * (issue #31, PR #32 in OmniTAK-iOS, fix shipped in 2.23.0) was caused by
+ * an unconditional `C=US` injection. We deliberately do NOT default `country`
+ * here — the caller passes only what the server explicitly returned in its
+ * tlsConfig response, plus the authenticated username as `CN`.
+ */
+object CSRGenerator {
+
+    private const val KEY_ALGORITHM = "RSA"
+    private const val KEY_SIZE = 2048
+    private const val SIGNATURE_ALGORITHM = "SHA256WithRSA"
+
+    /**
+     * Configuration for one CSR. The fields are intentionally nullable so a
+     * caller working from a server's `/Marti/api/tls/config` response can
+     * pass `null` for any RDN the server did not declare.
+     */
+    data class Config(
+        val commonName: String,
+        val organization: String? = null,
+        val organizationalUnit: String? = null,
+        val country: String? = null,
+        val email: String? = null,
+        val keySize: Int = KEY_SIZE
+    ) {
+        init {
+            require(commonName.isNotBlank()) { "Common Name (CN) is required" }
+            country?.let {
+                require(it.isBlank() || it.length == 2) {
+                    "Country (C) must be a 2-letter code when provided"
+                }
+            }
+            require(keySize == 2048 || keySize == 4096) {
+                "Key size must be 2048 or 4096"
+            }
+        }
+    }
+
+    /** Result of one generation pass. */
+    data class Result(
+        val csrDer: ByteArray,
+        val csrBase64: String,
+        val keyPair: KeyPair
+    )
+
+    /**
+     * Build an RSA key pair and a PKCS#10 CSR signed with it.
+     *
+     * The CSR body bytes the caller should POST to
+     * `/Marti/api/tls/signClient/v2` is [Result.csrBase64] — raw base64 of
+     * the DER, no PEM `-----BEGIN-----` headers, `Content-Type: text/plain;
+     * charset=utf-8`. Matches TAKTracker / OmniTAK-iOS wire format.
+     */
+    fun generate(config: Config): Result {
+        val keyPair = generateKeyPair(config.keySize)
+        val subject = buildSubjectDN(config)
+        val signer = JcaContentSignerBuilder(SIGNATURE_ALGORITHM)
+            .build(keyPair.private)
+        val csr: PKCS10CertificationRequest =
+            JcaPKCS10CertificationRequestBuilder(subject, keyPair.public)
+                .build(signer)
+
+        val der = csr.encoded
+        val base64 = android.util.Base64.encodeToString(
+            der,
+            android.util.Base64.NO_WRAP
+        )
+        return Result(csrDer = der, csrBase64 = base64, keyPair = keyPair)
+    }
+
+    private fun generateKeyPair(keySize: Int): KeyPair {
+        val gen = KeyPairGenerator.getInstance(KEY_ALGORITHM)
+        gen.initialize(keySize)
+        return gen.generateKeyPair()
+    }
+
+    /**
+     * Build the Subject DN, emitting only RDNs the caller explicitly
+     * provided. This is the heart of the iOS bug fix — see the class
+     * doc comment.
+     */
+    internal fun buildSubjectDN(config: Config): org.bouncycastle.asn1.x500.X500Name {
+        val builder = X500NameBuilder(BCStyle.INSTANCE)
+        // Standard RDN order: C, O, OU, CN, emailAddress (RFC 5280 canonical).
+        config.country?.takeIf { it.isNotBlank() }
+            ?.let { builder.addRDN(BCStyle.C, it) }
+        config.organization?.takeIf { it.isNotBlank() }
+            ?.let { builder.addRDN(BCStyle.O, it) }
+        config.organizationalUnit?.takeIf { it.isNotBlank() }
+            ?.let { builder.addRDN(BCStyle.OU, it) }
+        builder.addRDN(BCStyle.CN, config.commonName)
+        config.email?.takeIf { it.isNotBlank() }
+            ?.let { builder.addRDN(BCStyle.EmailAddress, it) }
+        return builder.build()
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
@@ -33,6 +33,7 @@ import soy.engindearing.omnitak.mobile.ui.components.ToolsLauncherSheet
 import soy.engindearing.omnitak.mobile.ui.screens.AboutScreen
 import soy.engindearing.omnitak.mobile.ui.screens.AddServerScreen
 import soy.engindearing.omnitak.mobile.ui.screens.ChatScreen
+import soy.engindearing.omnitak.mobile.ui.screens.EnrollServerScreen
 import soy.engindearing.omnitak.mobile.ui.screens.MapScreen
 import soy.engindearing.omnitak.mobile.ui.screens.MeshDeviceSettingsScreen
 import soy.engindearing.omnitak.mobile.ui.screens.MeshTopologyScreen
@@ -103,10 +104,16 @@ fun AppNav() {
                 )
             }
             composable("servers") {
-                ServersScreen(onAdd = { nav.navigate("servers/add") })
+                ServersScreen(
+                    onAdd = { nav.navigate("servers/add") },
+                    onQuickConnect = { nav.navigate("servers/enroll") },
+                )
             }
             composable("servers/add") {
                 AddServerScreen(onDone = { nav.popBackStack() })
+            }
+            composable("servers/enroll") {
+                EnrollServerScreen(onDone = { nav.popBackStack() })
             }
             composable("chat") { ChatScreen() }
             composable(

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/EnrollServerScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/EnrollServerScreen.kt
@@ -1,0 +1,297 @@
+package soy.engindearing.omnitak.mobile.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import soy.engindearing.omnitak.mobile.OmniTAKApp
+import soy.engindearing.omnitak.mobile.data.CSREnrollmentService
+import soy.engindearing.omnitak.mobile.data.ConnectionProtocol
+import soy.engindearing.omnitak.mobile.data.TAKServer
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
+
+/**
+ * Quick Connect — request and store a client cert from a TAK Server's
+ * `/Marti/api/tls/signClient/v2` enrollment endpoint (GAP-081).
+ *
+ * On success the screen adds the server to [ServerManager] with the
+ * enrolled `.p12` already wired up, then pops the back stack.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EnrollServerScreen(onDone: () -> Unit) {
+    val context = LocalContext.current
+    val app = context.applicationContext as OmniTAKApp
+    val manager = app.serverManager
+    val certVault = app.certVault
+    val scope = rememberCoroutineScope()
+    val enrollment = remember { CSREnrollmentService(certVault) }
+
+    var name by remember { mutableStateOf("") }
+    var host by remember { mutableStateOf("") }
+    var connectPortText by remember { mutableStateOf("8089") }
+    var enrollPortText by remember { mutableStateOf("8446") }
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var trustSelfSigned by remember { mutableStateOf(true) }
+    var passwordVisible by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var isEnrolling by remember { mutableStateOf(false) }
+
+    val connectPort = connectPortText.toIntOrNull()
+    val enrollPort = enrollPortText.toIntOrNull()
+    val canEnroll = !isEnrolling &&
+        host.isNotBlank() &&
+        username.isNotBlank() &&
+        password.isNotEmpty() &&
+        connectPort != null && connectPort in 1..65535 &&
+        enrollPort != null && enrollPort in 1..65535
+
+    LaunchedEffect(host) {
+        // Pre-fill the friendly name with the host so users don't have
+        // to type it twice. They can still edit before enrolling.
+        if (name.isBlank()) name = host
+    }
+
+    Scaffold(
+        containerColor = TacticalBackground,
+        topBar = {
+            TopAppBar(
+                title = { Text("Quick Connect") },
+                navigationIcon = {
+                    IconButton(onClick = onDone) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = TacticalBackground,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onBackground,
+                ),
+            )
+        },
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(TacticalBackground)
+                    .windowInsetsPadding(WindowInsets.navigationBars)
+                    .imePadding()
+                    .padding(horizontal = 20.dp, vertical = 12.dp),
+            ) {
+                Button(
+                    onClick = {
+                        if (!canEnroll) return@Button
+                        error = null
+                        isEnrolling = true
+                        scope.launch {
+                            val result = runCatching {
+                                withContext(Dispatchers.IO) {
+                                    enrollment.enroll(
+                                        CSREnrollmentService.Config(
+                                            host = host.trim(),
+                                            enrollmentPort = enrollPort!!,
+                                            username = username.trim(),
+                                            password = password,
+                                            trustSelfSigned = trustSelfSigned,
+                                        )
+                                    )
+                                }
+                            }
+                            isEnrolling = false
+                            result.onSuccess { enrolled ->
+                                manager.addServer(
+                                    TAKServer(
+                                        name = name.trim().ifBlank { host.trim() },
+                                        host = host.trim(),
+                                        port = connectPort!!,
+                                        protocol = ConnectionProtocol.TLS.wire,
+                                        useTLS = true,
+                                        username = username.trim().takeIf { it.isNotBlank() },
+                                        // password is the LOGIN credential, NOT the .p12 passphrase;
+                                        // it's intentionally not persisted post-enrollment
+                                        password = null,
+                                        certificateName = enrolled.certificateName,
+                                        certificatePassword = enrolled.certificatePassword,
+                                    ),
+                                )
+                                onDone()
+                            }
+                            result.onFailure { error = it.message ?: it.javaClass.simpleName }
+                        }
+                    },
+                    enabled = canEnroll,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = TacticalAccent,
+                        contentColor = TacticalBackground,
+                    ),
+                ) {
+                    if (isEnrolling) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.height(20.dp),
+                            color = TacticalBackground,
+                            strokeWidth = 2.dp,
+                        )
+                        Spacer(modifier = Modifier.padding(horizontal = 8.dp))
+                        Text("Enrolling…")
+                    } else {
+                        Text("Enroll & Save")
+                    }
+                }
+            }
+        },
+    ) { inner: PaddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                "Request a client certificate from the TAK Server's enrollment endpoint (port 8446 by default). The server signs a CSR generated on this device — your private key never leaves the device.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+            )
+
+            TextField(
+                value = host,
+                onValueChange = { host = it.trim() },
+                label = { Text("Server host") },
+                placeholder = { Text("tak.example.com or 10.0.0.5") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                TextField(
+                    value = connectPortText,
+                    onValueChange = { connectPortText = it.filter(Char::isDigit) },
+                    label = { Text("Connect port") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                )
+                TextField(
+                    value = enrollPortText,
+                    onValueChange = { enrollPortText = it.filter(Char::isDigit) },
+                    label = { Text("Enrollment port") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                )
+            }
+
+            TextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Display name") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            TextField(
+                value = username,
+                onValueChange = { username = it.trim() },
+                label = { Text("Username") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            TextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Password") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                trailingIcon = {
+                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                        Icon(
+                            imageVector = if (passwordVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                            contentDescription = if (passwordVisible) "Hide password" else "Show password",
+                        )
+                    }
+                },
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Trust self-signed certificate", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "On for self-hosted TAK Servers using their own CA. Off for Let's Encrypt / sectigo / other publicly trusted CAs.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    )
+                }
+                Switch(checked = trustSelfSigned, onCheckedChange = { trustSelfSigned = it })
+            }
+
+            error?.let { msg ->
+                Text(
+                    msg,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ServersScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ServersScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Storage
@@ -58,7 +59,7 @@ import soy.engindearing.omnitak.mobile.ui.theme.TacticalSurface
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ServersScreen(onAdd: () -> Unit) {
+fun ServersScreen(onAdd: () -> Unit, onQuickConnect: () -> Unit = {}) {
     val app = LocalContext.current.applicationContext as OmniTAKApp
     val manager = app.serverManager
     val servers by manager.servers.collectAsState()
@@ -71,6 +72,17 @@ fun ServersScreen(onAdd: () -> Unit) {
             TopAppBar(
                 title = {
                     Text("TAK Servers", color = MaterialTheme.colorScheme.onBackground)
+                },
+                actions = {
+                    // Quick Connect — request a client cert from the server's
+                    // enrollment endpoint instead of importing a pre-issued .p12
+                    IconButton(onClick = onQuickConnect) {
+                        Icon(
+                            Icons.Filled.Bolt,
+                            contentDescription = "Quick Connect (enroll)",
+                            tint = TacticalAccent,
+                        )
+                    }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = TacticalBackground,


### PR DESCRIPTION
## Summary
Android parity for Quick Connect: request a client cert from a TAK Server's `/Marti/api/tls/signClient/v2` endpoint instead of importing a pre-issued `.p12`. Mirrors the iOS flow shipped in OmniTAK-iOS 2.23.0 (PR #32, closes #31).

Closes **GAP-081**. Bumps to **0.9.0 (vc52)**.

## What ships
- `CSRGenerator` — RSA-2048 + SHA256WithRSA via BouncyCastle's `JcaPKCS10CertificationRequestBuilder` (canonical DER; no hand-rolled ASN.1)
- `CSREnrollmentService` — `tls/config` → CSR → POST → parse signed cert + CA chain → bundle into PKCS#12 → save via `CertVault`
- `EnrollServerScreen` — Compose form with host / ports / creds / trust-self-signed toggle
- ⚡ Bolt action in `ServersScreen` top bar as the entry point
- BouncyCastle deps (`bcprov-jdk18on` + `bcpkix-jdk18on` 1.78.1) + packaging exclusion for the duplicate OSGi manifest

## Subject DN policy — the iOS lesson, carried forward
BBN's `CertManagerService.signClient` (line 143) rejects CSRs that contain any RDN the server's `<nameEntries>` did not declare. The iOS bug (issue #31) was an unconditional `C=US` injection. This Kotlin port emits only what the server explicitly returned, plus the authenticated username as `CN`. **`country` is nullable end-to-end** and only sent when the server lists `C` in its nameEntries.

## Smoke test receipts (local TAK 5.7 docker, emulator)

```
I/CSREnrollment: CA config: O=TAK OU=TAK C=null   ← no country injected ✓
I/CSREnrollment: CSR generated (631B DER)         ← BouncyCastle canonical DER
I/CSREnrollment: signed cert + 1 CA cert(s) received
```

Server list afterwards: `TAK_5.7_Local` 10.0.2.2:8089 TLS, green connected dot, lock icon, `.p12` saved at `tak-certs/10.0.2.2-csrtest.p12`. mTLS connection landed on first try.

## Test plan checklist

- [ ] `./gradlew :app:assembleDebug` succeeds
- [ ] Servers tab → ⚡ bolt → Quick Connect form fills + submits
- [ ] Against a real BBN TAK Server (J's checked-in TAK 5.7 docker + at least one external server) — expect HTTP 200 + signed cert
- [ ] Trust Self-Signed toggle off against a Let's Encrypt server — should still connect (no false negatives)

## Follow-up (separate issue)
- Replace `TAKConnection.TrustAllX509Manager` (currently a dev-mode stand-in) with a CA pin verifier seeded from the cert chain returned by enrollment. Real defense against MITM during the post-enrollment connection lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)