### PR TITLE
fix(android): Add TAK Server keyboard inset + Quick Connect clarity

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/AddServerScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/AddServerScreen.kt
@@ -172,12 +172,29 @@ fun AddServerScreen(onDone: () -> Unit) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                // BUG-C (closed-test, May 2026) — the focused field used to
+                // disappear behind the keyboard. Root cause was a double
+                // keyboard inset: the sticky bottomBar already applies
+                // imePadding, so Scaffold reports a keyboard-aware `inner`.
+                // The content Column ALSO applied .imePadding(), reserving
+                // ~2x the keyboard height at the bottom of the scroll
+                // viewport and pushing the focused field into the dead zone.
+                // `inner` is the single source of truth — no second imePadding.
                 .padding(inner)
-                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            // BUG-C — orient the user before the long form. Manual entry here
+            // vs. the Quick Connect (⚡) enrollment flow on the Servers screen.
+            Text(
+                "Fill in your server's details below. Has your server's admin " +
+                    "set up auto-enrollment? Use Quick Connect (⚡) on the " +
+                    "Servers screen instead to fetch a certificate automatically.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.65f),
+            )
+
             OutlinedTextField(
                 value = name,
                 onValueChange = { name = it },
@@ -327,7 +344,10 @@ fun AddServerScreen(onDone: () -> Unit) {
                 color = MaterialTheme.colorScheme.onBackground,
             )
             Text(
-                "Required for OpenTAKserver and most CoT servers with auth.",
+                "A username/password login — separate from the client " +
+                    "certificate above. Required for OpenTAKServer and most " +
+                    "CoT servers with basic auth. Leave blank if your server " +
+                    "only uses certificates.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.65f),
             )

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ServersScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ServersScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -75,13 +76,19 @@ fun ServersScreen(onAdd: () -> Unit, onQuickConnect: () -> Unit = {}) {
                 },
                 actions = {
                     // Quick Connect — request a client cert from the server's
-                    // enrollment endpoint instead of importing a pre-issued .p12
-                    IconButton(onClick = onQuickConnect) {
+                    // enrollment endpoint instead of importing a pre-issued .p12.
+                    // BUG-C (closed-test, May 2026) — the icon-only bolt was
+                    // not discoverable; testers couldn't tell it was for cert
+                    // enrollment vs. the + (manual add). Show a visible label.
+                    TextButton(onClick = onQuickConnect) {
                         Icon(
                             Icons.Filled.Bolt,
-                            contentDescription = "Quick Connect (enroll)",
+                            contentDescription = null,
                             tint = TacticalAccent,
+                            modifier = Modifier.size(18.dp),
                         )
+                        Spacer(Modifier.width(4.dp))
+                        Text("Quick Connect", color = TacticalAccent)
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -157,7 +164,9 @@ private fun EmptyServers(modifier: Modifier = Modifier) {
         )
         Spacer(Modifier.height(8.dp))
         Text(
-            "Tap the + button to add your first server.",
+            "Tap + to enter a server manually, or Quick Connect (⚡) to " +
+                "auto-enroll a certificate from a TAK Server's enrollment " +
+                "endpoint.",
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
         )


### PR DESCRIPTION
Closed-test feedback (SLAB, May 2026) on the **Add TAK Server** screen.

## 1. Keyboard hid the focused field
The sticky Save bar already applies `imePadding()`, so `Scaffold` reports a keyboard-aware `inner`. The content `Column` applied `imePadding()` a **second** time, reserving ~2× the keyboard height at the bottom of the scroll viewport and pushing the focused field into a dead zone. Dropped the duplicate — `inner` is the single source of truth.

## 2. "Server credentials vs cert enrollment" was unclear
- Lightning bolt → labeled **"⚡ Quick Connect"** button (was icon-only, undiscoverable)
- Servers empty state spells out both paths (`+` manual, ⚡ enroll)
- Add form gets a top orientation note + reworded "Server credentials" to clarify it's a login **separate from the client certificate**

## Verification
Built + installed on `engie_emulator`. Confirmed on-device: Port and bottom-most Username field stay fully visible above the docked keyboard; Save lifts above it. New copy + Quick Connect label render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)