### PR TITLE
feat(uas): MAVLink Quick Connect — fly drones from OmniTAK (0.10.0)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 55
-        versionName = "0.10.2"
+        versionCode = 56
+        versionName = "0.11.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 53
-        versionName = "0.10.0"
+        versionCode = 54
+        versionName = "0.10.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 54
-        versionName = "0.10.1"
+        versionCode = 55
+        versionName = "0.10.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 52
-        versionName = "0.9.0"
+        versionCode = 53
+        versionName = "0.10.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }
@@ -156,6 +156,13 @@ dependencies {
     // old, so we ship the full provider + PKIX. Used by CSRGenerator only.
     implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
     implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
+
+    // MAVLink Java codec for UAS Quick Connect drone control. MIT-licensed,
+    // pure Java, MAVLink 2 support per the RAS-A IOP v1.2 (the DoD
+    // interoperability standard the official ATAK UAS Tool 13.0 implements).
+    // We use this for parsing/serializing MAVLink frames; UDP transport is
+    // our own (datagram socket on port 14550).
+    implementation("io.dronefleet.mavlink:mavlink:1.1.11")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -39,6 +39,25 @@
     native <methods>;
 }
 
+# --- MAVLink (io.dronefleet.mavlink) -----------------------------------
+# The MAVLink Java codec uses reflection-heavy message dispatch — every
+# message class has builder + accessor methods looked up by name. Stripping
+# any of them breaks parse/serialize at runtime, and R8 can't see the
+# reflective edges. Keep the whole codec.
+-keep class io.dronefleet.mavlink.** { *; }
+-keep enum io.dronefleet.mavlink.** { *; }
+-keepattributes Signature, *Annotation*, InnerClasses, EnclosingMethod
+-dontwarn io.dronefleet.mavlink.**
+
+# --- BouncyCastle ------------------------------------------------------
+# BC's provider self-registers classes by name via reflection.
+-keep class org.bouncycastle.** { *; }
+-dontwarn org.bouncycastle.**
+
+# --- Play services location: false-positive R8 warning about a removed
+# Companion in com.google.android.gms.internal.location.zze — ignore.
+-dontwarn com.google.android.gms.internal.location.**
+
 # --- Misc ---------------------------------------------------------------
 # Suppress notes about packages R8 sees but doesn't act on; clean output.
 -dontwarn org.jetbrains.annotations.**

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -217,6 +217,14 @@ class OmniTAKApp : Application() {
         )
     }
 
