### PR TITLE
Multi-server parity: connections, chat attribution, map indicator, Mission Sync (0.32.0)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 78
-        versionName = "0.30.2"
+        versionCode = 79
+        versionName = "0.31.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 79
-        versionName = "0.31.0"
+        versionCode = 80
+        versionName = "0.32.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -226,6 +226,15 @@ class OmniTAKApp : Application() {
         )
     }
 
+    /** Multi-server mission / data-package sync over the Marti REST API.
+     *  Aggregates across every enabled TLS+cert server (iOS parity). */
+    val missionSyncManager: soy.engindearing.omnitak.mobile.domain.MissionSyncManager by lazy {
+        soy.engindearing.omnitak.mobile.domain.MissionSyncManager(
+            serverManager = serverManager,
+            certVault = certVault,
+        )
+    }
+
     /** UAS / drone control (GAP-XXX). Single active drone connection
      *  at a time. Multi-drone is a fast-follow once we have a UI for it. */
     /** Registry of all connected UAS — supports multi-drone ops. The

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ChatMessage.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ChatMessage.kt
@@ -21,6 +21,12 @@ data class ChatMessage(
     val timeIso: String,
     val status: ChatStatus = ChatStatus.RECEIVED,
     val isFromSelf: Boolean = false,
+    /**
+     * Source server (received) / target server (sent), = [TAKServer.id].
+     * null for mesh chat and for messages predating multi-server. Drives the
+     * per-message server badge and per-server DM conversation scoping.
+     */
+    val serverId: String? = null,
 )
 
 data class ChatParticipant(
@@ -36,6 +42,13 @@ data class ChatConversation(
     val lastMessagePreview: String? = null,
     val lastActivityIso: String? = null,
     val unread: Int = 0,
+    /**
+     * TAK server this (per-server) DM thread belongs to, = [TAKServer.id].
+     * null for the merged All-Chat broadcast room and for mesh chat, which
+     * broadcast to every connected server. Used to route DM replies back to
+     * their origin server (multi-server parity with iOS).
+     */
+    val serverId: String? = null,
 )
 
 object ChatRoom {
@@ -44,8 +57,18 @@ object ChatRoom {
     const val ALL_USERS = "All Chat Users"
     const val BROADCAST = "BROADCAST"
 
-    fun directConversationId(uidA: String, uidB: String): String {
+    /**
+     * Deterministic DM bucket. When [serverId] is given the bucket is scoped
+     * per server (DM-{serverId}-{uidA}-{uidB}) so a DM with the same callsign
+     * on two different TAK servers stays in two separate threads — matches
+     * iOS's per-server DM scoping.
+     */
+    fun directConversationId(uidA: String, uidB: String, serverId: String? = null): String {
         val sorted = listOf(uidA, uidB).sorted()
-        return "DM-${sorted[0]}-${sorted[1]}"
+        return if (serverId != null) {
+            "DM-$serverId-${sorted[0]}-${sorted[1]}"
+        } else {
+            "DM-${sorted[0]}-${sorted[1]}"
+        }
     }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ChatXml.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ChatXml.kt
@@ -87,7 +87,7 @@ object ChatXml {
      * not a chat message or is malformed. Direct-message detection
      * uses the chatroom name against ATAK's canonical broadcast label.
      */
-    fun parse(xml: String, selfUid: String? = null): ChatMessage? {
+    fun parse(xml: String, selfUid: String? = null, serverId: String? = null): ChatMessage? {
         val factory = XmlPullParserFactory.newInstance().apply { isNamespaceAware = false }
         val parser = factory.newPullParser()
         parser.setInput(StringReader(xml))
@@ -151,13 +151,16 @@ object ChatXml {
             chatroom.equals(ChatRoom.BROADCAST, ignoreCase = true) ||
             chatroom.lowercase().contains("all chat")
 
+        // Group chat (All Chat Rooms) is a single merged room across servers;
+        // DMs are scoped per server so the same callsign on two servers stays
+        // in two distinct threads (multi-server parity with iOS).
         val conversationId = if (isGroup) {
             ChatRoom.ALL_USERS
         } else if (selfUid != null) {
-            ChatRoom.directConversationId(finalSenderUid, selfUid)
+            ChatRoom.directConversationId(finalSenderUid, selfUid, serverId)
         } else {
-            // Without a self-uid, fall back to grouping by peer.
-            "DM-${finalSenderUid}"
+            // Without a self-uid, fall back to grouping by peer (still per-server).
+            if (serverId != null) "DM-$serverId-$finalSenderUid" else "DM-$finalSenderUid"
         }
 
         return ChatMessage(
@@ -171,6 +174,7 @@ object ChatXml {
             timeIso = eventTime ?: DateTimeFormatter.ISO_INSTANT.format(Instant.now()),
             status = ChatStatus.RECEIVED,
             isFromSelf = selfUid != null && finalSenderUid == selfUid,
+            serverId = serverId,
         )
     }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakRestApiClient.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakRestApiClient.kt
@@ -1,0 +1,239 @@
+package soy.engindearing.omnitak.mobile.data
+
+import android.util.Base64
+import android.util.Log
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import java.io.ByteArrayInputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.KeyManager
+import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSession
+import javax.net.ssl.X509TrustManager
+
+/**
+ * TAK Server Marti REST API client — mission + data-package sync. The Android
+ * counterpart to iOS's TAKRestAPIClient, built on plain [HttpsURLConnection]
+ * with mutual-TLS (same approach as [CSREnrollmentService]) so we add no new
+ * HTTP dependency.
+ *
+ * One instance is bound to one [TAKServer]; [MissionSyncManager] spins up one
+ * per enabled server and aggregates. mTLS uses the operator's imported `.p12`
+ * (via [CertVault]); server trust is dev-mode trust-all, matching
+ * [TAKConnection] until CA pinning lands.
+ *
+ * Dialect tolerance (verified against the 4-server matrix — TAK Server 5.7,
+ * OpenTAKServer 1.7.x, taky 0.10):
+ *  - reachability uses `/Marti/api/version/config` (the one endpoint all three
+ *    return 200 for — `/Marti/api/version` 404s on OpenTAKServer).
+ *  - list envelopes differ: TAK5.7/OTS wrap in `{data:[…]}`, taky's sync
+ *    search returns `{resultCount,results:[…]}` — both handled, plus a bare
+ *    top-level array.
+ *  - taky has no `/Marti/api/missions` route; that fetch is tolerated empty.
+ */
+class TakRestApiClient(
+    private val server: TAKServer,
+    private val certVault: CertVault?,
+) {
+    /** TAK HTTPS API port. Distinct from the CoT streaming port in [server]. */
+    private val apiPort = SECURE_API_PORT
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    private fun baseUrl(path: String) = "https://${server.host}:$apiPort$path"
+
+    // ------------------------------------------------------------------
+    // Public API (each is a blocking network call — invoke off the main
+    // thread; MissionSyncManager wraps these in Dispatchers.IO).
+    // ------------------------------------------------------------------
+
+    /**
+     * Lightweight reachability + mTLS probe. Throws [ApiException] when the
+     * host is unreachable, the cert is rejected, or the server errors —
+     * otherwise returns normally (the body is ignored).
+     */
+    fun checkReachability() {
+        val (code, body) = httpGet("/Marti/api/version/config")
+        if (code !in 200..299) throw ApiException(httpReason(code, body))
+    }
+
+    /** Available missions. Empty on dialects without the endpoint (taky). */
+    fun getMissions(): List<TakMissionInfo> {
+        val (code, body) = httpGet("/Marti/api/missions")
+        if (code !in 200..299) throw ApiException(httpReason(code, body))
+        return parseMissions(body)
+    }
+
+    /** Available data packages via the sync search index. */
+    fun getDataPackages(): List<TakDataPackageInfo> {
+        val (code, body) = httpGet("/Marti/api/sync/search")
+        if (code !in 200..299) throw ApiException(httpReason(code, body))
+        return parseDataPackages(body)
+    }
+
+    // ------------------------------------------------------------------
+    // JSON parsing — tolerant of the three envelope shapes.
+    // ------------------------------------------------------------------
+
+    internal fun parseMissions(body: String): List<TakMissionInfo> {
+        val arr = listEnvelope(body) ?: return emptyList()
+        return arr.mapNotNull { el ->
+            val o = el as? JsonObject ?: return@mapNotNull null
+            val name = o.str("name") ?: return@mapNotNull null
+            TakMissionInfo(
+                name = name,
+                description = o.str("description"),
+                creatorUid = o.str("creatorUid"),
+                keywords = o.strList("keywords"),
+                contentCount = (o["contents"] as? JsonArray)?.size ?: 0,
+            )
+        }
+    }
+
+    internal fun parseDataPackages(body: String): List<TakDataPackageInfo> {
+        val arr = listEnvelope(body) ?: return emptyList()
+        return arr.mapNotNull { el ->
+            val o = el as? JsonObject ?: return@mapNotNull null
+            val hash = o.str("hash") ?: o.str("Hash") ?: return@mapNotNull null
+            TakDataPackageInfo(
+                hash = hash,
+                name = o.str("name") ?: o.str("Name") ?: hash,
+                mimeType = o.str("mimeType") ?: o.str("MIMEType"),
+                size = o.long("size") ?: o.long("Size") ?: 0L,
+                submitter = o.str("submitter") ?: o.str("SubmissionUser"),
+            )
+        }
+    }
+
+    /**
+     * Pull the list out of whichever envelope the dialect used:
+     * `{data:[…]}` (TAK5.7/OTS), `{results:[…]}` (taky), or a bare array.
+     */
+    private fun listEnvelope(body: String): JsonArray? {
+        val root: JsonElement = runCatching { json.parseToJsonElement(body) }.getOrNull() ?: return null
+        return when (root) {
+            is JsonArray -> root
+            is JsonObject -> (root["data"] ?: root["results"]) as? JsonArray
+            else -> null
+        }
+    }
+
+    private fun JsonObject.str(key: String): String? =
+        (this[key] as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
+
+    private fun JsonObject.long(key: String): Long? =
+        (this[key] as? kotlinx.serialization.json.JsonPrimitive)?.longOrNull
+            ?: (this[key] as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull?.toLongOrNull()
+
+    private fun JsonObject.strList(key: String): List<String> =
+        (this[key] as? JsonArray)?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+
+    // ------------------------------------------------------------------
+    // HTTP + mTLS (HttpsURLConnection, no extra deps).
+    // ------------------------------------------------------------------
+
+    private fun httpGet(path: String): Pair<Int, String> {
+        val conn = (URL(baseUrl(path)).openConnection() as HttpsURLConnection).apply {
+            connectTimeout = CONNECT_TIMEOUT_MS
+            readTimeout = READ_TIMEOUT_MS
+            requestMethod = "GET"
+            setRequestProperty("Accept", "application/json")
+            // Some dialects (taky / OTS local-auth) accept basic auth in
+            // addition to mTLS; send it when the operator provided creds.
+            val user = server.username
+            val pass = server.password
+            if (!user.isNullOrBlank() && !pass.isNullOrBlank()) {
+                val raw = "$user:$pass".toByteArray(Charsets.UTF_8)
+                setRequestProperty("Authorization", "Basic " + Base64.encodeToString(raw, Base64.NO_WRAP))
+            }
+            val ctx = SSLContext.getInstance("TLS")
+            ctx.init(loadKeyManagers(), arrayOf(TrustAll), SecureRandom())
+            sslSocketFactory = ctx.socketFactory
+            hostnameVerifier = AcceptAllHostnames
+        }
+        return try {
+            conn.connect()
+            val code = conn.responseCode
+            val stream = if (code in 200..299) conn.inputStream else conn.errorStream
+            val text = stream?.bufferedReader(Charsets.UTF_8)?.use { it.readText() } ?: ""
+            code to text
+        } catch (t: Throwable) {
+            Log.w(TAG, "GET $path failed: ${t.javaClass.simpleName}: ${t.message}")
+            throw ApiException(t.message ?: t.javaClass.simpleName, t)
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    /** Client KeyManagers from the operator's imported `.p12`, or null. */
+    private fun loadKeyManagers(): Array<KeyManager>? {
+        val name = server.certificateName ?: return null
+        val pass = server.certificatePassword ?: return null
+        val bytes = certVault?.read(name) ?: return null
+        return runCatching {
+            val ks = KeyStore.getInstance("PKCS12")
+            ByteArrayInputStream(bytes).use { ks.load(it, pass.toCharArray()) }
+            val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
+            kmf.init(ks, pass.toCharArray())
+            kmf.keyManagers
+        }.onFailure {
+            Log.w(TAG, "Cert load failed: ${it.javaClass.simpleName}: ${it.message}")
+        }.getOrNull()
+    }
+
+    private fun httpReason(code: Int, body: String): String = when (code) {
+        401 -> "Authentication required"
+        403 -> "Access forbidden"
+        404 -> "Not found"
+        else -> "Server error ($code)" + body.take(80).let { if (it.isBlank()) "" else ": $it" }
+    }
+
+    class ApiException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+    private object TrustAll : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<X509Certificate>?, authType: String?) {}
+        override fun checkServerTrusted(chain: Array<X509Certificate>?, authType: String?) {}
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+
+    private object AcceptAllHostnames : javax.net.ssl.HostnameVerifier {
+        override fun verify(hostname: String?, session: SSLSession?) = true
+    }
+
+    companion object {
+        private const val TAG = "TakRestApiClient"
+        const val SECURE_API_PORT = 8443
+        private const val CONNECT_TIMEOUT_MS = 10_000
+        private const val READ_TIMEOUT_MS = 20_000
+    }
+}
+
+// MARK: - Marti API models (minimal subset the sync UI needs)
+
+data class TakMissionInfo(
+    val name: String,
+    val description: String? = null,
+    val creatorUid: String? = null,
+    val keywords: List<String> = emptyList(),
+    val contentCount: Int = 0,
+)
+
+data class TakDataPackageInfo(
+    val hash: String,
+    val name: String,
+    val mimeType: String? = null,
+    val size: Long = 0L,
+    val submitter: String? = null,
+)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ChatStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ChatStore.kt
@@ -120,6 +120,9 @@ class ChatStore {
             lastMessagePreview = message.text,
             lastActivityIso = message.timeIso,
             unread = (current?.unread ?: 0) + if (incrementUnread) 1 else 0,
+            // Per-server DM scoping: remember which server this thread is on
+            // so replies route back to it. Group/broadcast rooms stay null.
+            serverId = current?.serverId ?: if (!isGroup) message.serverId else null,
         )
         _conversations.value = _conversations.value + (message.conversationId to next)
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MissionSyncManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MissionSyncManager.kt
@@ -1,0 +1,148 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import soy.engindearing.omnitak.mobile.data.CertVault
+import soy.engindearing.omnitak.mobile.data.TAKServer
+import soy.engindearing.omnitak.mobile.data.TakDataPackageInfo
+import soy.engindearing.omnitak.mobile.data.TakMissionInfo
+import soy.engindearing.omnitak.mobile.data.TakRestApiClient
+
+/**
+ * Multi-server mission / data-package sync, driven entirely by the real TAK
+ * Marti REST API ([TakRestApiClient]) — no stubs. The Android counterpart to
+ * iOS's MissionSyncManager.
+ *
+ * Servers come from [ServerManager] (single source of truth): every ENABLED,
+ * TLS, cert-bearing server participates at once. Each is probed + fetched in
+ * parallel; the screen aggregates across all of them. Connection status is
+ * derived from a live reachability probe on every refresh, not a sticky flag,
+ * so it always reflects reality.
+ */
+class MissionSyncManager(
+    private val serverManager: ServerManager,
+    private val certVault: CertVault?,
+) {
+
+    private val _sessions = MutableStateFlow<List<ServerSyncSession>>(emptyList())
+    val sessions: StateFlow<List<ServerSyncSession>> = _sessions.asStateFlow()
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    private val _lastRefresh = MutableStateFlow<Long?>(null)
+    val lastRefresh: StateFlow<Long?> = _lastRefresh.asStateFlow()
+
+    /** Enrolled, enabled, TLS servers — the only ones that can do mTLS sync. */
+    private fun enabledServers(): List<TAKServer> =
+        serverManager.servers.value.filter { it.enabled && it.useTLS && it.certificateName != null }
+
+    /**
+     * Refresh every enabled server in parallel. Existing data is preserved and
+     * rows flip to [MissionServerStatus.Checking] while in flight, so the UI
+     * never blanks mid-refresh.
+     */
+    suspend fun refreshAll() {
+        val servers = enabledServers()
+        if (servers.isEmpty()) {
+            _sessions.value = emptyList()
+            return
+        }
+        _isRefreshing.value = true
+        val prior = _sessions.value.associateBy { it.serverId }
+        _sessions.value = servers.map { sv ->
+            prior[sv.id]?.copy(status = MissionServerStatus.Checking)
+                ?: ServerSyncSession(sv.id, sv.name, sv.host, MissionServerStatus.Checking)
+        }
+
+        val results = coroutineScope {
+            servers.map { sv -> async(Dispatchers.IO) { sync(sv) } }.awaitAll()
+        }
+        _sessions.value = results.sortedBy { it.serverName.lowercase() }
+        _isRefreshing.value = false
+        _lastRefresh.value = System.currentTimeMillis()
+    }
+
+    /** Refresh a single server (tap-to-retry on its row). */
+    suspend fun refresh(serverId: String) {
+        val sv = enabledServers().firstOrNull { it.id == serverId } ?: return
+        _sessions.value = _sessions.value.map {
+            if (it.serverId == serverId) it.copy(status = MissionServerStatus.Checking) else it
+        }
+        val updated = withContext(Dispatchers.IO) { sync(sv) }
+        _sessions.value = if (_sessions.value.any { it.serverId == serverId }) {
+            _sessions.value.map { if (it.serverId == serverId) updated else it }
+        } else {
+            (_sessions.value + updated).sortedBy { it.serverName.lowercase() }
+        }
+    }
+
+    /**
+     * Probe + fetch one server (blocking; call on Dispatchers.IO). Missions and
+     * data packages are fetched independently and tolerated per-endpoint — taky
+     * has no `/Marti/api/missions`, so missions come back empty while its data
+     * packages still load.
+     */
+    private fun sync(server: TAKServer): ServerSyncSession {
+        val client = TakRestApiClient(server, certVault)
+        val now = System.currentTimeMillis()
+        val base = ServerSyncSession(server.id, server.name, server.host, MissionServerStatus.Checking, lastChecked = now)
+        return try {
+            client.checkReachability()
+            val missions = runCatching { client.getMissions() }.getOrDefault(emptyList())
+            val packages = runCatching { client.getDataPackages() }.getOrDefault(emptyList())
+            base.copy(
+                status = MissionServerStatus.Online,
+                missions = missions,
+                dataPackages = packages,
+                lastChecked = System.currentTimeMillis(),
+            )
+        } catch (t: Throwable) {
+            base.copy(status = MissionServerStatus.Offline(t.message ?: t.javaClass.simpleName))
+        }
+    }
+}
+
+// MARK: - Per-server status + session + aggregated rows
+
+sealed interface MissionServerStatus {
+    data object Checking : MissionServerStatus
+    data object Online : MissionServerStatus
+    data class Offline(val reason: String) : MissionServerStatus
+
+    val isOnline: Boolean get() = this is Online
+}
+
+data class ServerSyncSession(
+    val serverId: String,
+    val serverName: String,
+    val host: String,
+    val status: MissionServerStatus,
+    val missions: List<TakMissionInfo> = emptyList(),
+    val dataPackages: List<TakDataPackageInfo> = emptyList(),
+    val lastChecked: Long? = null,
+) {
+    val itemCount: Int get() = missions.size + dataPackages.size
+}
+
+data class AggregatedMission(
+    val serverId: String,
+    val serverName: String,
+    val mission: TakMissionInfo,
+) {
+    val id: String get() = "$serverId:${mission.name}"
+}
+
+data class AggregatedPackage(
+    val serverId: String,
+    val serverName: String,
+    val pkg: TakDataPackageInfo,
+) {
+    val id: String get() = "$serverId:${pkg.hash}"
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ServerManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ServerManager.kt
@@ -16,6 +16,7 @@ import soy.engindearing.omnitak.mobile.data.TAKConnection
 import soy.engindearing.omnitak.mobile.data.TAKServer
 import soy.engindearing.omnitak.mobile.data.TAKServerStore
 import soy.engindearing.omnitak.mobile.data.UserPrefsStore
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Application-scoped TAK server registry. Exposes [servers] and
@@ -47,47 +48,81 @@ class ServerManager(
     private val _activeServer = MutableStateFlow<TAKServer?>(null)
     val activeServer: StateFlow<TAKServer?> = _activeServer.asStateFlow()
 
+    // Aggregate connection state across all servers. Kept for back-compat
+    // with the map status bar / FGS lifecycle / single-server callers:
+    //  - any Connected  → Connected (single server's name, or "N servers")
+    //  - else any Connecting → Connecting
+    //  - else any Failed → Failed
+    //  - else Disconnected
     private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
     val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+
+    // Per-server connection state, keyed by TAKServer.id. The Servers screen
+    // and the map's multi-server indicator read this so every enabled server
+    // shows its own live status, not just whichever one is "active".
+    private val _serverStates = MutableStateFlow<Map<String, ConnectionState>>(emptyMap())
+    val serverStates: StateFlow<Map<String, ConnectionState>> = _serverStates.asStateFlow()
+
+    // The subset of [_serverStates] that is currently Connected. Drives the
+    // "N/M ●●●" map indicator and is the broadcast target set for sendCoT.
+    private val _connectedServerIds = MutableStateFlow<Set<String>>(emptySet())
+    val connectedServerIds: StateFlow<Set<String>> = _connectedServerIds.asStateFlow()
 
     // GAP-030c — real ATAK-style status-bar counters. The status bar
     // chips ↓ / ↑ on MapScreen previously read hardcoded zeros, which
     // made the app look silent even when CoT was flowing both ways.
+    // Now aggregated across all connected servers.
     private val _messagesReceived = MutableStateFlow(0)
     val messagesReceived: StateFlow<Int> = _messagesReceived.asStateFlow()
 
     private val _messagesSent = MutableStateFlow(0)
     val messagesSent: StateFlow<Int> = _messagesSent.asStateFlow()
 
-    private var currentConnection: TAKConnection? = null
-    private var connectionCollectorJob: kotlinx.coroutines.Job? = null
-    private var receivedCollectorJob: kotlinx.coroutines.Job? = null
+    // One live socket per enabled server (iOS: TAKService.serverConnections).
+    // ConcurrentHashMap because reconcile runs on the store-collector
+    // coroutine while connect/disconnect can be called from the UI thread.
+    private val connections = ConcurrentHashMap<String, TAKConnection>()
+    private val stateJobs = ConcurrentHashMap<String, kotlinx.coroutines.Job>()
+    private val receivedJobs = ConcurrentHashMap<String, kotlinx.coroutines.Job>()
+    // Single PLI broadcaster — self-position fans out to every connected
+    // server via the broadcast path of sendCoT, so one broadcaster covers all.
     private var pliBroadcaster: SelfPositionBroadcaster? = null
 
     init { scope.launch { hydrate() } }
 
-    /** Tear down any existing connection and open a new one to [server]. */
+    /**
+     * Open a connection to [server] alongside any others. Idempotent — a
+     * second call for an already-connected server is a no-op (matches iOS
+     * where every enabled server is connected at once, not one-at-a-time).
+     */
     fun connect(server: TAKServer) {
-        disconnect()
+        if (connections.containsKey(server.id)) return
+        // Reset the shared ↓/↑ counters only when going from zero live
+        // sockets to the first one, so adding a 2nd server doesn't zero them.
+        if (connections.isEmpty()) {
+            _messagesReceived.value = 0
+            _messagesSent.value = 0
+        }
         val conn = TAKConnection(server, certVault)
-        currentConnection = conn
-        // Reset per-session counters so the status bar reflects this
-        // connection only, not the cumulative app lifetime.
-        _messagesReceived.value = 0
-        _messagesSent.value = 0
-        connectionCollectorJob = scope.launch {
+        connections[server.id] = conn
+        stateJobs[server.id] = scope.launch {
             conn.state.collect { state ->
-                _connectionState.value = state
-                if (state is ConnectionState.Connected) startPliBroadcast() else stopPliBroadcast()
+                _serverStates.value = _serverStates.value + (server.id to state)
+                recomputeAggregate()
+                // PLI broadcaster lives as long as ≥1 server is connected.
+                if (_connectedServerIds.value.isNotEmpty()) startPliBroadcast()
+                else stopPliBroadcast()
             }
         }
-        receivedCollectorJob = scope.launch {
+        receivedJobs[server.id] = scope.launch {
             conn.received.collect { xml ->
                 _messagesReceived.value = _messagesReceived.value + 1
                 // A frame is either a chat event or a contact/marker event,
                 // depending on the CoT type. Parsing chat first is cheap
                 // (string probe) and avoids double-ingesting as a contact.
-                val chat = ChatXml.parse(xml)
+                // Tag the source server so chat attribution + per-server DM
+                // scoping work (multi-server parity with iOS).
+                val chat = ChatXml.parse(xml, serverId = server.id)
                 if (chat != null) {
                     chatStore?.ingest(chat)
                 } else {
@@ -99,37 +134,86 @@ class ServerManager(
     }
 
     /**
-     * Re-open a connection if there's an enabled active server but no
-     * live socket. Called from MainActivity's ON_RESUME hook so that
-     * coming back from the background (where Android may have killed
-     * the read loop after Doze / app-standby) recovers without the
-     * operator needing to tap play. Issue #6.
+     * Connect every enabled server that isn't already on the wire, and drop
+     * any live connection whose server was disabled or removed. Called on
+     * cold-launch hydrate and whenever the server list changes so the set of
+     * live sockets always matches the set of enabled servers.
+     */
+    private fun reconcileConnections(servers: List<TAKServer>) {
+        servers.filter { it.enabled }.forEach { s ->
+            if (!connections.containsKey(s.id)) connect(s)
+        }
+        val enabledIds = servers.filter { it.enabled }.map { it.id }.toSet()
+        connections.keys.filterNot { it in enabledIds }.forEach { disconnect(it) }
+    }
+
+    /**
+     * Re-open connections for any enabled server with no live socket.
+     * Called from MainActivity's ON_RESUME hook so that coming back from
+     * the background (where Android may have killed read loops after Doze /
+     * app-standby) recovers without the operator tapping play. Issue #6.
      */
     fun reconnectIfNeeded() {
-        val state = _connectionState.value
-        if (state is ConnectionState.Connected || state is ConnectionState.Connecting) return
-        val target = _activeServer.value ?: return
-        if (!target.enabled) return
-        connect(target)
+        reconcileConnections(_servers.value)
     }
 
-    /** Send a CoT XML payload on the active connection. */
-    suspend fun sendCoT(xml: String): Boolean {
-        val ok = currentConnection?.send(xml) ?: false
-        if (ok) _messagesSent.value = _messagesSent.value + 1
-        return ok
+    /**
+     * Send a CoT XML payload. With [serverId] null the frame is broadcast to
+     * every connected server (group chat, PPLI, markers); with a specific id
+     * it routes to just that server (DM replies stay on their origin server).
+     * Returns true if at least one server accepted the write.
+     */
+    suspend fun sendCoT(xml: String, serverId: String? = null): Boolean {
+        val targets = if (serverId != null) {
+            listOfNotNull(connections[serverId])
+        } else {
+            connections.values.toList()
+        }
+        if (targets.isEmpty()) return false
+        var anyOk = false
+        for (conn in targets) {
+            if (conn.send(xml)) anyOk = true
+        }
+        if (anyOk) _messagesSent.value = _messagesSent.value + 1
+        return anyOk
     }
 
-    /** Disconnect the current connection if any. */
+    /** Disconnect a single server by id, leaving the others connected. */
+    fun disconnect(serverId: String) {
+        connections.remove(serverId)?.disconnect()
+        stateJobs.remove(serverId)?.cancel()
+        receivedJobs.remove(serverId)?.cancel()
+        _serverStates.value = _serverStates.value - serverId
+        recomputeAggregate()
+        if (_connectedServerIds.value.isEmpty()) stopPliBroadcast()
+    }
+
+    /** Disconnect every live connection. */
     fun disconnect() {
-        stopPliBroadcast()
-        currentConnection?.disconnect()
-        currentConnection = null
-        connectionCollectorJob?.cancel()
-        connectionCollectorJob = null
-        receivedCollectorJob?.cancel()
-        receivedCollectorJob = null
-        _connectionState.value = ConnectionState.Disconnected
+        connections.keys.toList().forEach { disconnect(it) }
+    }
+
+    /**
+     * Fold the per-server state map into the single aggregate the status bar
+     * and FGS lifecycle read, and refresh the connected-id set.
+     */
+    private fun recomputeAggregate() {
+        val states = _serverStates.value
+        _connectedServerIds.value = states
+            .filterValues { it is ConnectionState.Connected }
+            .keys.toSet()
+
+        val connected = states.values.filterIsInstance<ConnectionState.Connected>()
+        _connectionState.value = when {
+            connected.size == 1 -> connected.first()
+            connected.size > 1 ->
+                ConnectionState.Connected("${connected.size} servers", connected.all { it.useTLS })
+            states.values.any { it is ConnectionState.Connecting } ->
+                states.values.first { it is ConnectionState.Connecting }
+            states.values.any { it is ConnectionState.Failed } ->
+                states.values.first { it is ConnectionState.Failed }
+            else -> ConnectionState.Disconnected
+        }
     }
 
     private fun startPliBroadcast() {
@@ -154,26 +238,25 @@ class ServerManager(
     }
 
     private suspend fun hydrate() {
-        var initial: List<TAKServer> = emptyList()
+        var initialized = false
         store.servers.collect { loaded ->
             _servers.value = loaded
-            if (initial.isEmpty() && loaded.isNotEmpty()) {
-                initial = loaded
+            if (!initialized && loaded.isNotEmpty()) {
+                initialized = true
+                // Pick a sensible default-target ("active") server once. The
+                // active server is just which one new DMs route to by default;
+                // every enabled server is connected regardless.
                 val activeId = peekActiveId()
                 val active = loaded.firstOrNull { it.id == activeId }
                     ?: loaded.firstOrNull { it.enabled }
                     ?: loaded.firstOrNull()
                 _activeServer.value = active
-                // Resume the previously-active enabled server on cold
-                // launch. Without this the operator has to hit play after
-                // every app restart even though the server entry is still
-                // saved. The `currentConnection == null` guard means
-                // DataPackageBootstrap can race ahead and we won't
-                // double-connect on a fresh-import launch.
-                if (active != null && active.enabled && currentConnection == null) {
-                    connect(active)
-                }
             }
+            // Keep the live socket set equal to the enabled set — connect
+            // every enabled server at once on cold launch, and react to
+            // adds/removes/toggles persisted from anywhere. Idempotent, so a
+            // racing DataPackageBootstrap import won't double-connect.
+            reconcileConnections(loaded)
         }
     }
 
@@ -185,19 +268,15 @@ class ServerManager(
 
         val updated = _servers.value + server
         _servers.value = updated
-        val becomingActive = server.enabled &&
-            (_activeServer.value == null || _activeServer.value?.enabled != true)
-        if (becomingActive) {
+        // First enabled server becomes the default DM-target ("active").
+        if (server.enabled && (_activeServer.value == null || _activeServer.value?.enabled != true)) {
             _activeServer.value = server
             persistActive(server.id)
         }
         persist(updated)
-        // Auto-connect when this server becomes active and nothing is on the wire.
-        // Users expect "I added a server, it works" — the explicit play button is
-        // for switching between configured servers, not for first-use bootstrap.
-        if (becomingActive && currentConnection == null) {
-            connect(server)
-        }
+        // Enabled servers go on the wire immediately, alongside any others.
+        // Users expect "I added a server, it works" — no manual play needed.
+        reconcileConnections(updated)
         return server
     }
 
@@ -219,6 +298,8 @@ class ServerManager(
             persistActive(next?.id)
         }
         persist(updated)
+        disconnect(id)
+        reconcileConnections(updated)
     }
 
     fun toggleEnabled(id: String) {
@@ -226,28 +307,22 @@ class ServerManager(
             if (it.id == id) it.copy(enabled = !it.enabled) else it
         }
         _servers.value = updated
-
         val toggled = updated.firstOrNull { it.id == id }
-        val wasActive = _activeServer.value?.id == id
-        if (wasActive) {
-            if (toggled?.enabled == true) {
-                _activeServer.value = toggled
-            } else {
-                disconnect()
-                val next = updated.firstOrNull { it.enabled }
-                _activeServer.value = next
-                persistActive(next?.id)
-            }
+
+        // Keep the "active" default-target pointed at an enabled server: hand
+        // off when the active one is disabled, adopt one when none is active.
+        if (toggled?.enabled == false && _activeServer.value?.id == id) {
+            val next = updated.firstOrNull { it.enabled }
+            _activeServer.value = next
+            persistActive(next?.id)
+        } else if (toggled?.enabled == true &&
+            (_activeServer.value == null || _activeServer.value?.enabled != true)) {
+            _activeServer.value = toggled
+            persistActive(toggled.id)
         }
         persist(updated)
-        // Switch ON should put the server on the wire, not just permit it.
-        if (toggled?.enabled == true && currentConnection == null) {
-            if (!wasActive) {
-                _activeServer.value = toggled
-                persistActive(toggled.id)
-            }
-            connect(toggled)
-        }
+        // Connect newly-enabled / disconnect newly-disabled servers.
+        reconcileConnections(updated)
     }
 
     fun setActive(id: String) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ATAKStatusBar.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ATAKStatusBar.kt
@@ -46,6 +46,11 @@ fun ATAKStatusBar(
     onServerTap: () -> Unit,
     onMenuTap: () -> Unit,
     modifier: Modifier = Modifier,
+    // Multi-server indicator: one flag per enabled server (true = connected).
+    // When >1 server is enabled this replaces the single dot with a
+    // "N/M ●●●" cluster so the operator can see at a glance how many of
+    // their servers are live. Empty/size-1 falls back to the single dot.
+    serverConnectedFlags: List<Boolean> = emptyList(),
 ) {
     Row(
         modifier = modifier
@@ -54,7 +59,11 @@ fun ATAKStatusBar(
             .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        ConnectionDot(isConnected = isConnected)
+        if (serverConnectedFlags.size > 1) {
+            MultiServerIndicator(flags = serverConnectedFlags)
+        } else {
+            ConnectionDot(isConnected = isConnected)
+        }
         Spacer(Modifier.width(8.dp))
 
         Row(
@@ -119,6 +128,36 @@ private fun ConnectionDot(isConnected: Boolean) {
             .clip(CircleShape)
             .background(if (isConnected) TacticalAccent else Color(0xFFE53935)),
     )
+}
+
+/**
+ * Multi-server status cluster: "N/M" connected count followed by one small
+ * dot per enabled server (green = connected, red = down). Shown on the map
+ * status bar when the operator has more than one TAK server enabled.
+ */
+@Composable
+private fun MultiServerIndicator(flags: List<Boolean>) {
+    val connected = flags.count { it }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            "$connected/${flags.size}",
+            color = if (connected > 0) TacticalAccent else Color(0xFFE53935),
+            fontFamily = FontFamily.Monospace,
+            fontWeight = FontWeight.Bold,
+            fontSize = 12.sp,
+        )
+        Spacer(Modifier.width(5.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(3.dp)) {
+            flags.forEach { up ->
+                Box(
+                    modifier = Modifier
+                        .size(6.dp)
+                        .clip(CircleShape)
+                        .background(if (up) TacticalAccent else Color(0xFFE53935)),
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
@@ -240,6 +240,9 @@ fun AppNav() {
             composable("mesh/device-settings") {
                 MeshDeviceSettingsScreen(onDone = { nav.popBackStack() })
             }
+            composable("missionsync") {
+                soy.engindearing.omnitak.mobile.ui.screens.MissionSyncScreen(onBack = { nav.popBackStack() })
+            }
             composable("settings") { SettingsScreen() }
             composable("about") { AboutScreen() }
         }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
@@ -79,6 +79,14 @@ fun ChatScreen(initialConversationId: String? = null) {
     val prefs by app.userPrefsStore.prefs.collectAsState(initial = UserPrefs())
     val chatScope = rememberCoroutineScope()
 
+    // Multi-server: resolve a serverId → display name so chat can badge which
+    // server a message/thread came from. Badges only show when >1 server is
+    // configured, otherwise they're noise.
+    val servers by app.serverManager.servers.collectAsState()
+    val serverNames = remember(servers) { servers.associate { it.id to it.name } }
+    val multiServer = servers.size > 1
+    val serverNameFor: (String?) -> String? = { id -> id?.let { serverNames[it] } }
+
     // GAP-124 — when arriving with an initial convo id (eg. from the
     // node-detail sheet's "Message" button), open that conversation
     // straight away instead of dropping the user on the conversation list.
@@ -97,6 +105,8 @@ fun ChatScreen(initialConversationId: String? = null) {
                 app.chatStore.markRead(id)
                 selectedConversation = id
             },
+            multiServer = multiServer,
+            serverNameFor = serverNameFor,
         )
     } else {
         val convo = conversations[selectedConversation]
@@ -112,6 +122,8 @@ fun ChatScreen(initialConversationId: String? = null) {
             selfCallsign = prefs.callsign,
             onBack = { selectedConversation = null },
             onSend = { text -> sendChat(app, convo, prefs, text, chatScope) },
+            multiServer = multiServer,
+            serverNameFor = serverNameFor,
         )
     }
 }
@@ -121,6 +133,8 @@ fun ChatScreen(initialConversationId: String? = null) {
 private fun ConversationListView(
     conversations: List<ChatConversation>,
     onSelect: (String) -> Unit,
+    multiServer: Boolean,
+    serverNameFor: (String?) -> String?,
 ) {
     Scaffold(
         containerColor = TacticalBackground,
@@ -154,7 +168,12 @@ private fun ConversationListView(
                 .padding(inner),
         ) {
             items(conversations, key = { it.id }) { convo ->
-                ConversationRow(convo = convo, onClick = { onSelect(convo.id) })
+                ConversationRow(
+                    convo = convo,
+                    onClick = { onSelect(convo.id) },
+                    serverBadgeName = if (multiServer) serverNameFor(convo.serverId) else null,
+                    serverId = convo.serverId,
+                )
                 HorizontalDivider(color = TacticalSurface)
             }
         }
@@ -162,7 +181,12 @@ private fun ConversationListView(
 }
 
 @Composable
-private fun ConversationRow(convo: ChatConversation, onClick: () -> Unit) {
+private fun ConversationRow(
+    convo: ChatConversation,
+    onClick: () -> Unit,
+    serverBadgeName: String?,
+    serverId: String?,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -171,12 +195,18 @@ private fun ConversationRow(convo: ChatConversation, onClick: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                convo.title,
-                color = MaterialTheme.colorScheme.onBackground,
-                fontWeight = FontWeight.SemiBold,
-                style = MaterialTheme.typography.bodyLarge,
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    convo.title,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.SemiBold,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                if (serverBadgeName != null) {
+                    Spacer(Modifier.width(6.dp))
+                    ChatServerBadge(name = serverBadgeName, serverId = serverId)
+                }
+            }
             Spacer(Modifier.height(2.dp))
             Text(
                 convo.lastMessagePreview ?: if (convo.isGroup) "Broadcast chat" else "No messages yet",
@@ -212,6 +242,8 @@ private fun ConversationDetailView(
     selfCallsign: String,
     onBack: () -> Unit,
     onSend: (String) -> Unit,
+    multiServer: Boolean,
+    serverNameFor: (String?) -> String?,
 ) {
     var draft by remember { mutableStateOf("") }
     val listState = rememberLazyListState()
@@ -265,7 +297,11 @@ private fun ConversationDetailView(
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             items(messages, key = { it.id }) { msg ->
-                MessageBubble(msg = msg, selfUid = selfUid)
+                MessageBubble(
+                    msg = msg,
+                    selfUid = selfUid,
+                    serverBadgeName = if (multiServer) serverNameFor(msg.serverId) else null,
+                )
             }
         }
 
@@ -316,7 +352,7 @@ private fun ConversationDetailView(
 }
 
 @Composable
-private fun MessageBubble(msg: ChatMessage, selfUid: String) {
+private fun MessageBubble(msg: ChatMessage, selfUid: String, serverBadgeName: String?) {
     val isFromSelf = msg.isFromSelf || msg.senderUid == selfUid
     val bubbleColor = if (isFromSelf) TacticalAccent.copy(alpha = 0.25f) else TacticalSurface
     val alignment = if (isFromSelf) Alignment.End else Alignment.Start
@@ -326,13 +362,22 @@ private fun MessageBubble(msg: ChatMessage, selfUid: String) {
         horizontalAlignment = alignment,
     ) {
         if (!isFromSelf) {
-            Text(
-                msg.senderCallsign,
-                color = TacticalAccent,
-                style = MaterialTheme.typography.labelSmall,
-                fontFamily = FontFamily.Monospace,
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.padding(start = 10.dp, bottom = 2.dp),
-            )
+            ) {
+                Text(
+                    msg.senderCallsign,
+                    color = TacticalAccent,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontFamily = FontFamily.Monospace,
+                )
+                // Which server this message arrived on (multi-server).
+                if (serverBadgeName != null) {
+                    Spacer(Modifier.width(6.dp))
+                    ChatServerBadge(name = serverBadgeName, serverId = msg.serverId)
+                }
+            }
         }
         Box(
             modifier = Modifier
@@ -356,6 +401,47 @@ private fun MessageBubble(msg: ChatMessage, selfUid: String) {
             }
         }
     }
+}
+
+/**
+ * Small colored chip naming which TAK server a message/thread belongs to.
+ * The hue is derived deterministically from the serverId so a given server
+ * always reads the same color across bubbles, rows and the contact list —
+ * matching iOS's ChatServerBadge.
+ */
+@Composable
+private fun ChatServerBadge(name: String, serverId: String?) {
+    val color = serverBadgeColor(serverId)
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(color.copy(alpha = 0.22f))
+            .padding(horizontal = 5.dp, vertical = 1.dp),
+    ) {
+        Text(
+            name,
+            color = color,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+        )
+    }
+}
+
+private val SERVER_BADGE_PALETTE = listOf(
+    Color(0xFF4FC3F7), // light blue
+    Color(0xFF81C784), // green
+    Color(0xFFFFB74D), // orange
+    Color(0xFFBA68C8), // purple
+    Color(0xFF4DD0E1), // cyan
+    Color(0xFFE57373), // red
+    Color(0xFFFFD54F), // amber
+)
+
+private fun serverBadgeColor(serverId: String?): Color {
+    if (serverId == null) return Color(0xFF90A4AE) // blue-grey = broadcast/all servers
+    val idx = (serverId.hashCode() and 0x7fffffff) % SERVER_BADGE_PALETTE.size
+    return SERVER_BADGE_PALETTE[idx]
 }
 
 private fun statusSuffix(status: ChatStatus, isFromSelf: Boolean): String {
@@ -450,11 +536,14 @@ private fun sendChat(
         timeIso = now,
         status = ChatStatus.SENDING,
         isFromSelf = true,
+        serverId = convo.serverId,
     )
     app.chatStore.markOutgoing(message)
 
     scope.launch {
-        val sent = app.serverManager.sendCoT(generated.xml)
+        // Route to the conversation's origin server for per-server DMs;
+        // group/broadcast rooms (serverId == null) fan out to all servers.
+        val sent = app.serverManager.sendCoT(generated.xml, serverId = convo.serverId)
         app.chatStore.updateMessageStatus(
             conversationId = convo.id,
             messageId = generated.messageId,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -83,6 +83,8 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     val app = LocalContext.current.applicationContext as OmniTAKApp
     val active by app.serverManager.activeServer.collectAsState()
     val connState by app.serverManager.connectionState.collectAsState()
+    val allServers by app.serverManager.servers.collectAsState()
+    val connectedIds by app.serverManager.connectedServerIds.collectAsState()
     val msgReceived by app.serverManager.messagesReceived.collectAsState()
     val msgSent by app.serverManager.messagesSent.collectAsState()
     val contacts by app.contactStore.contacts.collectAsState()
@@ -967,6 +969,10 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 // there). Hamburger goes to Settings.
                 onServerTap = { onOpenTab("servers") },
                 onMenuTap = { onOpenTab("settings") },
+                // One flag per enabled server → "N/M ●●●" multi-server badge.
+                serverConnectedFlags = allServers
+                    .filter { it.enabled }
+                    .map { connectedIds.contains(it.id) },
             )
         }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.AddLocation
 import androidx.compose.material.icons.filled.FlightTakeoff
 import androidx.compose.material.icons.filled.GridOn
@@ -1013,6 +1014,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 ToolEntry("layers", Icons.Filled.Layers, "Layers"),
                 ToolEntry("adsb", Icons.Filled.Flight, if (adsbActive) "ADSB on" else "ADSB"),
                 ToolEntry("chat", Icons.Filled.Chat, "Chat"),
+                ToolEntry("missionsync", Icons.Filled.Sync, "Mission Sync"),
                 ToolEntry("teams", Icons.Filled.Groups, "Teams"),
                 ToolEntry(
                     "nav",
@@ -1047,6 +1049,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                         }
                     }
                     "chat" -> onOpenTab("chat")
+                    "missionsync" -> onOpenTab("missionsync")
                     "teams" -> teamsPanelOpen = true
                     "nav" -> {
                         if (!locationGranted) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MissionSyncScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MissionSyncScreen.kt
@@ -1,0 +1,377 @@
+package soy.engindearing.omnitak.mobile.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Inventory2
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import soy.engindearing.omnitak.mobile.OmniTAKApp
+import soy.engindearing.omnitak.mobile.domain.AggregatedMission
+import soy.engindearing.omnitak.mobile.domain.AggregatedPackage
+import soy.engindearing.omnitak.mobile.domain.MissionServerStatus
+import soy.engindearing.omnitak.mobile.domain.ServerSyncSession
+import soy.engindearing.omnitak.mobile.ui.theme.HostileRed
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalSurface
+
+/**
+ * Multi-server Mission Sync UI, bound to [MissionSyncManager] (no stubs).
+ * Shows every enabled server's live status and an aggregated list of missions
+ * + data packages across all of them. Android counterpart to iOS's
+ * MissionSyncView.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MissionSyncScreen(onBack: () -> Unit = {}) {
+    val app = LocalContext.current.applicationContext as OmniTAKApp
+    val manager = app.missionSyncManager
+    val sessions by manager.sessions.collectAsState()
+    val isRefreshing by manager.isRefreshing.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) { manager.refreshAll() }
+
+    val onlineCount = sessions.count { it.status.isOnline }
+    val allMissions = sessions.flatMap { s ->
+        s.missions.map { AggregatedMission(s.serverId, s.serverName, it) }
+    }
+    val allPackages = sessions.flatMap { s ->
+        s.dataPackages.map { AggregatedPackage(s.serverId, s.serverName, it) }
+    }
+
+    Scaffold(
+        containerColor = TacticalBackground,
+        topBar = {
+            TopAppBar(
+                title = { Text("Mission Sync", color = MaterialTheme.colorScheme.onBackground) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { scope.launch { manager.refreshAll() } },
+                        enabled = !isRefreshing,
+                    ) {
+                        if (isRefreshing) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                strokeWidth = 2.dp,
+                                color = TacticalAccent,
+                            )
+                        } else {
+                            Icon(Icons.Filled.Refresh, contentDescription = "Refresh", tint = TacticalAccent)
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = TacticalBackground,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                ),
+            )
+        },
+    ) { inner: PaddingValues ->
+        if (sessions.isEmpty()) {
+            EmptyMissionSync(Modifier.padding(inner))
+            return@Scaffold
+        }
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            item {
+                SectionHeader("SERVERS", "$onlineCount/${sessions.size} online")
+            }
+            items(sessions, key = { it.serverId }) { s ->
+                ServerStatusRow(s, onTap = { scope.launch { manager.refresh(s.serverId) } })
+            }
+
+            if (allMissions.isNotEmpty()) {
+                item { SectionHeader("MISSIONS", "${allMissions.size}") }
+                items(allMissions, key = { it.id }) { m -> MissionRow(m) }
+            }
+
+            if (allPackages.isNotEmpty()) {
+                item { SectionHeader("DATA PACKAGES", "${allPackages.size}") }
+                items(allPackages, key = { it.id }) { p -> PackageRow(p) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String, trailing: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            title,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.weight(1f))
+        Text(
+            trailing,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+            style = MaterialTheme.typography.labelMedium,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+@Composable
+private fun ServerStatusRow(s: ServerSyncSession, onTap: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(TacticalSurface)
+            .clickable(onClick = onTap)
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        StatusDot(s.status)
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                s.serverName,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                statusLine(s),
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        if (s.status.isOnline) {
+            Text(
+                "${s.missions.size}m · ${s.dataPackages.size}p",
+                color = TacticalAccent,
+                style = MaterialTheme.typography.labelMedium,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusDot(status: MissionServerStatus) {
+    Box(modifier = Modifier.size(14.dp), contentAlignment = Alignment.Center) {
+        when (status) {
+            is MissionServerStatus.Checking -> CircularProgressIndicator(
+                modifier = Modifier.size(12.dp),
+                strokeWidth = 2.dp,
+                color = TacticalAccent,
+            )
+            is MissionServerStatus.Online -> Dot(Color(0xFF4CAF50))
+            is MissionServerStatus.Offline -> Dot(HostileRed)
+        }
+    }
+}
+
+@Composable
+private fun Dot(color: Color) {
+    Box(
+        modifier = Modifier
+            .size(10.dp)
+            .clip(CircleShape)
+            .background(color),
+    )
+}
+
+private fun statusLine(s: ServerSyncSession): String = when (val st = s.status) {
+    is MissionServerStatus.Checking -> "${s.host} — checking…"
+    is MissionServerStatus.Online -> s.host
+    is MissionServerStatus.Offline -> "${s.host} — ${st.reason}"
+}
+
+@Composable
+private fun MissionRow(item: AggregatedMission) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(TacticalSurface)
+            .padding(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                item.mission.name,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.Medium,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.weight(1f),
+            )
+            ServerBadge(item.serverName)
+        }
+        val desc = item.mission.description
+        if (!desc.isNullOrBlank()) {
+            Spacer(Modifier.height(2.dp))
+            Text(
+                desc,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 2,
+            )
+        }
+        if (item.mission.contentCount > 0) {
+            Spacer(Modifier.height(2.dp))
+            val n = item.mission.contentCount
+            Text(
+                "$n item${if (n == 1) "" else "s"}",
+                color = TacticalAccent,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PackageRow(item: AggregatedPackage) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(TacticalSurface)
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            Icons.Filled.Inventory2,
+            contentDescription = null,
+            tint = TacticalAccent,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(10.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                item.pkg.name,
+                color = MaterialTheme.colorScheme.onBackground,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+            )
+            if (item.pkg.size > 0) {
+                Text(
+                    formatBytes(item.pkg.size),
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            }
+        }
+        ServerBadge(item.serverName)
+    }
+}
+
+@Composable
+private fun ServerBadge(name: String) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(TacticalAccent.copy(alpha = 0.85f))
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    ) {
+        Text(
+            name,
+            color = Color.Black,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun EmptyMissionSync(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            Icons.Filled.Sync,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = TacticalAccent.copy(alpha = 0.6f),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            "No servers enabled",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            "Enable a TLS TAK server with a client certificate in Servers, then " +
+                "refresh. Every enabled server syncs here at once.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+        )
+    }
+}
+
+private fun formatBytes(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val kb = bytes / 1024.0
+    if (kb < 1024) return String.format("%.1f KB", kb)
+    val mb = kb / 1024.0
+    if (mb < 1024) return String.format("%.1f MB", mb)
+    return String.format("%.1f GB", mb / 1024.0)
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ServersScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ServersScreen.kt
@@ -65,7 +65,9 @@ fun ServersScreen(onAdd: () -> Unit, onQuickConnect: () -> Unit = {}) {
     val manager = app.serverManager
     val servers by manager.servers.collectAsState()
     val active by manager.activeServer.collectAsState()
-    val connState by manager.connectionState.collectAsState()
+    // Per-server live state — every card reflects its own connection, not
+    // just whichever server happens to be "active" (multi-server).
+    val serverStates by manager.serverStates.collectAsState()
 
     Scaffold(
         containerColor = TacticalBackground,
@@ -118,21 +120,20 @@ fun ServersScreen(onAdd: () -> Unit, onQuickConnect: () -> Unit = {}) {
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 items(items = servers, key = { it.id }) { server ->
-                    val connectedToThis = active?.id == server.id && (
-                        connState is ConnectionState.Connected || connState is ConnectionState.Connecting
-                    )
+                    val thisState = serverStates[server.id] ?: ConnectionState.Disconnected
+                    val connectedToThis = thisState is ConnectionState.Connected ||
+                        thisState is ConnectionState.Connecting
                     ServerCard(
                         server = server,
                         isActive = active?.id == server.id,
-                        connState = if (active?.id == server.id) connState else ConnectionState.Disconnected,
+                        connState = thisState,
                         onTap = { manager.setActive(server.id) },
                         onToggle = { manager.toggleEnabled(server.id) },
                         onDelete = { manager.deleteServer(server.id) },
                         onConnectToggle = {
-                            if (connectedToThis) manager.disconnect() else {
-                                manager.setActive(server.id)
-                                manager.connect(server)
-                            }
+                            // Connect/disconnect just this server — others stay up.
+                            if (connectedToThis) manager.disconnect(server.id)
+                            else manager.connect(server)
                         },
                     )
                 }

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/TakRestApiClientParseTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/TakRestApiClientParseTest.kt
@@ -1,0 +1,65 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Marti API envelope tolerance — the reason multi-server sync exists. The
+ * 4-server matrix exposed three list shapes; the parser must handle all of
+ * them and never throw on a dialect it doesn't recognise.
+ */
+class TakRestApiClientParseTest {
+
+    private val client = TakRestApiClient(
+        server = TAKServer(name = "t", host = "h", port = 8089),
+        certVault = null,
+    )
+
+    @Test
+    fun `TAK57 OTS data envelope parses missions`() {
+        val body = """
+            {"version":"3","type":"Mission","data":[
+              {"name":"alpha","description":"first","contents":[{"hash":"a"},{"hash":"b"}]},
+              {"name":"bravo"}
+            ]}
+        """.trimIndent()
+        val missions = client.parseMissions(body)
+        assertEquals(2, missions.size)
+        assertEquals("alpha", missions[0].name)
+        assertEquals("first", missions[0].description)
+        assertEquals(2, missions[0].contentCount)
+        assertEquals(0, missions[1].contentCount)
+    }
+
+    @Test
+    fun `taky results envelope parses data packages`() {
+        val body = """
+            {"resultCount":1,"results":[
+              {"hash":"abc123","name":"overlay.zip","size":2048,"mimeType":"application/zip"}
+            ]}
+        """.trimIndent()
+        val pkgs = client.parseDataPackages(body)
+        assertEquals(1, pkgs.size)
+        assertEquals("abc123", pkgs[0].hash)
+        assertEquals("overlay.zip", pkgs[0].name)
+        assertEquals(2048L, pkgs[0].size)
+    }
+
+    @Test
+    fun `bare top-level array parses`() {
+        val body = """[{"name":"solo"}]"""
+        val missions = client.parseMissions(body)
+        assertEquals(1, missions.size)
+        assertEquals("solo", missions[0].name)
+    }
+
+    @Test
+    fun `unrecognised or empty body yields empty list, never throws`() {
+        assertTrue(client.parseMissions("").isEmpty())
+        assertTrue(client.parseMissions("not json").isEmpty())
+        assertTrue(client.parseDataPackages("""{"unexpected":true}""").isEmpty())
+        // an entry missing the required key is skipped, not fatal
+        assertTrue(client.parseMissions("""{"data":[{"description":"no name"}]}""").isEmpty())
+    }
+}


### PR DESCRIPTION
Brings Android to full parity with iOS 2.29.0's multi-server work — all three iOS multi-server features, plus the Marti REST layer Android was missing entirely.

## What's in
- **Multi-server connections** — `ServerManager` replaces the single `currentConnection` with a per-server connection map (`ConcurrentHashMap`). All enabled servers connect at once via `reconcileConnections` (cold launch + ON_RESUME); connect/disconnect operate per-id. New `connectedServerIds` + `serverStates` flows; `connectionState` retained as an aggregate for the status bar / FGS lifecycle. `sendCoT(xml, serverId?)` routes to one server or broadcasts to all.
- **Multi-server chat attribution** — `ChatMessage`/`ChatConversation` carry `serverId`; `ChatXml.parse` threads the source server and scopes DMs per server (`DM-{serverId}-…`); `ChatStore` remembers a thread's server; `ChatScreen` badges each received message + conversation row with its origin server and routes DM replies back to it.
- **Map UI** — `ATAKStatusBar` shows an `N/M ●●●` indicator when >1 server is enabled; `ServersScreen` reads per-server live state so every card reflects its own connection.
- **Multi-server Mission Sync (NEW Marti REST layer)** — Android had no Marti REST client; this adds `TakRestApiClient` (HttpsURLConnection + mTLS via `CertVault`, same approach as `TAKConnection`): reachability (`/Marti/api/version/config`), missions (`/Marti/api/missions`), data packages (`/Marti/api/sync/search`). `MissionSyncManager` aggregates across every enabled TLS+cert server, probing + fetching in parallel. `MissionSyncScreen` (map Tools → "Mission Sync") shows per-server status + aggregated missions/packages with origin badges. Tolerant of all three envelope dialects (`data[]` / `results[]` / bare array) and taky's missing `/missions` route.

## Verification
- `./gradlew assembleDebug` ✅
- `./gradlew testDebugUnitTest` ✅ (incl. new `TakRestApiClientParseTest` — 4 cases covering the dialect envelopes)
- Version 0.30.2/78 → 0.32.0/80

🤖 Generated with [Claude Code](https://claude.com/claude-code)