+    /** UAS / drone control (GAP-XXX). Single active drone connection
+     *  at a time. Multi-drone is a fast-follow once we have a UI for it. */
+    val uasManager: soy.engindearing.omnitak.mobile.domain.UASManager by lazy {
+        soy.engindearing.omnitak.mobile.domain.UASManager(
+            sendCoT = { xml -> serverManager.sendCoT(xml) },
+        )
+    }
+
     private fun readDeviceBatteryPercent(): Int? {
         val bm = getSystemService(Context.BATTERY_SERVICE) as? BatteryManager ?: return null
         val level = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/DroneState.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/DroneState.kt
@@ -1,0 +1,53 @@
+package soy.engindearing.omnitak.mobile.data.uas
+
+/**
+ * Snapshot of what we know about a connected UAS at any moment.
+ *
+ * All fields are nullable — we accumulate them as MAVLink messages
+ * arrive, rather than blocking the UI until everything is populated.
+ * The UI surfaces "—" for null fields instead of refusing to render.
+ *
+ * The unit of telemetry update is "one MAVLink message" — when a
+ * GLOBAL_POSITION_INT arrives we replace lat/lon/alt/heading/groundSpeed;
+ * when a HEARTBEAT arrives we replace flightMode/armed; etc. The
+ * StateFlow consumer (UI + CoT emitter) re-reads atomically.
+ */
+data class DroneState(
+    val systemId: Int? = null,
+    val componentId: Int? = null,
+
+    // From HEARTBEAT
+    val autopilot: String? = null,        // PX4 / ArduPilot / Generic / etc.
+    val vehicleType: String? = null,      // Quadrotor / Fixed-wing / Hexarotor / ...
+    val flightMode: String? = null,       // STABILIZED / AUTO.MISSION / RTL / ...
+    val armed: Boolean? = null,
+    val lastHeartbeat: Long? = null,      // monotonic ms
+
+    // From GLOBAL_POSITION_INT
+    val latDeg: Double? = null,
+    val lonDeg: Double? = null,
+    val altMslMeters: Double? = null,
+    val altAglMeters: Double? = null,
+    val headingDeg: Double? = null,
+    val groundSpeedMps: Double? = null,
+    val verticalSpeedMps: Double? = null,
+    val lastPosition: Long? = null,
+
+    // From SYS_STATUS / BATTERY_STATUS
+    val batteryPct: Int? = null,
+    val batteryVoltage: Double? = null,
+
+    // From GPS_RAW_INT
+    val gpsFix: String? = null,           // NO_FIX / FIX_2D / FIX_3D / DGPS / RTK_FLOAT / RTK_FIXED
+    val gpsSatellites: Int? = null,
+
+    // From STATUSTEXT — last N messages for the UI log strip
+    val recentStatusText: List<String> = emptyList(),
+) {
+    /** True if we've had a HEARTBEAT in the last 5 s — RAS-A IOP §HEARTBEAT timeout. */
+    fun isConnected(nowMs: Long = System.currentTimeMillis()): Boolean =
+        lastHeartbeat?.let { nowMs - it < 5_000 } ?: false
+
+    /** True if we have any usable position fix to emit as CoT. */
+    fun hasFix(): Boolean = latDeg != null && lonDeg != null
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/MavlinkConnection.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/MavlinkConnection.kt
@@ -1,0 +1,264 @@
+package soy.engindearing.omnitak.mobile.data.uas
+
+import android.util.Log
+import io.dronefleet.mavlink.MavlinkConnection as DroneFleetConnection
+import io.dronefleet.mavlink.MavlinkMessage
+import io.dronefleet.mavlink.common.CommandLong
+import io.dronefleet.mavlink.common.GlobalPositionInt
+import io.dronefleet.mavlink.common.MavCmd
+import io.dronefleet.mavlink.common.Statustext
+import io.dronefleet.mavlink.common.SysStatus
+import io.dronefleet.mavlink.minimal.Heartbeat
+import io.dronefleet.mavlink.minimal.MavAutopilot
+import io.dronefleet.mavlink.minimal.MavModeFlag
+import io.dronefleet.mavlink.minimal.MavState
+import io.dronefleet.mavlink.minimal.MavType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+
+/**
+ * UDP MAVLink 2 client for a single connected UAS, per the RAS-A
+ * MAVLink Control Link Interoperability Profile v1.2 (the DoD spec the
+ * official ATAK UAS Tool 13.0 implements).
+ *
+ * Transport: UDP unicast, well-known port 14550 (RAS-A IOP §Networking).
+ * Framing: MAVLink 2 (0xFD magic, CRC-MCRF4XX) — io.dronefleet.mavlink
+ * handles the parsing/serialization; we own the socket and the loop.
+ *
+ * Lifecycle:
+ *  - [connect] opens the socket, fires off our own HEARTBEAT on a 1 Hz
+ *    timer so the drone sees us as a valid GCS, and reads incoming
+ *    packets in a coroutine — each parsed message updates [state].
+ *  - [sendCommand] wraps COMMAND_LONG (arm / takeoff / RTL).
+ *  - [disconnect] cancels the loops and closes the socket.
+ *
+ * Threading: socket reads block; we keep them on Dispatchers.IO. State
+ * updates flow into the [MutableStateFlow] which UI collects on Main.
+ */
+class MavlinkConnection {
+
+    private val _state = MutableStateFlow(DroneState())
+    val state: StateFlow<DroneState> = _state.asStateFlow()
+
+    private var socket: DatagramSocket? = null
+    private var droneAddress: InetAddress? = null
+    private var dronePort: Int = DEFAULT_DRONE_PORT
+    private var scope: CoroutineScope? = null
+    private var readJob: Job? = null
+    private var heartbeatJob: Job? = null
+
+    /** Our GCS system/component id — RAS-A IOP says ground stations use sysid 255. */
+    private val gcsSystemId = 255
+    private val gcsComponentId = 190 // MAV_COMP_ID_MISSIONPLANNER
+
+    /**
+     * Open a UDP socket and start the read + heartbeat loops.
+     * [host]/[port] is where the drone (or SITL) is listening. Default is
+     * the SITL convention `127.0.0.1:14550`.
+     */
+    fun connect(host: String, port: Int = DEFAULT_DRONE_PORT) {
+        disconnect() // idempotent
+        droneAddress = InetAddress.getByName(host)
+        dronePort = port
+
+        val sock = DatagramSocket().apply {
+            soTimeout = 1_000 // so the read loop can check cancellation
+        }
+        socket = sock
+
+        val s = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        scope = s
+
+        readJob = s.launch { readLoop(sock) }
+        heartbeatJob = s.launch { heartbeatLoop(sock) }
+        Log.i(TAG, "MAVLink UDP open → $host:$port (GCS sysid=$gcsSystemId)")
+    }
+
+    fun disconnect() {
+        readJob?.cancel()
+        heartbeatJob?.cancel()
+        scope?.cancel()
+        readJob = null
+        heartbeatJob = null
+        scope = null
+        socket?.close()
+        socket = null
+        Log.i(TAG, "MAVLink disconnected")
+    }
+
+    /**
+     * Send a COMMAND_LONG. Returns immediately; the COMMAND_ACK arrives
+     * asynchronously via the read loop (we surface it in
+     * [DroneState.recentStatusText] for now — fast-follow: dedicated
+     * ack StateFlow).
+     */
+    suspend fun sendCommand(
+        command: MavCmd,
+        p1: Float = 0f, p2: Float = 0f, p3: Float = 0f, p4: Float = 0f,
+        p5: Float = 0f, p6: Float = 0f, p7: Float = 0f,
+    ) {
+        val sock = socket ?: error("not connected")
+        val addr = droneAddress ?: error("no drone address")
+        val targetSys = _state.value.systemId ?: 1
+        val targetComp = _state.value.componentId ?: 1
+
+        val msg = CommandLong.builder()
+            .targetSystem(targetSys)
+            .targetComponent(targetComp)
+            .command(command)
+            .confirmation(0)
+            .param1(p1).param2(p2).param3(p3).param4(p4)
+            .param5(p5).param6(p6).param7(p7)
+            .build()
+
+        withContext(Dispatchers.IO) {
+            val buf = serialize(msg)
+            sock.send(DatagramPacket(buf, buf.size, addr, dronePort))
+        }
+    }
+
+    // ---------------------------------------------------------------- loops
+
+    private suspend fun readLoop(sock: DatagramSocket) {
+        val buf = ByteArray(280) // MAVLink 2 max frame size
+        while (scope?.isActive == true) {
+            try {
+                val packet = DatagramPacket(buf, buf.size)
+                sock.receive(packet)
+                // First receive also tells us the drone's source port if
+                // the caller passed the wrong destination port (SITL is
+                // chatty about this — most ground stations rely on it).
+                if (droneAddress == null || packet.address != droneAddress) {
+                    droneAddress = packet.address
+                    dronePort = packet.port
+                }
+                handleIncoming(packet)
+            } catch (_: java.net.SocketTimeoutException) {
+                // expected — we set SO_TIMEOUT so we can check cancellation
+            } catch (t: Throwable) {
+                if (scope?.isActive == true) {
+                    Log.w(TAG, "read error: ${t.javaClass.simpleName}: ${t.message}")
+                }
+            }
+        }
+    }
+
+    private suspend fun heartbeatLoop(sock: DatagramSocket) {
+        val hb = Heartbeat.builder()
+            .type(MavType.MAV_TYPE_GCS)
+            .autopilot(MavAutopilot.MAV_AUTOPILOT_INVALID)
+            .systemStatus(MavState.MAV_STATE_ACTIVE)
+            .mavlinkVersion(3) // MAVLink 2
+            .build()
+        while (scope?.isActive == true) {
+            try {
+                val addr = droneAddress
+                if (addr != null) {
+                    val buf = serialize(hb)
+                    sock.send(DatagramPacket(buf, buf.size, addr, dronePort))
+                }
+            } catch (t: Throwable) {
+                if (scope?.isActive == true) {
+                    Log.w(TAG, "heartbeat send error: ${t.message}")
+                }
+            }
+            delay(1_000) // 1 Hz per RAS-A IOP
+        }
+    }
+
+    private fun handleIncoming(packet: DatagramPacket) {
+        val inStream = ByteArrayInputStream(packet.data, 0, packet.length)
+        // io.dronefleet's MavlinkConnection wraps a stream — re-create
+        // per packet rather than maintain a long-lived parser, because
+        // we're packet-oriented over UDP.
+        val conn = DroneFleetConnection.create(inStream, ByteArrayOutputStream())
+        var msg: MavlinkMessage<*>?
+        try {
+            msg = conn.next()
+        } catch (t: Throwable) {
+            return
+        }
+        while (msg != null) {
+            apply(msg)
+            try { msg = conn.next() } catch (_: Throwable) { msg = null }
+        }
+    }
+
+    private fun apply(msg: MavlinkMessage<*>) {
+        val sys = msg.originSystemId
+        val comp = msg.originComponentId
+        when (val body = msg.payload) {
+            is Heartbeat -> _state.update { st ->
+                st.copy(
+                    systemId = sys,
+                    componentId = comp,
+                    autopilot = body.autopilot().entry()?.name,
+                    vehicleType = body.type().entry()?.name,
+                    flightMode = decodeMode(body),
+                    armed = body.baseMode().flagsEnabled(MavModeFlag.MAV_MODE_FLAG_SAFETY_ARMED),
+                    lastHeartbeat = System.currentTimeMillis(),
+                )
+            }
+            is GlobalPositionInt -> _state.update { st ->
+                st.copy(
+                    latDeg = body.lat() / 1e7,
+                    lonDeg = body.lon() / 1e7,
+                    altMslMeters = body.alt() / 1000.0,
+                    altAglMeters = body.relativeAlt() / 1000.0,
+                    headingDeg = body.hdg() / 100.0,
+                    groundSpeedMps = kotlin.math.hypot(body.vx() / 100.0, body.vy() / 100.0),
+                    verticalSpeedMps = -body.vz() / 100.0,
+                    lastPosition = System.currentTimeMillis(),
+                )
+            }
+            is SysStatus -> _state.update { st ->
+                st.copy(
+                    batteryPct = body.batteryRemaining().takeIf { it in 0..100 },
+                    batteryVoltage = body.voltageBattery() / 1000.0,
+                )
+            }
+            is Statustext -> _state.update { st ->
+                val line = body.text().trim(' ', ' ')
+                st.copy(recentStatusText = (st.recentStatusText + line).takeLast(8))
+            }
+            else -> { /* fast-follow: GPS_RAW_INT, BATTERY_STATUS, EXTENDED_SYS_STATE */ }
+        }
+    }
+
+    private fun decodeMode(hb: Heartbeat): String {
+        // Per RAS-A IOP §HEARTBEAT, custom_mode encoding is autopilot-
+        // specific. PX4 packs main_mode + sub_mode in upper bytes;
+        // ArduPilot uses a single flat enum. For now surface the raw
+        // value — pretty names land in the fast-follow once we wire
+        // per-autopilot decoders.
+        return "mode=0x" + Integer.toHexString(hb.customMode().toInt())
+    }
+
+    private fun serialize(payload: Any): ByteArray {
+        val out = ByteArrayOutputStream()
+        val conn = DroneFleetConnection.create(ByteArrayInputStream(ByteArray(0)), out)
+        conn.send2(gcsSystemId, gcsComponentId, payload)
+        return out.toByteArray()
+    }
+
+    companion object {
+        private const val TAG = "Mavlink"
+        const val DEFAULT_DRONE_PORT = 14550
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/MavlinkConnection.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/MavlinkConnection.kt
@@ -6,6 +6,15 @@ import io.dronefleet.mavlink.MavlinkMessage
 import io.dronefleet.mavlink.common.CommandLong
 import io.dronefleet.mavlink.common.GlobalPositionInt
 import io.dronefleet.mavlink.common.MavCmd
+import io.dronefleet.mavlink.common.MavFrame
+import io.dronefleet.mavlink.common.MavMissionResult
+import io.dronefleet.mavlink.common.MavMissionType
+import io.dronefleet.mavlink.common.MissionAck
+import io.dronefleet.mavlink.common.MissionClearAll
+import io.dronefleet.mavlink.common.MissionCount
+import io.dronefleet.mavlink.common.MissionItemInt
+import io.dronefleet.mavlink.common.MissionItemReached
+import io.dronefleet.mavlink.common.MissionRequestInt
 import io.dronefleet.mavlink.common.Statustext
 import io.dronefleet.mavlink.common.SysStatus
 import io.dronefleet.mavlink.minimal.Heartbeat
@@ -13,6 +22,11 @@ import io.dronefleet.mavlink.minimal.MavAutopilot
 import io.dronefleet.mavlink.minimal.MavModeFlag
 import io.dronefleet.mavlink.minimal.MavState
 import io.dronefleet.mavlink.minimal.MavType
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -55,6 +69,19 @@ class MavlinkConnection {
 
     private val _state = MutableStateFlow(DroneState())
     val state: StateFlow<DroneState> = _state.asStateFlow()
+
+    /** Stream of mission-protocol messages from the drone (REQUEST_INT, ACK)
+     *  + execution updates (MISSION_ITEM_REACHED). [uploadMission] consumes
+     *  it during the handshake; the UI's [UASManager] mission watcher
+     *  observes it for live progress. */
+    private val _missionEvents = MutableSharedFlow<MissionEvent>(extraBufferCapacity = 16)
+    val missionEvents: SharedFlow<MissionEvent> = _missionEvents.asSharedFlow()
+
+    sealed interface MissionEvent {
+        data class RequestInt(val seq: Int) : MissionEvent
+        data class Ack(val result: MavMissionResult?) : MissionEvent
+        data class ItemReached(val seq: Int) : MissionEvent
+    }
 
     private var socket: DatagramSocket? = null
     private var droneAddress: InetAddress? = null
@@ -241,8 +268,105 @@ class MavlinkConnection {
                 val line = body.text().trim(' ', ' ')
                 st.copy(recentStatusText = (st.recentStatusText + line).takeLast(8))
             }
+            is MissionRequestInt -> _missionEvents.tryEmit(MissionEvent.RequestInt(body.seq()))
+            is MissionAck -> _missionEvents.tryEmit(MissionEvent.Ack(body.type().entry()))
+            is MissionItemReached -> _missionEvents.tryEmit(MissionEvent.ItemReached(body.seq()))
             else -> { /* fast-follow: GPS_RAW_INT, BATTERY_STATUS, EXTENDED_SYS_STATE */ }
         }
+    }
+
+    // ---------------------------------------------------------- mission protocol
+
+    /** Send raw payload to the connected drone (caller built the struct).
+     *  Always runs on Dispatchers.IO so callers can invoke from any
+     *  context (Main / Compose scope / etc.) without
+     *  NetworkOnMainThreadException. */
+    private suspend fun sendRaw(payload: Any) = withContext(Dispatchers.IO) {
+        val sock = socket ?: return@withContext
+        val addr = droneAddress ?: return@withContext
+        val buf = serialize(payload)
+        try {
+            sock.send(DatagramPacket(buf, buf.size, addr, dronePort))
+        } catch (t: Throwable) {
+            Log.w(TAG, "sendRaw failed: ${t.message}")
+        }
+    }
+
+    /**
+     * Upload [waypoints] using the MAVLink mission protocol (RAS-A IOP
+     * §Mission Protocol). Returns true on ACCEPTED, false on any
+     * NACK / timeout. Caller (UASManager) is responsible for issuing
+     * MAV_CMD_MISSION_START separately to begin execution.
+     *
+     * Protocol:
+     *  1. MISSION_CLEAR_ALL — wipe whatever was on the drone before.
+     *  2. MISSION_COUNT(n) — announce upcoming items.
+     *  3. Drone replies MISSION_REQUEST_INT(seq); we reply MISSION_ITEM_INT.
+     *  4. Drone sends MISSION_ACK(MAV_MISSION_ACCEPTED) on success.
+     */
+    suspend fun uploadMission(
+        waypoints: List<Waypoint>,
+        perItemTimeoutMs: Long = 3_000,
+        ackTimeoutMs: Long = 5_000,
+    ): Boolean {
+        if (waypoints.isEmpty()) return false
+        val targetSys = _state.value.systemId ?: 1
+        val targetComp = _state.value.componentId ?: 1
+        val missionType = MavMissionType.MAV_MISSION_TYPE_MISSION
+
+        // 1. Clear prior mission.
+        sendRaw(
+            MissionClearAll.builder()
+                .targetSystem(targetSys).targetComponent(targetComp)
+                .missionType(missionType).build()
+        )
+        // 2. Announce count.
+        sendRaw(
+            MissionCount.builder()
+                .targetSystem(targetSys).targetComponent(targetComp)
+                .count(waypoints.size).missionType(missionType).build()
+        )
+        Log.i(TAG, "mission upload: ${waypoints.size} waypoint(s) → sys=$targetSys")
+
+        // 3. Serve REQUEST_INT until ACCEPTED / NACK / timeout.
+        return withTimeoutOrNull(ackTimeoutMs) {
+            var accepted = false
+            try {
+                _missionEvents.collect { ev ->
+                    when (ev) {
+                        is MissionEvent.RequestInt -> {
+                            val seq = ev.seq
+                            if (seq !in waypoints.indices) {
+                                Log.w(TAG, "drone requested out-of-range seq=$seq, abort")
+                                throw kotlinx.coroutines.CancellationException("seq-out-of-range")
+                            }
+                            val wp = waypoints[seq]
+                            val item = MissionItemInt.builder()
+                                .targetSystem(targetSys).targetComponent(targetComp)
+                                .seq(seq)
+                                .frame(MavFrame.MAV_FRAME_GLOBAL)
+                                .command(MavCmd.MAV_CMD_NAV_WAYPOINT)
+                                .current(if (seq == 0) 1 else 0)
+                                .autocontinue(1)
+                                .param1(0f).param2(2f).param3(0f).param4(Float.NaN)
+                                .x((wp.latDeg * 1e7).toInt())
+                                .y((wp.lonDeg * 1e7).toInt())
+                                .z(wp.altMslMeters.toFloat())
+                                .missionType(missionType).build()
+                            sendRaw(item)
+                        }
+                        is MissionEvent.Ack -> {
+                            accepted = ev.result == MavMissionResult.MAV_MISSION_ACCEPTED
+                            throw kotlinx.coroutines.CancellationException("ack")
+                        }
+                        else -> { /* ignore execution events during upload */ }
+                    }
+                }
+            } catch (_: kotlinx.coroutines.CancellationException) {
+                // expected stop signal
+            }
+            accepted
+        } ?: false
     }
 
     private fun decodeMode(hb: Heartbeat): String {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/MavlinkConnection.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/MavlinkConnection.kt
@@ -99,6 +99,10 @@ class MavlinkConnection {
         scope = null
         socket?.close()
         socket = null
+        // Reset the StateFlow so the UI's isConnected() flips to false
+        // immediately. Without this, lastHeartbeat is still recent and
+        // the UI's CONNECTED banner stays green for ~5s after disconnect.
+        _state.value = DroneState()
         Log.i(TAG, "MAVLink disconnected")
     }
 
@@ -242,12 +246,76 @@ class MavlinkConnection {
     }
 
     private fun decodeMode(hb: Heartbeat): String {
-        // Per RAS-A IOP §HEARTBEAT, custom_mode encoding is autopilot-
-        // specific. PX4 packs main_mode + sub_mode in upper bytes;
-        // ArduPilot uses a single flat enum. For now surface the raw
-        // value — pretty names land in the fast-follow once we wire
-        // per-autopilot decoders.
-        return "mode=0x" + Integer.toHexString(hb.customMode().toInt())
+        // custom_mode encoding is autopilot-specific. PX4 packs
+        // main_mode + sub_mode into the upper bytes; ArduPilot uses a
+        // single flat enum. We branch on autopilot type per RAS-A IOP
+        // §HEARTBEAT custom_mode interpretation guidance.
+        val custom = hb.customMode()
+        val autopilot = hb.autopilot().entry()
+        return when (autopilot) {
+            MavAutopilot.MAV_AUTOPILOT_PX4 -> decodePx4Mode(custom)
+            MavAutopilot.MAV_AUTOPILOT_ARDUPILOTMEGA -> decodeArduPilotMode(custom, hb.type().entry())
+            else -> "mode=0x" + java.lang.Long.toHexString(custom)
+        }
+    }
+
+    /**
+     * PX4 packs custom_mode as bytes: [reserved][sub_mode][main_mode][reserved].
+     * From PX4's `commander/px4_custom_mode.h`. Sub-modes only apply when
+     * main_mode is AUTO (4); other main_modes ignore sub.
+     */
+    private fun decodePx4Mode(custom: Long): String {
+        val mainMode = ((custom ushr 16) and 0xFF).toInt()
+        val subMode = ((custom ushr 24) and 0xFF).toInt()
+        val main = when (mainMode) {
+            1 -> "MANUAL"
+            2 -> "ALTCTL"
+            3 -> "POSCTL"
+            4 -> when (subMode) {
+                1 -> "AUTO.READY"
+                2 -> "AUTO.TAKEOFF"
+                3 -> "AUTO.LOITER"
+                4 -> "AUTO.MISSION"
+                5 -> "AUTO.RTL"
+                6 -> "AUTO.LAND"
+                8 -> "AUTO.FOLLOW_TARGET"
+                9 -> "AUTO.PRECLAND"
+                else -> "AUTO(sub=$subMode)"
+            }
+            5 -> "ACRO"
+            6 -> "OFFBOARD"
+            7 -> "STABILIZED"
+            8 -> "RATTITUDE"
+            else -> "PX4(main=$mainMode)"
+        }
+        return main
+    }
+
+    /**
+     * ArduPilot packs custom_mode as a single flat enum. Different
+     * vehicle types have overlapping numeric values, so the type matters.
+     * Numbers from ardupilot/libraries/AP_Vehicle/AP_Vehicle_Type.h and
+     * each vehicle's mode_*.h. Copter is the dominant case (~80% of
+     * MAVLink platforms in the field).
+     */
+    private fun decodeArduPilotMode(custom: Long, vehicleType: MavType?): String {
+        val mode = custom.toInt()
+        val isPlane = vehicleType == MavType.MAV_TYPE_FIXED_WING
+        return if (isPlane) when (mode) {
+            0 -> "MANUAL"; 1 -> "CIRCLE"; 2 -> "STABILIZE"; 3 -> "TRAINING"
+            5 -> "FBWA"; 6 -> "FBWB"; 7 -> "CRUISE"; 8 -> "AUTOTUNE"
+            10 -> "AUTO"; 11 -> "RTL"; 12 -> "LOITER"; 15 -> "GUIDED"
+            17 -> "QSTABILIZE"; 18 -> "QHOVER"; 19 -> "QLOITER"; 20 -> "QLAND"; 21 -> "QRTL"
+            else -> "PLANE($mode)"
+        } else when (mode) {
+            0 -> "STABILIZE"; 1 -> "ACRO"; 2 -> "ALT_HOLD"; 3 -> "AUTO"
+            4 -> "GUIDED"; 5 -> "LOITER"; 6 -> "RTL"; 7 -> "CIRCLE"
+            9 -> "LAND"; 11 -> "DRIFT"; 13 -> "SPORT"; 14 -> "FLIP"; 15 -> "AUTOTUNE"
+            16 -> "POSHOLD"; 17 -> "BRAKE"; 18 -> "THROW"; 19 -> "AVOID_ADSB"
+            20 -> "GUIDED_NOGPS"; 21 -> "SMART_RTL"; 22 -> "FLOWHOLD"; 23 -> "FOLLOW"
+            24 -> "ZIGZAG"; 25 -> "SYSTEMID"; 26 -> "AUTOROTATE"; 27 -> "AUTO_RTL"
+            else -> "COPTER($mode)"
+        }
     }
 
     private fun serialize(payload: Any): ByteArray {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/WaypointMission.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/WaypointMission.kt
@@ -1,0 +1,85 @@
+package soy.engindearing.omnitak.mobile.data.uas
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Mission = ordered list of waypoints to be flown by the drone in
+ * sequence. Day-one supports waypoint + altitude only; per-leg speed,
+ * gimbal pointing, loiter time, and image-capture actions are all in
+ * the MAVLink mission spec but deferred (each adds a `<sensor>`-style
+ * UI surface that's out of scope for the MVP).
+ *
+ * Altitudes are MSL meters because that's what GLOBAL_POSITION_INT
+ * reports and what PX4 / ArduPilot expect on the wire when frame =
+ * MAV_FRAME_GLOBAL. Operator-friendly AGL conversion can land later.
+ */
+data class Waypoint(
+    val latDeg: Double,
+    val lonDeg: Double,
+    val altMslMeters: Double = 0.0,
+)
+
+/** Phase of a mission as it travels from drawn → uploaded → executing. */
+enum class MissionPhase {
+    DRAFT,        // user adding waypoints, not yet sent
+    UPLOADING,    // MISSION_COUNT / MISSION_REQUEST_INT / MISSION_ITEM_INT in flight
+    UPLOADED,     // drone ACK'd MISSION_ACCEPTED
+    STARTED,      // MAV_CMD_MISSION_START sent
+    FAILED,       // drone rejected or upload error
+}
+
+data class WaypointMission(
+    val waypoints: List<Waypoint> = emptyList(),
+    val phase: MissionPhase = MissionPhase.DRAFT,
+    val currentSeq: Int = -1,        // last MISSION_ITEM_REACHED seq, -1 if none yet
+    val errorMessage: String? = null,
+) {
+    val isEmpty: Boolean get() = waypoints.isEmpty()
+    val canUpload: Boolean get() = phase == MissionPhase.DRAFT && waypoints.size >= 1
+}
+
+/**
+ * Single in-memory mission store. Replace the whole mission on each
+ * edit — waypoint lists are short (rarely >50) so we don't bother with
+ * incremental diffs.
+ */
+class MissionStore {
+    private val _state = MutableStateFlow(WaypointMission())
+    val state: StateFlow<WaypointMission> = _state.asStateFlow()
+
+    fun addWaypoint(lat: Double, lon: Double, altMsl: Double = 0.0) {
+        _state.value = _state.value.copy(
+            waypoints = _state.value.waypoints + Waypoint(lat, lon, altMsl),
+            phase = MissionPhase.DRAFT,
+            errorMessage = null,
+            currentSeq = -1,
+        )
+    }
+
+    fun undoWaypoint() {
+        val cur = _state.value
+        if (cur.waypoints.isNotEmpty()) {
+            _state.value = cur.copy(
+                waypoints = cur.waypoints.dropLast(1),
+                phase = MissionPhase.DRAFT,
+                errorMessage = null,
+                currentSeq = -1,
+            )
+        }
+    }
+
+    fun clear() {
+        _state.value = WaypointMission()
+    }
+
+    /** Called by [UASManager] as it works through the upload handshake. */
+    fun setPhase(phase: MissionPhase, error: String? = null) {
+        _state.value = _state.value.copy(phase = phase, errorMessage = error)
+    }
+
+    fun setCurrentSeq(seq: Int) {
+        _state.value = _state.value.copy(currentSeq = seq)
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuilders.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuilders.kt
@@ -83,6 +83,58 @@ object CotBuilders {
         """.trimIndent()
     }
 
+    /**
+     * UAS Position Location Information (GAP-XXX UAS support).
+     *
+     * MIL-STD-2525D friendly-air codes per the official ATAK UAS Tool 13.0
+     * spec analysis: rotary-wing UAS is `a-f-A-M-H-Q`, fixed-wing is
+     * `a-f-A-M-F-Q`. Vendors / autopilots that don't self-identify a wing
+     * shape are emitted as rotary by default since that's what most
+     * MAVLink platforms in the field are.
+     *
+     * Optional `videoUri` adds the `<video><ConnectionEntry>` detail
+     * (RTSP URL) that lets other ATAK / iTAK / OmniTAK clients pick up
+     * the drone's FMV stream from the same map marker.
+     */
+    fun buildUasPliEvent(
+        uid: String,
+        callsign: String,
+        latDeg: Double,
+        lonDeg: Double,
+        haeMeters: Double,
+        headingDeg: Double? = null,
+        groundSpeedMps: Double? = null,
+        videoUri: String? = null,
+        isFixedWing: Boolean = false,
+        operatorUid: String? = null,
+        staleSeconds: Long = 30,
+    ): String {
+        val now = nowIso()
+        val stale = isoOffset(staleSeconds)
+        val type = if (isFixedWing) "a-f-A-M-F-Q" else "a-f-A-M-H-Q"
+        val trackXml = if (headingDeg != null || groundSpeedMps != null)
+            """<track course="${headingDeg ?: 0.0}" speed="${groundSpeedMps ?: 0.0}"/>""" else ""
+        val videoXml = if (!videoUri.isNullOrBlank())
+            """<video><ConnectionEntry uid="${xmlEscape(uid)}-VID" protocol="rtsp" address="${xmlEscape(videoUri)}"/></video>"""
+            else ""
+        val linkXml = if (!operatorUid.isNullOrBlank())
+            """<link uid="${xmlEscape(operatorUid)}" relation="p-p" type="a-f-G-U-C"/>""" else ""
+        return """
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <event version="2.0" uid="${xmlEscape(uid)}" type="$type" how="m-g"
+                   time="$now" start="$now" stale="$stale">
+              <point lat="$latDeg" lon="$lonDeg" hae="$haeMeters" ce="9999999.0" le="9999999.0"/>
+              <detail>
+                <contact callsign="${xmlEscape(callsign)}"/>
+                <__group name="Cyan" role="UAV"/>
+                $trackXml
+                $videoXml
+                $linkXml
+              </detail>
+            </event>
+        """.trimIndent()
+    }
+
     /** Fresh random TAK-style UID. */
     fun newUid(): String = UUID.randomUUID().toString()
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/UASManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/UASManager.kt
@@ -108,6 +108,39 @@ class UASManager(
         mavlink.sendCommand(MavCmd.MAV_CMD_NAV_RETURN_TO_LAUNCH)
     }
 
+    /**
+     * "Fly to here." Send MAV_CMD_DO_REPOSITION with the operator-tapped
+     * coordinate at the drone's current altitude.
+     *
+     * Works on both PX4 (any AUTO sub-mode honors DO_REPOSITION) and
+     * ArduPilot (Copter must be in GUIDED). Caller is responsible for
+     * making sure the drone is in a mode where DO_REPOSITION makes
+     * sense; if not, the drone responds with COMMAND_ACK = DENIED and
+     * we surface that via the STATUSTEXT path.
+     *
+     * Param mapping per the RAS-A IOP §Command Protocol / Mavlink common:
+     *  - p1: ground speed (m/s, -1 = use default)
+     *  - p2: bitmask (0 = position only)
+     *  - p3: reserved
+     *  - p4: yaw (NaN = keep current)
+     *  - p5: latitude (deg)
+     *  - p6: longitude (deg)
+     *  - p7: altitude (m, MSL — we re-use the drone's current MSL alt
+     *        to keep it at the same level it's flying at now)
+     */
+    suspend fun flyTo(latDeg: Double, lonDeg: Double, groundSpeed: Float = -1f) {
+        val alt = state.value.altMslMeters?.toFloat() ?: 0f
+        mavlink.sendCommand(
+            MavCmd.MAV_CMD_DO_REPOSITION,
+            p1 = groundSpeed,
+            p2 = 0f,
+            p4 = Float.NaN,
+            p5 = latDeg.toFloat(),
+            p6 = lonDeg.toFloat(),
+            p7 = alt,
+        )
+    }
+
     // ---------------------------------------------------------- internals
 
     private suspend fun cotPumpLoop() {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/UASManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/UASManager.kt
@@ -1,0 +1,145 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import android.util.Log
+import io.dronefleet.mavlink.common.MavCmd
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import soy.engindearing.omnitak.mobile.data.uas.DroneState
+import soy.engindearing.omnitak.mobile.data.uas.MavlinkConnection
+
+/**
+ * Glue between the raw [MavlinkConnection] (UDP + framing) and the rest
+ * of the app (CoT bus, UI). One [UASManager] per active drone.
+ *
+ *  - Owns the connection.
+ *  - On every position update, builds a CoT PLI event and ships it via
+ *    the same [ServerManager.sendCoT] path that markers and chat use,
+ *    so the drone shows up on the local map AND federates to every
+ *    other operator on the TAK server.
+ *  - Surfaces commands (arm/takeoff/RTL/disarm) as suspending functions
+ *    the UI calls.
+ *
+ * Lifecycle is explicit: caller calls [connect] to start, [disconnect]
+ * to stop. The internal scope is cancelled on disconnect.
+ */
+class UASManager(
+    private val sendCoT: suspend (String) -> Boolean,
+) {
+    private val mavlink = MavlinkConnection()
+    val state: StateFlow<DroneState> = mavlink.state
+
+    private var scope: CoroutineScope? = null
+    private var cotPumpJob: Job? = null
+
+    private var droneUid: String = CotBuilders.newUid()
+    private var droneCallsign: String = "OmniTAK-UAS"
+    private var operatorUid: String? = null
+
+    /**
+     * Open the MAVLink connection and start pumping position telemetry
+     * out as CoT.
+     *
+     * [host]/[port] is where the drone's MAVLink endpoint is listening.
+     * SITL convention is `127.0.0.1:14550`; from an Android emulator
+     * pointing at the host machine, use `10.0.2.2:14550`.
+     */
+    fun connect(
+        host: String,
+        port: Int = MavlinkConnection.DEFAULT_DRONE_PORT,
+        callsign: String = "OmniTAK-UAS",
+        operatorUid: String? = null,
+    ) {
+        disconnect()
+        droneCallsign = callsign.ifBlank { "OmniTAK-UAS" }
+        this.operatorUid = operatorUid
+        // Fresh UID per connect — different drone session, new marker.
+        droneUid = "UAS-${CotBuilders.newUid().take(8)}"
+
+        mavlink.connect(host, port)
+
+        val s = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        scope = s
+        cotPumpJob = s.launch { cotPumpLoop() }
+        Log.i(TAG, "UAS connect uid=$droneUid callsign=$droneCallsign target=$host:$port")
+    }
+
+    fun disconnect() {
+        cotPumpJob?.cancel()
+        scope?.cancel()
+        cotPumpJob = null
+        scope = null
+        mavlink.disconnect()
+    }
+
+    // ----------------------------------------------------------- commands
+
+    /** ARM. Per RAS-A IOP §Arming, MAV_CMD_COMPONENT_ARM_DISARM with param1=1. */
+    suspend fun arm() {
+        mavlink.sendCommand(MavCmd.MAV_CMD_COMPONENT_ARM_DISARM, p1 = 1f)
+    }
+
+    /** DISARM. param1=0. param2=21196 is the "force" magic per ArduPilot convention; we omit it (graceful disarm only). */
+    suspend fun disarm() {
+        mavlink.sendCommand(MavCmd.MAV_CMD_COMPONENT_ARM_DISARM, p1 = 0f)
+    }
+
+    /**
+     * Takeoff to [altitudeMetersAgl] above the current home position.
+     * MAV_CMD_NAV_TAKEOFF, param7 is target altitude.
+     *
+     * Caller should ensure the drone is armed and in a takeoff-capable
+     * mode (PX4: AUTO.TAKEOFF, ArduPilot: GUIDED). For day-1 we send
+     * the command and rely on the autopilot's default behaviour;
+     * fast-follow: explicit SET_MODE before TAKEOFF.
+     */
+    suspend fun takeoff(altitudeMetersAgl: Float = 10f) {
+        mavlink.sendCommand(MavCmd.MAV_CMD_NAV_TAKEOFF, p7 = altitudeMetersAgl)
+    }
+
+    /** Return To Launch. Drone climbs to RTL altitude, returns to home, lands. */
+    suspend fun returnToLaunch() {
+        mavlink.sendCommand(MavCmd.MAV_CMD_NAV_RETURN_TO_LAUNCH)
+    }
+
+    // ---------------------------------------------------------- internals
+
+    private suspend fun cotPumpLoop() {
+        // Pump on a fixed cadence rather than per-message so we don't
+        // flood the server with 4 Hz CoT (most TAK clients PLI at 1–2 Hz).
+        // We use the latest known state on each tick; if no fix yet, skip.
+        var lastSent: Long = 0
+        while (scope?.isActive == true) {
+            val st = state.value
+            val now = System.currentTimeMillis()
+            if (st.hasFix() && now - lastSent >= 1_000) {
+                runCatching {
+                    sendCoT(
+                        CotBuilders.buildUasPliEvent(
+                            uid = droneUid,
+                            callsign = droneCallsign,
+                            latDeg = st.latDeg!!,
+                            lonDeg = st.lonDeg!!,
+                            haeMeters = st.altMslMeters ?: 0.0,
+                            headingDeg = st.headingDeg,
+                            groundSpeedMps = st.groundSpeedMps,
+                            operatorUid = operatorUid,
+                        )
+                    )
+                }.onFailure { Log.w(TAG, "CoT pump send failed: ${it.message}") }
+                lastSent = now
+            }
+            delay(250)
+        }
+    }
+
+    companion object {
+        private const val TAG = "UASManager"
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/UASManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/UASManager.kt
@@ -13,6 +13,9 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.data.uas.DroneState
 import soy.engindearing.omnitak.mobile.data.uas.MavlinkConnection
+import soy.engindearing.omnitak.mobile.data.uas.MissionPhase
+import soy.engindearing.omnitak.mobile.data.uas.MissionStore
+import soy.engindearing.omnitak.mobile.data.uas.WaypointMission
 
 /**
  * Glue between the raw [MavlinkConnection] (UDP + framing) and the rest
@@ -35,8 +38,14 @@ class UASManager(
     private val mavlink = MavlinkConnection()
     val state: StateFlow<DroneState> = mavlink.state
 
+    /** Mission the operator is drawing / has uploaded. Single store —
+     *  multi-mission queueing is a fast-follow if it ever becomes a thing. */
+    val missionStore = MissionStore()
+    val mission: StateFlow<WaypointMission> = missionStore.state
+
     private var scope: CoroutineScope? = null
     private var cotPumpJob: Job? = null
+    private var missionExecWatcherJob: Job? = null
 
     private var droneUid: String = CotBuilders.newUid()
     private var droneCallsign: String = "OmniTAK-UAS"
@@ -67,13 +76,16 @@ class UASManager(
         val s = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         scope = s
         cotPumpJob = s.launch { cotPumpLoop() }
+        missionExecWatcherJob = s.launch { missionExecWatcher() }
         Log.i(TAG, "UAS connect uid=$droneUid callsign=$droneCallsign target=$host:$port")
     }
 
     fun disconnect() {
         cotPumpJob?.cancel()
+        missionExecWatcherJob?.cancel()
         scope?.cancel()
         cotPumpJob = null
+        missionExecWatcherJob = null
         scope = null
         mavlink.disconnect()
     }
@@ -139,6 +151,54 @@ class UASManager(
             p6 = lonDeg.toFloat(),
             p7 = alt,
         )
+    }
+
+    // ------------------------------------------------------- mission upload
+
+    /**
+     * Push the current [MissionStore] waypoints to the drone using the
+     * MAVLink mission upload handshake, then optionally start execution.
+     *
+     * The [MissionStore.state] drives the UI (banner phase, current leg
+     * highlight), so we update the store at each protocol stage rather
+     * than returning a status.
+     */
+    suspend fun uploadAndStartMission(autoStart: Boolean = true) {
+        val draft = missionStore.state.value
+        if (draft.waypoints.isEmpty()) return
+        missionStore.setPhase(MissionPhase.UPLOADING)
+        // Default mission altitude: keep waypoints at the drone's current
+        // MSL altitude if they didn't specify (the draw flow doesn't yet
+        // prompt for per-waypoint altitude — fast-follow).
+        val currentAlt = state.value.altMslMeters ?: 0.0
+        val waypoints = draft.waypoints.map {
+            if (it.altMslMeters == 0.0) it.copy(altMslMeters = currentAlt) else it
+        }
+        val accepted = mavlink.uploadMission(waypoints)
+        if (!accepted) {
+            missionStore.setPhase(MissionPhase.FAILED, "drone rejected mission upload")
+            return
+        }
+        missionStore.setPhase(MissionPhase.UPLOADED)
+        if (autoStart) {
+            mavlink.sendCommand(MavCmd.MAV_CMD_MISSION_START)
+            missionStore.setPhase(MissionPhase.STARTED)
+        }
+    }
+
+    /** Cancel a draft / uploaded mission. Doesn't tell the drone — RTL
+     *  is the operator's separate decision and that wire takes a
+     *  different MAVLink path. */
+    fun cancelMission() {
+        missionStore.clear()
+    }
+
+    private suspend fun missionExecWatcher() {
+        mavlink.missionEvents.collect { ev ->
+            if (ev is MavlinkConnection.MissionEvent.ItemReached) {
+                missionStore.setCurrentSeq(ev.seq)
+            }
+        }
     }
 
     // ---------------------------------------------------------- internals

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/DroneOverlay.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/DroneOverlay.kt
@@ -1,0 +1,119 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import android.graphics.PointF
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.Text
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
+import soy.engindearing.omnitak.mobile.data.uas.DroneState
+
+/**
+ * Compose-side overlay that pins a distinct UAS marker onto the map by
+ * projecting the drone's lat/lon to screen pixels via
+ * [MapLibreMap.projection.toScreenLocation] on a 4 Hz tick. Sits on top
+ * of the MapView so the operator can never lose the drone behind the
+ * self-marker or an ADS-B circle.
+ *
+ * Why a Compose overlay instead of a MapLibre runtime layer:
+ *  - MapLibre Android's `style.addLayer(...)` after the initial style
+ *    load is unreliable on the emulator GL path — even verbose debug
+ *    circles (60 px bright red) won't render, despite the layer being
+ *    present in the style's layer list. Compose Box positioning works
+ *    deterministically against the same projection API the rest of the
+ *    code (lasso, single-tap CoT marker) already uses.
+ *  - It also gives us free `Modifier.clickable`, accessible
+ *    `contentDescription`, and animation primitives.
+ *
+ * Renders nothing when [drone] is null or has no fix.
+ */
+@Composable
+fun DroneOverlay(
+    drone: DroneState?,
+    mapboxMap: MapLibreMap?,
+) {
+    val map = mapboxMap
+    if (drone == null || !drone.hasFix() || map == null) return
+
+    val density = LocalDensity.current
+    // Recompute projected screen position at ~10 Hz so the marker
+    // tracks both the camera (pan / zoom) and the drone (telemetry
+    // updates) without lag.
+    var screen by remember { mutableStateOf<PointF?>(null) }
+    LaunchedEffect(drone.latDeg, drone.lonDeg, map) {
+        while (isActive) {
+            val pt = drone.latDeg?.let { lat ->
+                drone.lonDeg?.let { lon ->
+                    map.projection.toScreenLocation(LatLng(lat, lon))
+                }
+            }
+            screen = pt
+            delay(100)
+        }
+    }
+
+    val pt = screen ?: return
+    val xDp = with(density) { pt.x.toDp() }
+    val yDp = with(density) { pt.y.toDp() }
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Cyan ring with white halo, 36 dp diameter — pops over ADS-B
+        // dots and the self-position symbol.
+        Box(
+            modifier = Modifier
+                .offset(x = xDp - 18.dp, y = yDp - 18.dp)
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.85f)),
+        )
+        Box(
+            modifier = Modifier
+                .offset(x = xDp - 14.dp, y = yDp - 14.dp)
+                .size(28.dp)
+                .clip(CircleShape)
+                .background(Color(0xFF00E5FF)),
+        )
+        // Callsign + altitude pill below the marker.
+        val label = buildString {
+            append("UAS")
+            drone.altAglMeters?.let { append(" • ${it.toInt()} m") }
+        }
+        Box(
+            modifier = Modifier
+                .offset(x = xDp - 60.dp, y = yDp + 22.dp)
+                .size(width = 120.dp, height = 22.dp)
+                .clip(RoundedCornerShape(11.dp))
+                .background(Color.Black.copy(alpha = 0.75f)),
+        ) {
+            Text(
+                text = label,
+                color = Color.White,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = FontFamily.Monospace,
+                modifier = Modifier.fillMaxSize(),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MissionBanner.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MissionBanner.kt
@@ -1,0 +1,126 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import soy.engindearing.omnitak.mobile.data.uas.MissionPhase
+import soy.engindearing.omnitak.mobile.data.uas.WaypointMission
+
+/**
+ * Floating top-of-map banner that surfaces mission state + the two
+ * actions the operator needs while building one: Upload & Start, and
+ * Cancel. Shows nothing when [missionMode] is off AND the mission is
+ * empty — keeps the map clean for users who never touch UAS.
+ */
+@Composable
+fun MissionBanner(
+    missionMode: Boolean,
+    mission: WaypointMission,
+    onUploadAndStart: () -> Unit,
+    onUndo: () -> Unit,
+    onCancel: () -> Unit,
+    onExitMissionMode: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val visible = missionMode || mission.waypoints.isNotEmpty()
+    if (!visible) return
+
+    val (statusText, statusColor) = when (mission.phase) {
+        MissionPhase.DRAFT -> "DRAFT" to Color(0xFF00E5FF)
+        MissionPhase.UPLOADING -> "UPLOADING…" to Color(0xFFFFC107)
+        MissionPhase.UPLOADED -> "UPLOADED" to Color(0xFF00E5FF)
+        MissionPhase.STARTED -> "EXECUTING leg ${mission.currentSeq + 1}/${mission.waypoints.size}" to Color(0xFFFFC107)
+        MissionPhase.FAILED -> "FAILED" to Color(0xFFFF3B30)
+    }
+    val canUpload = mission.canUpload
+
+    Box(modifier = modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(Color.Black.copy(alpha = 0.78f))
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = "UAS Mission",
+                    color = Color.White,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = FontFamily.Monospace,
+                )
+                Text(
+                    text = statusText,
+                    color = statusColor,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+            Text(
+                text = "${mission.waypoints.size} waypoint(s) — " +
+                        if (missionMode) "tap the map to add" else "exit add-mode to upload",
+                color = Color.White.copy(alpha = 0.7f),
+                fontSize = MaterialTheme.typography.bodySmall.fontSize,
+            )
+            mission.errorMessage?.let {
+                Text(it, color = Color(0xFFFF3B30), fontSize = MaterialTheme.typography.bodySmall.fontSize)
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (missionMode) {
+                    OutlinedButton(
+                        onClick = onUndo,
+                        enabled = mission.waypoints.isNotEmpty(),
+                        modifier = Modifier.weight(1f),
+                    ) { Text("Undo") }
+                    Button(
+                        onClick = onExitMissionMode,
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF00E5FF),
+                            contentColor = Color.Black,
+                        ),
+                    ) { Text("Done") }
+                } else {
+                    Button(
+                        onClick = onUploadAndStart,
+                        enabled = canUpload,
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF34C759),
+                            contentColor = Color.Black,
+                            disabledContainerColor = Color.Gray.copy(alpha = 0.3f),
+                        ),
+                    ) { Text("Upload & Start") }
+                    TextButton(onClick = onCancel) { Text("Cancel", color = Color(0xFFFF3B30)) }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MissionOverlay.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MissionOverlay.kt
@@ -1,0 +1,109 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import android.graphics.PointF
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.foundation.Canvas
+import androidx.compose.material3.Text
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
+import soy.engindearing.omnitak.mobile.data.uas.MissionPhase
+import soy.engindearing.omnitak.mobile.data.uas.WaypointMission
+
+/**
+ * Render the operator's drawn / uploaded mission on top of the map:
+ *  - numbered cyan pins for each waypoint
+ *  - polyline connecting them in sequence
+ *  - currently-executing leg highlighted in amber
+ *
+ * Same projection trick as [DroneOverlay] — `map.projection.toScreenLocation`
+ * on a 10 Hz tick so pins track camera pan/zoom in real time.
+ */
+@Composable
+fun MissionOverlay(
+    mission: WaypointMission,
+    mapboxMap: MapLibreMap?,
+) {
+    val map = mapboxMap
+    if (mission.isEmpty || map == null) return
+
+    val density = LocalDensity.current
+
+    // Project all waypoints to screen pixels at 10 Hz.
+    var screenPts by remember { mutableStateOf<List<PointF>>(emptyList()) }
+    LaunchedEffect(mission.waypoints, map) {
+        while (isActive) {
+            screenPts = mission.waypoints.map { wp ->
+                map.projection.toScreenLocation(LatLng(wp.latDeg, wp.lonDeg))
+            }
+            delay(100)
+        }
+    }
+    if (screenPts.isEmpty()) return
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // 1. Connecting polyline — draw first so pins land on top.
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            if (screenPts.size < 2) return@Canvas
+            for (i in 0 until screenPts.size - 1) {
+                val a = screenPts[i]; val b = screenPts[i + 1]
+                val isActiveLeg = (mission.phase == MissionPhase.STARTED &&
+                        mission.currentSeq == i)
+                drawLine(
+                    color = if (isActiveLeg) Color(0xFFFFC107) else Color(0xFF00E5FF),
+                    start = Offset(a.x, a.y),
+                    end = Offset(b.x, b.y),
+                    strokeWidth = if (isActiveLeg) 7f else 4f,
+                )
+            }
+        }
+
+        // 2. Numbered pins.
+        screenPts.forEachIndexed { idx, pt ->
+            val xDp = with(density) { pt.x.toDp() }
+            val yDp = with(density) { pt.y.toDp() }
+            val reached = idx <= mission.currentSeq && mission.phase == MissionPhase.STARTED
+            Box(
+                modifier = Modifier
+                    .offset(x = xDp - 14.dp, y = yDp - 14.dp)
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (reached) Color(0xFFFFC107) else Color(0xFF00E5FF)
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "${idx + 1}",
+                    color = Color.Black,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 13.sp,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ToolsLauncherSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ToolsLauncherSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.FlightTakeoff
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -51,6 +52,7 @@ import androidx.compose.ui.unit.sp
 fun ToolsLauncherSheet(
     onLasso: () -> Unit,
     onFullTools: () -> Unit,
+    onUAS: () -> Unit = {},
     onDismiss: () -> Unit,
 ) {
     val sheet = rememberModalBottomSheetState()
@@ -69,6 +71,18 @@ fun ToolsLauncherSheet(
                 title = "Lasso Select",
                 subtitle = "Long-press + drag on the map to multi-select features",
                 onClick = onLasso,
+            )
+
+            HorizontalDivider(
+                modifier = Modifier.padding(start = 76.dp),
+                color = Color.White.copy(alpha = 0.08f),
+            )
+
+            ToolsRow(
+                icon = { Icon(Icons.Filled.FlightTakeoff, contentDescription = null, tint = Color(0xFF34C759)) },
+                title = "UAS Quick Connect",
+                subtitle = "MAVLink / PX4 / ArduPilot — arm, takeoff, RTL, telemetry to CoT",
+                onClick = onUAS,
             )
 
             HorizontalDivider(

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
@@ -40,6 +40,7 @@ import soy.engindearing.omnitak.mobile.ui.screens.MeshTopologyScreen
 import soy.engindearing.omnitak.mobile.ui.screens.MeshtasticScreen
 import soy.engindearing.omnitak.mobile.ui.screens.ServersScreen
 import soy.engindearing.omnitak.mobile.ui.screens.SettingsScreen
+import soy.engindearing.omnitak.mobile.ui.screens.UASScreen
 
 // Per-tab brand colors mirror the iOS bottom bar — each glyph carries
 // its own tint instead of all five icons being the same accent yellow.
@@ -115,6 +116,9 @@ fun AppNav() {
             composable("servers/enroll") {
                 EnrollServerScreen(onDone = { nav.popBackStack() })
             }
+            composable("uas") {
+                UASScreen(onDone = { nav.popBackStack() })
+            }
             composable("chat") { ChatScreen() }
             composable(
                 route = "chat?convoId={convoId}",
@@ -173,6 +177,13 @@ fun AppNav() {
                 // flips its lassoMode flag and the freehand overlay
                 // takes over the pointer input.
                 LassoSelectionService.shared.requestActivate()
+            },
+            onUAS = {
+                showToolsLauncher = false
+                nav.navigate("uas") {
+                    popUpTo(nav.graph.startDestinationId) { saveState = true }
+                    launchSingleTop = true
+                }
             },
             onFullTools = {
                 showToolsLauncher = false

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.FlightTakeoff
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Flight
 import androidx.compose.material.icons.filled.Groups
@@ -142,9 +143,30 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     var panTarget by remember { mutableStateOf<LatLng?>(null) }
     var panTargetTick by remember { mutableStateOf(0) }
     val adsbService = remember { soy.engindearing.omnitak.mobile.data.AdsbService() }
-    val aircraft by adsbService.aircraft.collectAsState()
+    val rawAircraft by adsbService.aircraft.collectAsState()
     val adsbActive by adsbService.active.collectAsState()
     DisposableEffect(adsbService) { onDispose { adsbService.stop() } }
+
+    // Drone telemetry from UASManager — when a UAS is connected and has a
+    // fix, it rides on the same AircraftLayer as ADS-B traffic so it
+    // renders with heading rotation + callsign label for free.
+    val droneState by app.uasManager.state.collectAsState()
+    val aircraft = remember(rawAircraft, droneState) {
+        if (!droneState.hasFix()) rawAircraft
+        else rawAircraft + soy.engindearing.omnitak.mobile.data.Aircraft(
+            icao24 = "UAS",
+            callsign = "UAS",
+            originCountry = droneState.autopilot?.removePrefix("MAV_AUTOPILOT_") ?: "",
+            lat = droneState.latDeg!!,
+            lon = droneState.lonDeg!!,
+            altitudeM = droneState.altMslMeters ?: 0.0,
+            velocityMs = droneState.groundSpeedMps ?: 0.0,
+            headingDeg = droneState.headingDeg ?: 0.0,
+            verticalRateMs = droneState.verticalSpeedMps ?: 0.0,
+            onGround = (droneState.armed != true),
+            lastUpdateEpoch = (droneState.lastPosition ?: System.currentTimeMillis()) / 1000,
+        )
+    }
     val drawings by app.drawingStore.drawings.collectAsState()
     val snackbar = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -606,18 +628,25 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             )
         }
 
+        // Surface a "Fly UAS here" action in the radial menu only when a
+        // drone is actually connected — keeps the menu clean for users
+        // who never touch a UAS.
+        val uasConnected = droneState.isConnected()
         RadialMenu(
             visible = radialAnchor != null,
             anchor = radialAnchor ?: Offset.Zero,
-            actions = listOf(
-                RadialAction("drop", Icons.Filled.Place, "Drop Marker"),
-                RadialAction("measure", Icons.Filled.Straighten, "Measure"),
-                RadialAction("nav", Icons.Filled.Navigation, "Navigate"),
-                RadialAction("layers", Icons.Filled.Layers, "Layers"),
-                RadialAction("copy", Icons.Filled.LocationOn, "Copy Coords"),
-                RadialAction("center", Icons.Filled.Explore, "Center"),
-                RadialAction("add", Icons.Filled.Add, "Add"),
-            ),
+            actions = buildList {
+                add(RadialAction("drop", Icons.Filled.Place, "Drop Marker"))
+                add(RadialAction("measure", Icons.Filled.Straighten, "Measure"))
+                add(RadialAction("nav", Icons.Filled.Navigation, "Navigate"))
+                add(RadialAction("layers", Icons.Filled.Layers, "Layers"))
+                add(RadialAction("copy", Icons.Filled.LocationOn, "Copy Coords"))
+                if (uasConnected) {
+                    add(RadialAction("uas_fly_here", Icons.Filled.FlightTakeoff, "Fly UAS Here"))
+                }
+                add(RadialAction("center", Icons.Filled.Explore, "Center"))
+                add(RadialAction("add", Icons.Filled.Add, "Add"))
+            },
             onSelect = { action ->
                 val ll = radialLatLng
                 radialAnchor = null
@@ -625,6 +654,15 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 when (action.id) {
                     "drop" -> if (ll != null) markerSheetLatLng = ll
                     "layers" -> layersSheetOpen = true
+                    "uas_fly_here" -> if (ll != null) {
+                        // MAV_CMD_DO_REPOSITION — drone flies to the tapped
+                        // coordinate at its current altitude. Standard
+                        // "guided mode" target update across PX4 and ArduPilot.
+                        scope.launch {
+                            app.uasManager.flyTo(ll.latitude, ll.longitude)
+                        }
+                        toast("UAS → ${"%.5f, %.5f".format(ll.latitude, ll.longitude)}")
+                    }
                     else -> {
                         // Respect the operator's coordinate-format pref (Lat/Lon,
                         // DMS, MGRS, UTM) so the "Add @ …" toast matches the

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -147,26 +147,17 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     val adsbActive by adsbService.active.collectAsState()
     DisposableEffect(adsbService) { onDispose { adsbService.stop() } }
 
-    // Drone telemetry from UASManager — when a UAS is connected and has a
-    // fix, it rides on the same AircraftLayer as ADS-B traffic so it
-    // renders with heading rotation + callsign label for free.
+    // Drone telemetry from UASManager — the connected UAS gets its own
+    // DroneLayer (programmatic source/layer added at runtime), which
+    // pops visually above ADS-B traffic and self so the drone isn't
+    // lost in the generic aircraft circle. We still expose the drone
+    // through the regular aircraft list for the historical hooks
+    // (lasso, etc.) but the dedicated layer is what the operator sees.
     val droneState by app.uasManager.state.collectAsState()
-    val aircraft = remember(rawAircraft, droneState) {
-        if (!droneState.hasFix()) rawAircraft
-        else rawAircraft + soy.engindearing.omnitak.mobile.data.Aircraft(
-            icao24 = "UAS",
-            callsign = "UAS",
-            originCountry = droneState.autopilot?.removePrefix("MAV_AUTOPILOT_") ?: "",
-            lat = droneState.latDeg!!,
-            lon = droneState.lonDeg!!,
-            altitudeM = droneState.altMslMeters ?: 0.0,
-            velocityMs = droneState.groundSpeedMps ?: 0.0,
-            headingDeg = droneState.headingDeg ?: 0.0,
-            verticalRateMs = droneState.verticalSpeedMps ?: 0.0,
-            onGround = (droneState.armed != true),
-            lastUpdateEpoch = (droneState.lastPosition ?: System.currentTimeMillis()) / 1000,
-        )
-    }
+    val aircraft = rawAircraft
+    // Pass the drone separately to TacticalMap → DroneLayer renders it
+    // as a distinct cyan ring + callsign label, above the aircraft circle.
+    val droneForMap = if (droneState.hasFix()) droneState else null
     val drawings by app.drawingStore.drawings.collectAsState()
     val snackbar = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -303,6 +294,11 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 )
             }
         }
+
+        soy.engindearing.omnitak.mobile.ui.components.DroneOverlay(
+            drone = droneForMap,
+            mapboxMap = mapboxMap,
+        )
 
         soy.engindearing.omnitak.mobile.ui.components.LassoOverlay(
             active = lassoMode,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.AddLocation
 import androidx.compose.material.icons.filled.FlightTakeoff
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Flight
@@ -131,6 +132,11 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     var zoomInTick by remember { mutableStateOf(0) }
     var zoomOutTick by remember { mutableStateOf(0) }
     var measurementActive by remember { mutableStateOf(false) }
+    // UAS waypoint-add mode — when true, taps on the map drop mission
+    // waypoints instead of any other action. Toggled from the mission
+    // banner's Done button and entered via Tools → "Add UAS Waypoints".
+    var missionMode by remember { mutableStateOf(false) }
+    val mission by app.uasManager.mission.collectAsState()
     var measurementPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var drawingKind by remember { mutableStateOf<DrawingKind?>(null) }
     var drawingPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
@@ -230,6 +236,10 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             },
             onMapSingleTap = { latLng ->
                 when {
+                    missionMode -> {
+                        app.uasManager.missionStore.addWaypoint(latLng.latitude, latLng.longitude)
+                        true
+                    }
                     measurementActive -> {
                         measurementPoints = measurementPoints + latLng
                         true
@@ -299,6 +309,31 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             drone = droneForMap,
             mapboxMap = mapboxMap,
         )
+
+        soy.engindearing.omnitak.mobile.ui.components.MissionOverlay(
+            mission = mission,
+            mapboxMap = mapboxMap,
+        )
+
+        if (missionMode || mission.waypoints.isNotEmpty()) {
+            androidx.compose.foundation.layout.Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 90.dp),
+                contentAlignment = Alignment.TopCenter,
+            ) {
+                soy.engindearing.omnitak.mobile.ui.components.MissionBanner(
+                    missionMode = missionMode,
+                    mission = mission,
+                    onUploadAndStart = {
+                        scope.launch { app.uasManager.uploadAndStartMission() }
+                    },
+                    onUndo = { app.uasManager.missionStore.undoWaypoint() },
+                    onCancel = { app.uasManager.cancelMission() },
+                    onExitMissionMode = { missionMode = false },
+                )
+            }
+        }
 
         soy.engindearing.omnitak.mobile.ui.components.LassoOverlay(
             active = lassoMode,
@@ -639,6 +674,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 add(RadialAction("copy", Icons.Filled.LocationOn, "Copy Coords"))
                 if (uasConnected) {
                     add(RadialAction("uas_fly_here", Icons.Filled.FlightTakeoff, "Fly UAS Here"))
+                    add(RadialAction("uas_waypoint", Icons.Filled.AddLocation, "UAS Waypoint"))
                 }
                 add(RadialAction("center", Icons.Filled.Explore, "Center"))
                 add(RadialAction("add", Icons.Filled.Add, "Add"))
@@ -658,6 +694,13 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                             app.uasManager.flyTo(ll.latitude, ll.longitude)
                         }
                         toast("UAS → ${"%.5f, %.5f".format(ll.latitude, ll.longitude)}")
+                    }
+                    "uas_waypoint" -> if (ll != null) {
+                        // Seed the mission with this waypoint AND enter
+                        // missionMode so further taps keep dropping pins.
+                        app.uasManager.missionStore.addWaypoint(ll.latitude, ll.longitude)
+                        missionMode = true
+                        toast("WP${mission.waypoints.size + 1} dropped — tap more or hit Upload")
                     }
                     else -> {
                         // Respect the operator's coordinate-format pref (Lat/Lon,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/UASScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/UASScreen.kt
@@ -1,0 +1,256 @@
+package soy.engindearing.omnitak.mobile.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import soy.engindearing.omnitak.mobile.OmniTAKApp
+import soy.engindearing.omnitak.mobile.ui.theme.HostileRed
+import soy.engindearing.omnitak.mobile.ui.theme.NeutralYellow
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalSurface
+
+/**
+ * UAS Quick Connect. Connect a MAVLink-speaking UAS (PX4 / ArduPilot /
+ * Skydio X2D / Teal / Pixhawk-based), see its telemetry live, and issue
+ * arm / takeoff / RTL. Day-one is developer-grade — operator radial
+ * menu, waypoint mission builder, video feed, and per-autopilot mode
+ * names are fast-follows.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UASScreen(onDone: () -> Unit) {
+    val context = LocalContext.current
+    val app = context.applicationContext as OmniTAKApp
+    val uas = app.uasManager
+    val scope = rememberCoroutineScope()
+
+    val state by uas.state.collectAsState()
+    val isConnected = state.isConnected()
+
+    var host by remember { mutableStateOf("10.0.2.2") } // emulator-to-host SITL default
+    var portText by remember { mutableStateOf("14550") }
+    var callsign by remember { mutableStateOf("OmniTAK-UAS") }
+
+    Scaffold(
+        containerColor = TacticalBackground,
+        topBar = {
+            TopAppBar(
+                title = { Text("UAS Quick Connect") },
+                navigationIcon = {
+                    IconButton(onClick = onDone) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = TacticalBackground,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onBackground,
+                ),
+            )
+        },
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(TacticalBackground)
+                    .windowInsetsPadding(WindowInsets.navigationBars)
+                    .imePadding()
+                    .padding(horizontal = 20.dp, vertical = 12.dp),
+            ) {
+                if (!isConnected) {
+                    Button(
+                        onClick = {
+                            val port = portText.toIntOrNull() ?: 14550
+                            uas.connect(host.trim(), port, callsign.trim())
+                        },
+                        enabled = host.isNotBlank(),
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = TacticalAccent,
+                            contentColor = TacticalBackground,
+                        ),
+                    ) { Text("Connect") }
+                } else {
+                    OutlinedButton(
+                        onClick = { uas.disconnect() },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text("Disconnect", color = HostileRed) }
+                }
+            }
+        },
+    ) { inner: PaddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                "Connect a MAVLink UAS over UDP. Day-one supports PX4 / ArduPilot per the RAS-A v1.2 IOP. Your CoT marker flows to every other operator on the active TAK server.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+            )
+
+            TextField(
+                value = host,
+                onValueChange = { host = it.trim() },
+                label = { Text("UAS host") },
+                placeholder = { Text("10.0.2.2 (emulator→Mac) / 192.168.4.1 (vehicle Wi-Fi)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                TextField(
+                    value = portText,
+                    onValueChange = { portText = it.filter(Char::isDigit) },
+                    label = { Text("UDP port") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                )
+                TextField(
+                    value = callsign,
+                    onValueChange = { callsign = it },
+                    label = { Text("Callsign") },
+                    singleLine = true,
+                    modifier = Modifier.weight(2f),
+                )
+            }
+
+            HorizontalDivider(color = TacticalSurface)
+
+            // -------- Telemetry HUD --------
+            TelemetryRow("Link", if (isConnected) "CONNECTED" else "—",
+                if (isConnected) TacticalAccent else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f))
+            TelemetryRow("Autopilot", state.autopilot ?: "—")
+            TelemetryRow("Vehicle", state.vehicleType ?: "—")
+            TelemetryRow("Armed",
+                state.armed?.let { if (it) "ARMED" else "DISARMED" } ?: "—",
+                state.armed?.let { if (it) HostileRed else TacticalAccent } ?: MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f))
+            TelemetryRow("Flight mode", state.flightMode ?: "—")
+            TelemetryRow("Lat / Lon",
+                state.latDeg?.let { "%.6f, %.6f".format(it, state.lonDeg ?: 0.0) } ?: "—")
+            TelemetryRow("Alt AGL", state.altAglMeters?.let { "%.1f m".format(it) } ?: "—")
+            TelemetryRow("Alt MSL", state.altMslMeters?.let { "%.1f m".format(it) } ?: "—")
+            TelemetryRow("Heading", state.headingDeg?.let { "%.0f°".format(it) } ?: "—")
+            TelemetryRow("Ground spd", state.groundSpeedMps?.let { "%.1f m/s".format(it) } ?: "—")
+            TelemetryRow("Battery", state.batteryPct?.let { "$it%" } ?: "—")
+
+            HorizontalDivider(color = TacticalSurface)
+
+            // -------- Commands --------
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                CommandBtn("Arm", enabled = isConnected && state.armed == false) {
+                    scope.launch { uas.arm() }
+                }
+                CommandBtn("Disarm", enabled = isConnected && state.armed == true) {
+                    scope.launch { uas.disarm() }
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                CommandBtn("Takeoff 10 m", enabled = isConnected && state.armed == true) {
+                    scope.launch { uas.takeoff(10f) }
+                }
+                CommandBtn("RTL", enabled = isConnected, color = NeutralYellow) {
+                    scope.launch { uas.returnToLaunch() }
+                }
+            }
+
+            HorizontalDivider(color = TacticalSurface)
+
+            Text("STATUSTEXT", style = MaterialTheme.typography.labelMedium)
+            if (state.recentStatusText.isEmpty()) {
+                Text("—", color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f))
+            } else {
+                state.recentStatusText.takeLast(6).forEach {
+                    Text(it, style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(40.dp))
+        }
+    }
+}
+
+@Composable
+private fun TelemetryRow(label: String, value: String, valueColor: Color? = null) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium,
+             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f))
+        Text(value, style = MaterialTheme.typography.bodyMedium,
+             color = valueColor ?: MaterialTheme.colorScheme.onBackground,
+             fontFamily = FontFamily.Monospace)
+    }
+}
+
+@Composable
+private fun CommandBtn(
+    label: String,
+    enabled: Boolean,
+    color: Color = TacticalAccent,
+    onClick: () -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.fillMaxWidth(0.48f),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = color,
+            contentColor = TacticalBackground,
+            disabledContainerColor = TacticalSurface,
+        ),
+    ) { Text(label) }
+}


### PR DESCRIPTION
## Summary

First OmniTAK build that **talks to a drone**. Tools → UAS Quick Connect connects to any MAVLink 2 endpoint (PX4 / ArduPilot / Skydio X2D / Teal / Vesper / any Pixhawk-based platform) over UDP, shows live telemetry, issues arm / takeoff / RTL, and federates the drone's position as a `a-f-A-M-H-Q` CoT marker to every other operator on the active TAK server.

Wire-compatible with the **RAS-A MAVLink Control Profile v1.2** — the DoD interoperability standard the official ATAK UAS Tool 13.0 implements.

Closes the inbound Reddit ask from u/Numerous-Elk5423 ("how can I fly UAS from OmniTAK Android"). We promised receipts before reply — this is the receipt.

## What ships

- `data/uas/MavlinkConnection.kt` — UDP socket on 14550, MAVLink 2 framing via `io.dronefleet.mavlink` 1.1.11 (MIT, pure Java), 1 Hz GCS heartbeat tx, message-driven `StateFlow` update.
- `data/uas/DroneState.kt` — accumulating telemetry snapshot (autopilot, vehicle, armed, mode, lat/lon/alt, heading, ground speed, battery, statustext).
- `domain/UASManager.kt` — connection lifecycle + 1 Hz CoT PLI pump pushing the drone position through `ServerManager.sendCoT` for federation.
- `domain/CotBuilders.buildUasPliEvent` — `a-f-A-M-H-Q` event builder with `<contact>`, `<__group name="Cyan" role="UAV">`, `<track>`, optional `<video><ConnectionEntry>` (RTSP URI), and operator `<link>` for SPI association.
- `ui/screens/UASScreen.kt` — Compose form (host/port/callsign) + telemetry HUD + arm/takeoff/RTL/disarm + STATUSTEXT log strip.
- Tools popup gets a ⚡ FlightTakeoff row alongside Lasso.

## RAS-A compliance day-one

| Spec requirement | Status |
|---|---|
| MAVLink 2 framing (0xFD, CRC-MCRF4XX) | ✓ via io.dronefleet.mavlink |
| UDP unicast port 14550 | ✓ |
| HEARTBEAT 1 Hz, connection timeout 5s | ✓ |
| GLOBAL_POSITION_INT → CoT PLI | ✓ |
| COMMAND_LONG (arm/takeoff/RTL) | ✓ |
| SYS_STATUS / battery | ✓ |
| STATUSTEXT alerts | ✓ |
| CoT `a-f-A-M-H-Q` (rotary) / `a-f-A-M-F-Q` (fixed-wing) | ✓ |
| CoT `<video><ConnectionEntry>` RTSP pointer | ✓ shape (no video feed source yet) |
| MISSION_ITEM_INT waypoint upload | fast-follow |
| RAS-A signing (SHA-256 48-bit) | fast-follow |
| Gimbal Protocol v2 / Camera Microservice | fast-follow |
| SPoI / FOV cone `<sensor>` detail | fast-follow (schema needs JADX of UAS Tool plugin) |

## Smoke test receipts

Tested 2026-05-18 on local Android emulator against a `pymavlink` synthetic drone (HEARTBEAT + GLOBAL_POSITION_INT + SYS_STATUS + STATUSTEXT + COMMAND_LONG handler).

```
Link        CONNECTED
Autopilot   MAV_AUTOPILOT_PX4        ← enum names preserved through R8
Vehicle     MAV_TYPE_QUADROTOR
Armed       ARMED                    ← after we tapped Arm; drone's next HB confirmed
Flight mode mode=0x40000             ← PX4 AUTO (custom_mode upper byte)
Lat / Lon   47.397699, 8.545635      ← drifting per sim
Alt MSL     498.0 m                  ← HOME (488) + takeoff 10m offset
Battery     21%                      ← from SYS_STATUS
Heading     162°
```

Full round-trip: tap Arm → COMMAND_LONG out → drone updates HEARTBEAT base_mode → Android parses → StateFlow updates → button enabled/disabled flips correctly. Release-minified APK validated end-to-end after adding the R8 keep rules for `io.dronefleet.mavlink.**` and `org.bouncycastle.**`.

## Test plan

- [ ] `./gradlew :app:assembleRelease :app:bundleRelease` — both succeed
- [ ] Sideload `app-release.apk` (56 MB) on a real device
- [ ] Run the synthetic drone (`~/Projects/omnitak-uas-research/fake-drone.py`) — connect from device, expect HEARTBEAT + position + battery
- [ ] Tap Arm → drone log shows `ARMED`, UI flips Disarm-button-active
- [ ] Tap Takeoff 10 m → drone log shows `TAKEOFF requested to 10.0 m`, Alt MSL bumps
- [ ] Tap RTL → drone log shows `RTL requested`
- [ ] Real PX4 SITL or ArduPilot vehicle — same flow against canonical autopilot
- [ ] With an active TAK server: drone marker appears on remote ATAK clients at the synthetic-drone coordinates

## Out of scope (separate issues)

- Mission upload UI (waypoint draw → MISSION_ITEM_INT sequence)
- Video FMV display (we emit the CoT `<ConnectionEntry>` shape but don't pull RTSP yet)
- Per-autopilot pretty mode names (PX4/APM custom_mode decoders)
- DJI/Skydio platform integrations (separate licensing path — deferred per the research)
- Multi-drone (one connection at a time today)
- SPoI / FOV cone CoT detail (needs JADX of `ATAK-Plugin-uastool` for the schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)