### PR TITLE
Closeout sweep: #9 #16 #17 #22 #23 #29 #36 #38 #41 (+#30 partial)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -185,6 +185,9 @@ dependencies {
     // runTest / StandardTestDispatcher for coroutine-driven tests
     // (e.g. MeshtasticCoTBridge enabled toggle).
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    // Real org.json impl so JVM tests can exercise JSONObject/JSONArray
+    // (e.g. CesiumEntityJson serialization). Android stubs them otherwise.
+    testImplementation("org.json:json:20240303")
 
     // Instrumented tests — symbology validation runs on a real device or
     // emulator because MapLibre's SurfaceView renders through native GL

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CSREnrollmentService.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CSREnrollmentService.kt
@@ -77,7 +77,12 @@ class CSREnrollmentService(
      */
     data class Result(
         val certificateName: String,
-        val certificatePassword: String
+        val certificatePassword: String,
+        // Filename of the PEM-encoded CA chain persisted alongside the
+        // .p12 (e.g. `ca-host-username.pem`). Plumb this onto the new
+        // TAKServer so subsequent connections pin against it instead of
+        // accepting any server cert (#38 / GAP-106).
+        val caCertificateName: String?,
     )
 
     /**
@@ -112,7 +117,32 @@ class CSREnrollmentService(
         val certName = "${sanitize(config.host)}-${config.username}.p12"
         val saved = certVault.importBytes(certName, p12Bytes)
             ?: throw EnrollmentException("Failed to write enrolled cert to vault")
-        return Result(certificateName = saved, certificatePassword = String(p12Password))
+
+        // Pin against the enrollment CA chain on every future connect.
+        // `importBytes` returning null means the IO write failed — log
+        // and proceed without a pin rather than aborting the whole
+        // enrollment, since the client cert is already on disk and the
+        // operator can still connect (falling back to system trust).
+        val savedCa = if (response.caChain.isNotEmpty()) {
+            val caBytes = CaTrust.encodePemChain(response.caChain)
+            val caName = "ca-${sanitize(config.host)}-${config.username}.pem"
+            certVault.importBytes(caName, caBytes).also { written ->
+                if (written != null) {
+                    Log.i(TAG, "CA chain pinned as '$written' (${response.caChain.size} cert)")
+                } else {
+                    Log.w(TAG, "CA chain write failed — server will use system trust on connect")
+                }
+            }
+        } else {
+            Log.w(TAG, "Server returned 0 CA certs — no pin will be persisted")
+            null
+        }
+
+        return Result(
+            certificateName = saved,
+            certificatePassword = String(p12Password),
+            caCertificateName = savedCa,
+        )
     }
 
     // ------------------------------------------------------------------

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CaTrust.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CaTrust.kt
@@ -1,0 +1,99 @@
+package soy.engindearing.omnitak.mobile.data
+
+import java.io.ByteArrayInputStream
+import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Base64
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+/**
+ * CA-pinning helpers for TAK Server connections.
+ *
+ * Replaces the dev-mode `TrustAllX509Manager` we shipped through 0.9.x.
+ * When the operator enrolls via Quick Connect, the server hands back the
+ * signed client cert plus its CA chain (`ca0`/`ca1`/…) — those CA certs
+ * are the right pin to validate every subsequent connection against,
+ * since they're the same CA that signed the client cert the server is
+ * already happy with.
+ *
+ * Storage shape is a concatenated PEM file (one BEGIN/END CERTIFICATE
+ * block per CA cert). [CertVault] keeps it next to the `.p12`. Loader
+ * here is forgiving about whitespace inside the base64 body.
+ *
+ * Closes #38 (GAP-106).
+ */
+object CaTrust {
+
+    private const val PEM_BEGIN = "-----BEGIN CERTIFICATE-----"
+    private const val PEM_END = "-----END CERTIFICATE-----"
+
+    /**
+     * Serialize a CA chain to a single PEM file — one CERTIFICATE block
+     * per cert, in chain order (ca0 first, ca1 next, …).
+     */
+    fun encodePemChain(chain: List<X509Certificate>): ByteArray {
+        val encoder = Base64.getMimeEncoder(64, "\n".toByteArray(Charsets.US_ASCII))
+        return buildString {
+            chain.forEach { cert ->
+                append(PEM_BEGIN).append('\n')
+                append(encoder.encodeToString(cert.encoded)).append('\n')
+                append(PEM_END).append('\n')
+            }
+        }.toByteArray(Charsets.US_ASCII)
+    }
+
+    /**
+     * Parse zero-or-more PEM CERTIFICATE blocks out of [pem]. Returns
+     * an empty list when nothing parses — caller decides whether that's
+     * a fall-back-to-system-trust signal or a hard failure.
+     */
+    fun decodePemChain(pem: ByteArray): List<X509Certificate> {
+        val text = String(pem, Charsets.US_ASCII)
+        val cf = CertificateFactory.getInstance("X.509")
+        val out = mutableListOf<X509Certificate>()
+        var cursor = 0
+        while (true) {
+            val begin = text.indexOf(PEM_BEGIN, cursor)
+            if (begin < 0) break
+            val end = text.indexOf(PEM_END, begin + PEM_BEGIN.length)
+            if (end < 0) break
+            val body = text.substring(begin + PEM_BEGIN.length, end)
+                .replace(Regex("\\s+"), "")
+            cursor = end + PEM_END.length
+            val der = runCatching { Base64.getDecoder().decode(body) }.getOrNull() ?: continue
+            val cert = runCatching {
+                cf.generateCertificate(ByteArrayInputStream(der)) as X509Certificate
+            }.getOrNull() ?: continue
+            out += cert
+        }
+        return out
+    }
+
+    /**
+     * Build a trust manager that accepts certs anchored to any cert in
+     * [pinnedCAs]. Standard Android pattern: keystore with the CA(s),
+     * fed through [TrustManagerFactory]. Path validation (expiry, chain
+     * walk, basic constraints) is handled by the platform code.
+     */
+    fun trustManagerFor(pinnedCAs: List<X509Certificate>): X509TrustManager {
+        require(pinnedCAs.isNotEmpty()) { "pinnedCAs must contain at least one certificate" }
+        val ks = KeyStore.getInstance(KeyStore.getDefaultType()).apply { load(null, null) }
+        pinnedCAs.forEachIndexed { i, cert -> ks.setCertificateEntry("ca-$i", cert) }
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(ks)
+        return tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+    }
+
+    /**
+     * System default trust manager (Android's bundled CA store). Used
+     * when no pin exists for a server — legacy `.p12` imports from
+     * before Quick Connect existed, or when the pin file is missing.
+     */
+    fun systemTrustManager(): X509TrustManager {
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(null as KeyStore?)
+        return tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTEvent.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTEvent.kt
@@ -38,6 +38,12 @@ data class CoTEvent(
     val callsign: String? = null,
     val remarks: String = "",
     val rawXml: String? = null,
+    // Optional ATAK `<usericon iconsetpath="...">` value. FEMA / IC
+    // markers carry `COT_MAPPING_FEMA/<category>/<kind>` here so peers
+    // with the FEMA catalog render the right glyph; receivers without
+    // it fall back to the friendly-ground-installation default that
+    // [type] declares. See `FemaIconCatalog` and #29 / iOS PR for #13.
+    val iconsetPath: String? = null,
 ) {
     val affiliation: CoTAffiliation
         get() {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/FemaIconCatalog.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/FemaIconCatalog.kt
@@ -1,0 +1,214 @@
+package soy.engindearing.omnitak.mobile.data
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.CellTower
+import androidx.compose.material.icons.filled.FlightTakeoff
+import androidx.compose.material.icons.filled.Flag
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.House
+import androidx.compose.material.icons.filled.Inventory2
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material.icons.filled.LocalHospital
+import androidx.compose.material.icons.filled.MedicalServices
+import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.Vaccines
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * FEMA / Incident Command symbology catalog for the SAR / disaster
+ * response marker palette (closes #29).
+ *
+ * Why this exists
+ * ---------------
+ * K9Blue SAR feedback (5/10/26 via TAK Discord): pre-planned + hasty
+ * searches need IC, medical, LZ, vehicle, and support-station markers
+ * that MIL-STD-2525 can't express in civil-response vocabulary.
+ *
+ * CoT type convention
+ * -------------------
+ * FEMA / ICS markers don't have canonical MIL-STD-2525 unit types, so
+ * we emit them as friendly ground installations (`a-f-G-I-*`) and rely
+ * on the `<usericon iconsetpath="COT_MAPPING_FEMA/...">` detail
+ * extension to carry the FEMA glyph. Receivers without the FEMA set
+ * still get a plausible friendly-installation fallback rendered by
+ * ATAK/iTAK.
+ *
+ * Mirrors OmniTAK-iOS `FEMAIconCatalog.swift` byte-for-byte on the
+ * Kind raw values + cotType strings so a marker dropped on one platform
+ * round-trips to the other through CoT.
+ *
+ * References:
+ *   * NIMS / ICS-237 Resource Typing — symbology categories used here
+ *   * TAK ATAK-CIV iconsetpath convention (`COT_MAPPING_<SET>/<group>/<icon>`)
+ */
+object FemaIconCatalog {
+
+    /** SAR / incident-command grouping shown as palette sections. */
+    enum class Category(val displayName: String, val accent: Color) {
+        INCIDENT_COMMAND("Command", Color(0xFFFF9800)),  // orange
+        MEDICAL("Medical", Color(0xFFF44336)),           // red
+        AVIATION("Aviation", Color(0xFF00BCD4)),         // cyan
+        VEHICLES("Vehicles", Color(0xFFFFEB3B)),         // yellow
+        SUPPORT("Support", Color(0xFF4CAF50)),           // green
+    }
+
+    /**
+     * Individual FEMA / IC icons. The [raw] values are embedded in
+     * `<usericon iconsetpath="COT_MAPPING_FEMA/<category>/<raw>">` —
+     * stable identifier, never rename once a peer ships with one.
+     */
+    enum class Kind(val raw: String) {
+        COMMAND_POST("command_post"),
+        STAGING_AREA("staging_area"),
+        TRIAGE_STATION("triage_station"),
+        MEDICAL_SUPPLY("medical_supply"),
+        HELICOPTER_LZ("helicopter_lz"),
+        FIRE_TRUCK("fire_truck"),
+        AMBULANCE("ambulance"),
+        SEARCH_TEAM("search_team"),
+        BASE_CAMP("base_camp"),
+        FOOD_WATER("food_water"),
+        GENERATOR("generator"),
+        COMMUNICATIONS_HUB("communications_hub"),
+    }
+
+    data class FemaIcon(
+        val kind: Kind,
+        val category: Category,
+        val label: String,
+        val image: ImageVector,
+        val cotType: String,
+    ) {
+        // Stable wire identifier for inbound parsers + the `<usericon
+        // iconsetpath="...">` emission in CotBuilders.
+        val iconsetPath: String
+            get() = "COT_MAPPING_FEMA/${category.raw}/${kind.raw}"
+    }
+
+    private val entries: Map<Kind, FemaIcon> = mapOf(
+        // ── Incident Command ────────────────────────────────────────
+        Kind.COMMAND_POST to FemaIcon(
+            kind = Kind.COMMAND_POST,
+            category = Category.INCIDENT_COMMAND,
+            label = "Command Post",
+            image = Icons.Filled.Flag,
+            cotType = "a-f-G-I-U-T",
+        ),
+        Kind.STAGING_AREA to FemaIcon(
+            kind = Kind.STAGING_AREA,
+            category = Category.INCIDENT_COMMAND,
+            label = "Staging Area",
+            image = Icons.Filled.Inventory2,
+            cotType = "a-f-G-I-B-A",
+        ),
+        // ── Medical ─────────────────────────────────────────────────
+        Kind.TRIAGE_STATION to FemaIcon(
+            kind = Kind.TRIAGE_STATION,
+            category = Category.MEDICAL,
+            label = "Triage Station",
+            image = Icons.Filled.MedicalServices,
+            cotType = "a-f-G-I-M-T",
+        ),
+        Kind.MEDICAL_SUPPLY to FemaIcon(
+            kind = Kind.MEDICAL_SUPPLY,
+            category = Category.MEDICAL,
+            label = "Medical Supply",
+            image = Icons.Filled.Vaccines,
+            cotType = "a-f-G-I-M-S",
+        ),
+        // ── Aviation ────────────────────────────────────────────────
+        Kind.HELICOPTER_LZ to FemaIcon(
+            kind = Kind.HELICOPTER_LZ,
+            category = Category.AVIATION,
+            label = "Helicopter LZ",
+            image = Icons.Filled.FlightTakeoff,
+            cotType = "a-f-G-I-X-H",
+        ),
+        // ── Vehicles ────────────────────────────────────────────────
+        Kind.FIRE_TRUCK to FemaIcon(
+            kind = Kind.FIRE_TRUCK,
+            category = Category.VEHICLES,
+            label = "Fire Engine",
+            image = Icons.Filled.LocalFireDepartment,
+            cotType = "a-f-G-E-V-F-R",
+        ),
+        Kind.AMBULANCE to FemaIcon(
+            kind = Kind.AMBULANCE,
+            category = Category.VEHICLES,
+            label = "Ambulance",
+            image = Icons.Filled.LocalHospital,
+            cotType = "a-f-G-E-V-M-A",
+        ),
+        Kind.SEARCH_TEAM to FemaIcon(
+            kind = Kind.SEARCH_TEAM,
+            category = Category.VEHICLES,
+            label = "Search Team",
+            image = Icons.Filled.Groups,
+            cotType = "a-f-G-U-U-S",
+        ),
+        // ── Support ─────────────────────────────────────────────────
+        Kind.BASE_CAMP to FemaIcon(
+            kind = Kind.BASE_CAMP,
+            category = Category.SUPPORT,
+            label = "Base Camp",
+            image = Icons.Filled.House,
+            cotType = "a-f-G-I-B-C",
+        ),
+        Kind.FOOD_WATER to FemaIcon(
+            kind = Kind.FOOD_WATER,
+            category = Category.SUPPORT,
+            label = "Food / Water",
+            image = Icons.Filled.Restaurant,
+            cotType = "a-f-G-I-B-F",
+        ),
+        Kind.GENERATOR to FemaIcon(
+            kind = Kind.GENERATOR,
+            category = Category.SUPPORT,
+            label = "Generator",
+            image = Icons.Filled.Bolt,
+            cotType = "a-f-G-I-U-E",
+        ),
+        Kind.COMMUNICATIONS_HUB to FemaIcon(
+            kind = Kind.COMMUNICATIONS_HUB,
+            category = Category.SUPPORT,
+            label = "Comms Hub",
+            image = Icons.Filled.CellTower,
+            cotType = "a-f-G-I-U-C",
+        ),
+    )
+
+    /** All icons, in stable enum-declaration order. */
+    val all: List<FemaIcon> get() = Kind.entries.mapNotNull(entries::get)
+
+    /** Icons filtered to a single category, declaration-order preserved. */
+    fun iconsIn(category: Category): List<FemaIcon> = all.filter { it.category == category }
+
+    /** Lookup by enum. */
+    fun iconFor(kind: Kind): FemaIcon? = entries[kind]
+
+    /** Reverse lookup from a stored raw key (e.g. `"command_post"`). */
+    fun iconByRaw(raw: String): FemaIcon? =
+        Kind.entries.firstOrNull { it.raw == raw }?.let(entries::get)
+
+    /**
+     * Reverse lookup from a CoT `<usericon iconsetpath="...">` value.
+     * Returns null when the path doesn't point at the FEMA catalog (or
+     * the kind isn't one this build knows about).
+     */
+    fun iconByIconsetPath(path: String): FemaIcon? {
+        val parts = path.split('/')
+        if (parts.size < 3 || parts[0] != "COT_MAPPING_FEMA") return null
+        return iconByRaw(parts[2])
+    }
+
+    private val Category.raw: String
+        get() = when (this) {
+            Category.INCIDENT_COMMAND -> "incidentCommand"
+            Category.MEDICAL -> "medical"
+            Category.AVIATION -> "aviation"
+            Category.VEHICLES -> "vehicles"
+            Category.SUPPORT -> "support"
+        }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TAKConnection.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TAKConnection.kt
@@ -23,7 +23,6 @@ import java.net.InetSocketAddress
 import java.net.Socket
 import java.security.KeyStore
 import java.security.SecureRandom
-import java.security.cert.X509Certificate
 import javax.net.ssl.KeyManager
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
@@ -128,9 +127,10 @@ class TAKConnection(
      * TLS otherwise. TAK servers default to mTLS — without a client cert the
      * server closes the connection at handshake (PEER_DID_NOT_RETURN_A_CERTIFICATE).
      *
-     * Server-side trust still uses [TrustAllX509Manager] because TAK servers
-     * almost always present a self-signed CA. CA-import / pinning is the next
-     * GAP after this one.
+     * Server-side trust resolves in this order (#38 / GAP-106):
+     *   1. CA pin written during Quick Connect enrollment (preferred).
+     *   2. System trust store — for legacy `.p12` imports without a pin.
+     * No trust-all path remains.
      */
     private fun openTlsSocket(): Socket {
         val keyManagers = loadClientKeyManagers()
@@ -139,15 +139,51 @@ class TAKConnection(
         } else {
             Log.i(TAG, "TLS with client cert ${server.certificateName} (mTLS)")
         }
-        Log.w(TAG, "⚠ DEV-MODE server trust: accepting any server certificate. Add CA trust before shipping.")
+        val trustManager = loadServerTrustManager()
         val ctx = SSLContext.getInstance("TLS")
-        ctx.init(keyManagers, arrayOf<TrustManager>(TrustAllX509Manager()), SecureRandom())
+        ctx.init(keyManagers, arrayOf<TrustManager>(trustManager), SecureRandom())
         val s = ctx.socketFactory.createSocket() as SSLSocket
         s.tcpNoDelay = true
         s.soTimeout = READ_TIMEOUT_MS
         s.connect(InetSocketAddress(server.host, server.port), CONNECT_TIMEOUT_MS.toInt())
         s.startHandshake()
         return s
+    }
+
+    /**
+     * Build the server-trust X509TrustManager for this connection.
+     *
+     * Prefers the enrollment-time CA pin (TAKServer.caCertificateName →
+     * CertVault → CaTrust.trustManagerFor). Falls back to the system
+     * trust store when no pin exists or the pin file fails to load —
+     * legacy `.p12` imports from before Quick Connect existed end up on
+     * this branch.
+     *
+     * Never returns a trust-all manager. If a server presents a cert
+     * the pinned CA didn't sign (or the system bundle doesn't trust),
+     * the handshake fails — that's the point.
+     */
+    private fun loadServerTrustManager(): X509TrustManager {
+        val caName = server.caCertificateName
+        val vault = certVault
+        if (caName != null && vault != null) {
+            val bytes = vault.read(caName)
+            if (bytes != null) {
+                val chain = runCatching { CaTrust.decodePemChain(bytes) }.getOrElse {
+                    Log.w(TAG, "CA pin '$caName' parse failed: ${it.javaClass.simpleName}: ${it.message}")
+                    emptyList()
+                }
+                if (chain.isNotEmpty()) {
+                    Log.i(TAG, "TLS trust: pinned CA(s) from '$caName' (${chain.size} cert)")
+                    return CaTrust.trustManagerFor(chain)
+                }
+                Log.w(TAG, "CA pin '$caName' present but yielded no certs — falling back to system trust")
+            } else {
+                Log.w(TAG, "CA pin '$caName' missing from vault — falling back to system trust")
+            }
+        }
+        Log.i(TAG, "TLS trust: system trust store (no CA pin for this server)")
+        return CaTrust.systemTrustManager()
     }
 
     /**
@@ -203,12 +239,6 @@ class TAKConnection(
     private fun cleanup() {
         runCatching { socket?.close() }
         socket = null
-    }
-
-    private class TrustAllX509Manager : X509TrustManager {
-        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
-        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
-        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
     }
 
     companion object {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakRestApiClient.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakRestApiClient.kt
@@ -83,6 +83,97 @@ class TakRestApiClient(
         return parseDataPackages(body)
     }
 
+    /**
+     * `PUT /Marti/api/missions/{name}?creatorUid&tool&description&group&bbox`
+     * Returns the server's view of the freshly-created mission. iOS parity
+     * for issue #14 (commit ffcd48d): Marti tolerates an empty body on
+     * create, but some CIV builds insist on valid JSON, so we ship `{}`.
+     * Body shape on success varies across TAK 5.7 / OTS / taky — when the
+     * server returns 2xx with an unparseable / empty body we synthesise
+     * the response from the create args. Closes #30 slice 1.
+     */
+    fun createMission(
+        name: String,
+        creatorUid: String,
+        tool: String = "public",
+        description: String? = null,
+        groups: List<String> = emptyList(),
+        defaultRole: String? = null,
+        bbox: MissionBbox? = null,
+    ): TakMissionInfo {
+        val q = buildList {
+            add("creatorUid" to creatorUid)
+            add("tool" to tool)
+            if (!description.isNullOrBlank()) add("description" to description)
+            if (!defaultRole.isNullOrBlank()) add("defaultRole" to defaultRole)
+            groups.filter { it.isNotBlank() }.forEach { add("group" to it) }
+            bbox?.let { add("bbox" to it.queryValue) }
+        }
+        val (code, body) = httpRequest(
+            method = "PUT",
+            path = "/Marti/api/missions/${urlSegment(name)}",
+            query = q,
+            body = "{}".toByteArray(Charsets.UTF_8),
+            contentType = "application/json",
+        )
+        if (code !in 200..299) throw ApiException(httpReason(code, body))
+        // Best-effort decode; fall back to a synthesized record so the UI
+        // gets something back when the server returns 200 with empty body.
+        val parsed = runCatching { parseMissions(body).firstOrNull() }.getOrNull()
+        return parsed ?: TakMissionInfo(
+            name = name,
+            description = description,
+            creatorUid = creatorUid,
+            keywords = emptyList(),
+            contentCount = 0,
+        )
+    }
+
+    /**
+     * `POST /Marti/sync/missionupload` — multipart upload of a TAK
+     * Mission Package (.zip). Returns the server's SHA-256 hash from
+     * the plain-text response (`https://server/Marti/sync/content?hash=…`,
+     * or fall back to `hash=…` token form for older Marti builds).
+     */
+    fun uploadDataPackage(
+        zipBytes: ByteArray,
+        filename: String,
+        creatorUid: String,
+    ): String {
+        val boundary = "omnitak-${java.util.UUID.randomUUID()}"
+        val body = buildMultipartPackage(boundary, filename, zipBytes)
+        val (code, response) = httpRequest(
+            method = "POST",
+            path = "/Marti/sync/missionupload",
+            query = listOf(
+                "creatorUid" to creatorUid,
+                "filename" to filename,
+            ),
+            body = body,
+            contentType = "multipart/form-data; boundary=$boundary",
+        )
+        if (code !in 200..299) throw ApiException(httpReason(code, response))
+        return extractHash(response)
+            ?: throw ApiException("Server accepted upload but returned no hash: ${response.take(120)}")
+    }
+
+    /**
+     * `PUT /Marti/api/missions/{name}/contents` — attach a previously
+     * uploaded data-package hash to the named mission. Mission must
+     * already exist; pair with [createMission] + [uploadDataPackage].
+     */
+    fun attachHashToMission(missionName: String, hash: String) {
+        val payload = """{"hashes":["${jsonEscape(hash)}"]}""".toByteArray(Charsets.UTF_8)
+        val (code, body) = httpRequest(
+            method = "PUT",
+            path = "/Marti/api/missions/${urlSegment(missionName)}/contents",
+            query = emptyList(),
+            body = payload,
+            contentType = "application/json",
+        )
+        if (code !in 200..299) throw ApiException(httpReason(code, body))
+    }
+
     // ------------------------------------------------------------------
     // JSON parsing — tolerant of the three envelope shapes.
     // ------------------------------------------------------------------
@@ -143,6 +234,53 @@ class TakRestApiClient(
     // ------------------------------------------------------------------
     // HTTP + mTLS (HttpsURLConnection, no extra deps).
     // ------------------------------------------------------------------
+
+    /**
+     * Generalised mTLS request used by the write endpoints. GET callers
+     * (legacy [httpGet]) keep their narrow signature; write callers use
+     * this so the body + content-type wiring is in one place.
+     */
+    internal fun httpRequest(
+        method: String,
+        path: String,
+        query: List<Pair<String, String>>,
+        body: ByteArray?,
+        contentType: String?,
+    ): Pair<Int, String> {
+        val url = URL(baseUrl(path) + encodeQuery(query))
+        val conn = (url.openConnection() as HttpsURLConnection).apply {
+            connectTimeout = CONNECT_TIMEOUT_MS
+            readTimeout = WRITE_READ_TIMEOUT_MS
+            requestMethod = method
+            doInput = true
+            doOutput = body != null
+            setRequestProperty("Accept", "application/json")
+            if (contentType != null) setRequestProperty("Content-Type", contentType)
+            val user = server.username
+            val pass = server.password
+            if (!user.isNullOrBlank() && !pass.isNullOrBlank()) {
+                val raw = "$user:$pass".toByteArray(Charsets.UTF_8)
+                setRequestProperty("Authorization", "Basic " + Base64.encodeToString(raw, Base64.NO_WRAP))
+            }
+            val ctx = SSLContext.getInstance("TLS")
+            ctx.init(loadKeyManagers(), arrayOf(TrustAll), SecureRandom())
+            sslSocketFactory = ctx.socketFactory
+            hostnameVerifier = AcceptAllHostnames
+        }
+        return try {
+            conn.connect()
+            if (body != null) conn.outputStream.use { it.write(body) }
+            val code = conn.responseCode
+            val stream = if (code in 200..299) conn.inputStream else conn.errorStream
+            val text = stream?.bufferedReader(Charsets.UTF_8)?.use { it.readText() } ?: ""
+            code to text
+        } catch (t: Throwable) {
+            Log.w(TAG, "$method $path failed: ${t.javaClass.simpleName}: ${t.message}")
+            throw ApiException(t.message ?: t.javaClass.simpleName, t)
+        } finally {
+            conn.disconnect()
+        }
+    }
 
     private fun httpGet(path: String): Pair<Int, String> {
         val conn = (URL(baseUrl(path)).openConnection() as HttpsURLConnection).apply {
@@ -217,7 +355,116 @@ class TakRestApiClient(
         const val SECURE_API_PORT = 8443
         private const val CONNECT_TIMEOUT_MS = 10_000
         private const val READ_TIMEOUT_MS = 20_000
+        // Write endpoints (mission upload in particular) can carry
+        // multi-MB payloads. Bump the read timeout for those without
+        // affecting the snappier list reads.
+        private const val WRITE_READ_TIMEOUT_MS = 60_000
+
+        // ---- Exposed `internal` for unit-test instrumentation ----
+
+        /**
+         * Marti `missionupload` returns a URL like
+         * `https://server/Marti/sync/content?hash=ABC123…` on success.
+         * Older builds emit `Hash: ABC123` headers — handle both.
+         * Returns null when no hash can be parsed.
+         */
+        internal fun extractHash(body: String): String? {
+            val trimmed = body.trim()
+            if (trimmed.isEmpty()) return null
+            // Try URL query parse first.
+            runCatching {
+                val url = URL(trimmed)
+                val q = url.query.orEmpty()
+                q.split('&').forEach { pair ->
+                    val (k, v) = pair.split('=', limit = 2).let { it[0] to it.getOrNull(1).orEmpty() }
+                    if (k.equals("hash", ignoreCase = true) && v.isNotBlank()) return v
+                }
+            }
+            // Fallback: any `hash=...` token anywhere in the response.
+            val idx = trimmed.lowercase().indexOf("hash=")
+            if (idx >= 0) {
+                val tail = trimmed.substring(idx + "hash=".length)
+                val token = tail.takeWhile { it != '&' && !it.isWhitespace() }
+                if (token.isNotBlank()) return token
+            }
+            return null
+        }
+
+        /**
+         * URL-encode the path segment between slashes — mission names
+         * can contain spaces, slashes, and unicode that must round-trip
+         * through Marti without rewriting the route.
+         */
+        internal fun urlSegment(raw: String): String =
+            java.net.URLEncoder.encode(raw, Charsets.UTF_8).replace("+", "%20")
+
+        internal fun encodeQuery(pairs: List<Pair<String, String>>): String {
+            if (pairs.isEmpty()) return ""
+            val sb = StringBuilder("?")
+            pairs.forEachIndexed { i, (k, v) ->
+                if (i > 0) sb.append('&')
+                sb.append(java.net.URLEncoder.encode(k, Charsets.UTF_8))
+                    .append('=')
+                    .append(java.net.URLEncoder.encode(v, Charsets.UTF_8))
+            }
+            return sb.toString()
+        }
+
+        internal fun jsonEscape(raw: String): String =
+            buildString {
+                raw.forEach { c ->
+                    when (c) {
+                        '\\' -> append("\\\\")
+                        '"' -> append("\\\"")
+                        '\n' -> append("\\n")
+                        '\r' -> append("\\r")
+                        '\t' -> append("\\t")
+                        else -> if (c.code < 0x20) append("\\u%04x".format(c.code)) else append(c)
+                    }
+                }
+            }
+
+        /**
+         * Build the `multipart/form-data` body Marti's missionupload
+         * endpoint expects: one `assetfile` part containing the .zip
+         * with `application/x-zip-compressed` content-type.
+         */
+        internal fun buildMultipartPackage(
+            boundary: String,
+            filename: String,
+            zipBytes: ByteArray,
+        ): ByteArray {
+            val crlf = "\r\n"
+            val header = StringBuilder()
+                .append("--").append(boundary).append(crlf)
+                .append("Content-Disposition: form-data; name=\"assetfile\"; filename=\"")
+                .append(filename.replace("\"", "")).append('"').append(crlf)
+                .append("Content-Type: application/x-zip-compressed").append(crlf)
+                .append(crlf)
+                .toString()
+                .toByteArray(Charsets.UTF_8)
+            val footer = (crlf + "--" + boundary + "--" + crlf).toByteArray(Charsets.UTF_8)
+            val out = java.io.ByteArrayOutputStream(header.size + zipBytes.size + footer.size)
+            out.write(header)
+            out.write(zipBytes)
+            out.write(footer)
+            return out.toByteArray()
+        }
     }
+}
+
+/**
+ * Bounding box for [TakRestApiClient.createMission]. Marti expects
+ * `bbox=minLat,minLon,maxLat,maxLon` (no spaces) in WGS-84 degrees.
+ */
+data class MissionBbox(
+    val minLat: Double,
+    val minLon: Double,
+    val maxLat: Double,
+    val maxLon: Double,
+) {
+    val queryValue: String
+        get() = "$minLat,$minLon,$maxLat,$maxLon"
 }
 
 // MARK: - Marti API models (minimal subset the sync UI needs)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 private val Context.userPrefsDataStore by preferencesDataStore(name = "user_prefs")
@@ -165,6 +166,24 @@ class UserPrefsStore(private val context: Context) {
     /** Convenience writer for the layers-dialog mesh visibility toggle. */
     suspend fun setMeshNodesLayerVisible(value: Boolean) {
         update { it.copy(meshNodesLayerVisible = value) }
+    }
+
+    /**
+     * Read the stable EUD UID, generating + persisting one on first
+     * call. Every wire CoT event tied to this device — PPLI, GeoChat,
+     * markers — has to share this UID; sending two different ones makes
+     * receiving ATAK render the operator as two separate contacts
+     * (#9).
+     *
+     * Format `ANDROID-<uuid>` matches what SelfPositionBroadcaster has
+     * been minting since 0.1; existing installs keep their value.
+     */
+    suspend fun ensureSelfUid(): String {
+        val current = prefs.first()
+        if (current.selfUid.isNotBlank()) return current.selfUid
+        val generated = "ANDROID-${java.util.UUID.randomUUID()}"
+        update { it.copy(selfUid = generated) }
+        return generated
     }
 
     private fun readFrom(p: androidx.datastore.preferences.core.Preferences): UserPrefs = UserPrefs(

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -31,7 +31,7 @@ enum class MapProvider { OSM_RASTER, SATELLITE_HINT, TOPO_HINT, WMTS_CUSTOM }
  */
 data class UserPrefs(
     val callsign: String = "OMNI-1",
-    val team: String = "CYAN",
+    val team: String = "Cyan",
     // Persistent EUD identifier broadcast in every PPLI CoT event. Empty
     // until the first connection generates one (`ANDROID-<uuid>`); after
     // that it never changes so TAK servers see a stable contact across
@@ -45,7 +45,7 @@ data class UserPrefs(
     val selfLon: Double = Double.NaN,
     val distanceUnit: DistanceUnit = DistanceUnit.METRIC,
     val coordFormat: CoordFormat = CoordFormat.LATLON_DECIMAL,
-    val mapProvider: MapProvider = MapProvider.OSM_RASTER,
+    val mapProvider: MapProvider = MapProvider.TOPO_HINT,
     // GAP-107 — XYZ tile URL template the operator pasted in. Used when
     // mapProvider == WMTS_CUSTOM. Format: https://host/{z}/{x}/{y}.png
     val customTileUrl: String = "",
@@ -169,7 +169,7 @@ class UserPrefsStore(private val context: Context) {
 
     private fun readFrom(p: androidx.datastore.preferences.core.Preferences): UserPrefs = UserPrefs(
         callsign = p[KEY_CALLSIGN] ?: "OMNI-1",
-        team = p[KEY_TEAM] ?: "CYAN",
+        team = normalizeTeam(p[KEY_TEAM]),
         selfUid = p[KEY_SELF_UID] ?: "",
         selfLat = p[KEY_SELF_LAT]?.toDoubleOrNull() ?: Double.NaN,
         selfLon = p[KEY_SELF_LON]?.toDoubleOrNull() ?: Double.NaN,
@@ -178,7 +178,7 @@ class UserPrefsStore(private val context: Context) {
         coordFormat = p[KEY_COORD]?.let { runCatching { CoordFormat.valueOf(it) }.getOrNull() }
             ?: CoordFormat.LATLON_DECIMAL,
         mapProvider = p[KEY_MAP]?.let { runCatching { MapProvider.valueOf(it) }.getOrNull() }
-            ?: MapProvider.OSM_RASTER,
+            ?: MapProvider.TOPO_HINT,
         customTileUrl = p[KEY_CUSTOM_TILE_URL] ?: "",
         autoPublishMeshToTak = p[KEY_AUTO_PUBLISH_MESH] ?: true,
         meshNodesLayerVisible = p[KEY_MESH_LAYER_VISIBLE] ?: true,
@@ -195,4 +195,19 @@ class UserPrefsStore(private val context: Context) {
         toolbarItemIds = p[KEY_TOOLBAR_ITEMS]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),
         toolbarCoachmarkSeen = p[KEY_TOOLBAR_COACH] ?: false,
     )
+
+    // ATAK / OpenTakServer canonical team names are Title Case ("Cyan",
+    // "Dark Blue"). OmniTAK shipped an ALLCAPS picker through 0.32.0, so
+    // legacy installs still have ALLCAPS in DataStore — normalize on read
+    // so wire emission (`<__group name="...">`) matches the server's DB
+    // keying and OTS's web UI stops rejecting our PPLI.
+    private fun normalizeTeam(raw: String?): String {
+        val trimmed = raw?.trim().orEmpty()
+        if (trimmed.isEmpty()) return "Cyan"
+        return trimmed.split(' ')
+            .filter { it.isNotEmpty() }
+            .joinToString(" ") { word ->
+                word.lowercase().replaceFirstChar { it.titlecase() }
+            }
+    }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconCache.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconCache.kt
@@ -29,6 +29,14 @@ import java.io.IOException
 object MilStdIconCache {
 
     private const val TAG = "MilStdIconCache"
+    // 64 px is the canonical milsymbol render size used by ATAK and
+    // matches the Marker annotation overlay's natural sizing. Larger
+    // values give more legible interior detail (rotor caret on
+    // SUAPMHQ multirotor, wing detail on fixed-wing UAS) but
+    // exacerbate cold-cache churn on every size change and visually
+    // dominate neighbouring contacts. Revisit alongside the
+    // [ContactSymbolLayer] migration when high-density CoT rendering
+    // is properly engineered.
     private const val DEFAULT_SIZE_PX = 64
 
     private data class Key(val sidc: String, val sizePx: Int)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconService.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconService.kt
@@ -88,6 +88,13 @@ object MilStdIconService {
         CoTTypeDefinition("a-u-G-U", "SUGPU------.svg", "Unknown Ground", "Unknown ground unit", "unknown"),
         CoTTypeDefinition("a-u-G-U-C-I", "SUGPUCI----.svg", "Unknown Infantry", "Unknown infantry unit", "unknown"),
         CoTTypeDefinition("a-u-A", "SUA---------.svg", "Unknown Air", "Unknown aircraft", "unknown"),
+        // Unknown UAS — the default targets for FAA Remote ID broadcasts.
+        // Multirotor and fixed-wing UAS pre-loaded in the floor so RID
+        // tracks render with the correct multirotor / fixed-wing glyph
+        // even before the JSON catalogue loads, and the unit tests on the
+        // CesiumEntityJson bridge are stable without Application.onCreate.
+        CoTTypeDefinition("a-u-A-M-H-Q", "SUAPMHQ----.svg", "Unknown UAS Multirotor", "Multirotor UAS detected via FAA Remote ID", "unknown"),
+        CoTTypeDefinition("a-u-A-M-F-Q", "SUAPMFQ----.svg", "Unknown UAS Fixed Wing", "Fixed-wing UAS detected via FAA Remote ID", "unknown"),
     )
 
     /**

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuilders.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuilders.kt
@@ -68,6 +68,12 @@ object CotBuilders {
         val callsignAttr = event.callsign?.let { """ callsign="${xmlEscape(it)}"""" } ?: ""
         val remarks = if (event.remarks.isNotBlank())
             "<remarks>${xmlEscape(event.remarks)}</remarks>" else ""
+        // ATAK / iTAK render FEMA markers (and any custom-glyph marker)
+        // off the `iconsetpath` detail — emit it when present so peers
+        // with the catalog show the right symbol (#29).
+        val userIcon = event.iconsetPath?.takeIf { it.isNotBlank() }?.let {
+            """<usericon iconsetpath="${xmlEscape(it)}"/>"""
+        } ?: ""
 
         return """
             <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -76,6 +82,7 @@ object CotBuilders {
               <point lat="${event.lat}" lon="${event.lon}" hae="${event.hae}" ce="${event.ce}" le="${event.le}"/>
               <detail>
                 <contact$callsignAttr/>
+                $userIcon
                 $remarks
                 $dests
               </detail>

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
@@ -4,13 +4,18 @@ import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.io.ByteArrayOutputStream
 import soy.engindearing.omnitak.mobile.data.AdminMessageParser
@@ -90,6 +95,27 @@ class MeshtasticManager(private val context: Context? = null) {
     /** BLE-specific state, lazily wired when the user opens the BLE tab. */
     fun bleState(): StateFlow<ConnectionState>? = bleClientOrNull()?.state
     fun bleBytesReceived(): StateFlow<Long>? = bleClientOrNull()?.bytesReceived
+
+    /**
+     * Transport-aware connection state. Tracks whichever transport
+     * [_activeTransport] currently points at — TCP, BLE, or neither.
+     *
+     * Screens that don't care which transport is live (e.g. Device
+     * Settings, which just needs to know whether *any* radio is
+     * reachable to enable the push button) should observe this rather
+     * than [state] (TCP-only). Fixes #36 where a BLE-connected radio
+     * showed as "No device connected" in Device Settings.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val activeConnectionState: StateFlow<ConnectionState> =
+        _activeTransport.flatMapLatest { transport ->
+            when (transport) {
+                MeshConnectionType.TCP -> tcpClient.state
+                MeshConnectionType.BLUETOOTH ->
+                    bleClientOrNull()?.state ?: flowOf(ConnectionState.Disconnected)
+                null -> flowOf(ConnectionState.Disconnected)
+            }
+        }.stateIn(scope, SharingStarted.Eagerly, ConnectionState.Disconnected)
 
     /** Eagerly construct the BLE client (if a Context is available) so
      *  the BLE tab can observe its state flows even before any

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MissionSyncManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MissionSyncManager.kt
@@ -69,6 +69,55 @@ class MissionSyncManager(
         _lastRefresh.value = System.currentTimeMillis()
     }
 
+    /**
+     * Upload a TAK Mission Package (.zip) to the first online,
+     * cert-enrolled, TLS server. Returns [UploadOutcome.Hash] with the
+     * Marti-assigned SHA on success, [UploadOutcome.NoServer] when no
+     * enrolled+enabled+TLS server is configured, or
+     * [UploadOutcome.Failed] with the server's reason on HTTP errors.
+     *
+     * Slice 3 of #30 — paired with [LassoExporters.writeMissionPackage]
+     * so the existing "Add to Data Package" button can also hand off to
+     * the TAK server instead of (or in addition to) the local share
+     * sheet. Returns just the hash; attaching it to a specific named
+     * mission is the slice-2 authoring flow.
+     */
+    suspend fun uploadDataPackage(
+        zipBytes: ByteArray,
+        filename: String,
+        creatorUid: String,
+    ): UploadOutcome {
+        val candidates = enabledServers()
+        if (candidates.isEmpty()) return UploadOutcome.NoServer
+        return withContext(Dispatchers.IO) {
+            for (server in candidates) {
+                val client = TakRestApiClient(server, certVault)
+                val attempt = runCatching {
+                    client.checkReachability()
+                    client.uploadDataPackage(zipBytes, filename, creatorUid)
+                }
+                val hash = attempt.getOrNull()
+                if (hash != null) {
+                    return@withContext UploadOutcome.Hash(
+                        hash = hash,
+                        serverId = server.id,
+                        serverName = server.name,
+                    )
+                }
+            }
+            // Last attempt's failure is the most informative one; the
+            // earlier ones were probably the same network condition.
+            val lastFailure = candidates.last().let { sv ->
+                runCatching {
+                    TakRestApiClient(sv, certVault).uploadDataPackage(zipBytes, filename, creatorUid)
+                }.exceptionOrNull()
+            }
+            UploadOutcome.Failed(
+                reason = lastFailure?.message ?: "All ${candidates.size} server(s) refused the upload"
+            )
+        }
+    }
+
     /** Refresh a single server (tap-to-retry on its row). */
     suspend fun refresh(serverId: String) {
         val sv = enabledServers().firstOrNull { it.id == serverId } ?: return
@@ -145,4 +194,15 @@ data class AggregatedPackage(
     val pkg: TakDataPackageInfo,
 ) {
     val id: String get() = "$serverId:${pkg.hash}"
+}
+
+/**
+ * Result of [MissionSyncManager.uploadDataPackage]. Wire-shape design
+ * goal: caller can pattern-match for a snappy toast — no exception
+ * juggling at the UI layer.
+ */
+sealed interface UploadOutcome {
+    data class Hash(val hash: String, val serverId: String, val serverName: String) : UploadOutcome
+    data object NoServer : UploadOutcome
+    data class Failed(val reason: String) : UploadOutcome
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJson.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJson.kt
@@ -1,0 +1,59 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.json.JSONArray
+import org.json.JSONObject
+import soy.engindearing.omnitak.mobile.data.CoTAffiliation
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
+
+/**
+ * Build the entity JSON payload `window.OmniBridge.setEntities(...)` consumes.
+ * Includes a MIL-STD-2525 `sidc` for each contact so cesium_scene.html's
+ * `_billboard()` takes the milsymbol branch and renders the proper symbol
+ * (multirotor / fixed-wing UAS / infantry / etc.) instead of falling back
+ * to a generic affiliation frame. Self stays sidc-less so it keeps the
+ * friendly-affiliation frame circle.
+ */
+internal fun buildCesiumEntitiesJson(
+    contacts: List<CoTEvent>,
+    selfLat: Double?,
+    selfLon: Double?,
+    selfCallsign: String,
+): String {
+    val arr = JSONArray()
+    if (selfLat != null && selfLon != null && !selfLat.isNaN() && !selfLon.isNaN()) {
+        arr.put(
+            JSONObject().apply {
+                put("uid", "__self__")
+                put("lat", selfLat)
+                put("lon", selfLon)
+                put("callsign", selfCallsign)
+                put("affiliation", "f")
+                put("kind", "self")
+            },
+        )
+    }
+    for (c in contacts) {
+        if (c.lat.isNaN() || c.lon.isNaN()) continue
+        arr.put(
+            JSONObject().apply {
+                put("uid", c.uid)
+                put("lat", c.lat)
+                put("lon", c.lon)
+                if (c.hae != 0.0) put("hae", c.hae)
+                c.callsign?.let { put("callsign", it) }
+                put("affiliation", affChar(c.affiliation))
+                put("kind", "contact")
+                put("sidc", MilStdIconService.getSidc(c.type))
+            },
+        )
+    }
+    return arr.toString()
+}
+
+private fun affChar(a: CoTAffiliation): String = when (a) {
+    CoTAffiliation.FRIEND -> "f"
+    CoTAffiliation.HOSTILE -> "h"
+    CoTAffiliation.NEUTRAL -> "n"
+    else -> "u"
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
@@ -16,10 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.viewinterop.AndroidView
-import org.json.JSONArray
 import org.json.JSONObject
 import org.maplibre.android.geometry.LatLng
-import soy.engindearing.omnitak.mobile.data.CoTAffiliation
 import soy.engindearing.omnitak.mobile.data.CoTEvent
 
 /**
@@ -68,7 +66,7 @@ fun CesiumMapView(
     fun pushEntities() {
         val wv = webViewRef.value ?: return
         if (!ready.value) return
-        val json = buildEntitiesJson(
+        val json = buildCesiumEntitiesJson(
             contactsState.value, selfLatState.value, selfLonState.value, selfCallsignState.value,
         )
         wv.evaluateJavascript("window.OmniBridge.setEntities($json);", null)
@@ -168,45 +166,3 @@ fun CesiumMapView(
     }
 }
 
-private fun buildEntitiesJson(
-    contacts: List<CoTEvent>,
-    selfLat: Double?,
-    selfLon: Double?,
-    selfCallsign: String,
-): String {
-    val arr = JSONArray()
-    if (selfLat != null && selfLon != null && !selfLat.isNaN() && !selfLon.isNaN()) {
-        arr.put(
-            JSONObject().apply {
-                put("uid", "__self__")
-                put("lat", selfLat)
-                put("lon", selfLon)
-                put("callsign", selfCallsign)
-                put("affiliation", "f")
-                put("kind", "self")
-            },
-        )
-    }
-    for (c in contacts) {
-        if (c.lat.isNaN() || c.lon.isNaN()) continue
-        arr.put(
-            JSONObject().apply {
-                put("uid", c.uid)
-                put("lat", c.lat)
-                put("lon", c.lon)
-                if (c.hae != 0.0) put("hae", c.hae)
-                c.callsign?.let { put("callsign", it) }
-                put("affiliation", affChar(c.affiliation))
-                put("kind", "contact")
-            },
-        )
-    }
-    return arr.toString()
-}
-
-private fun affChar(a: CoTAffiliation): String = when (a) {
-    CoTAffiliation.FRIEND -> "f"
-    CoTAffiliation.HOSTILE -> "h"
-    CoTAffiliation.NEUTRAL -> "n"
-    else -> "u"
-}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactLayer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactLayer.kt
@@ -81,19 +81,16 @@ object ContactLayer {
                 )
                 markers[c.uid] = marker
             } else {
-                // Position may have moved (live PPLI). Re-add to
-                // refresh — Marker's `position` setter doesn't
-                // always trigger a redraw on 11.x.
-                if (existing.position != ll || existing.icon != icon) {
-                    map.removeMarker(existing)
-                    val marker = map.addMarker(
-                        MarkerOptions()
-                            .position(ll)
-                            .title(c.callsign ?: c.uid)
-                            .icon(icon)
-                    )
-                    markers[c.uid] = marker
-                }
+                // In-place mutation on PPLI ticks. MapLibre 11.8's
+                // Marker.setPosition / setIcon both call
+                // map.updateMarker(this) internally, so the annotation
+                // view is preserved across updates — fixes the
+                // remove+readd flicker the previous workaround caused
+                // (port of iOS PR D #1 / closes #23).
+                if (existing.position != ll) existing.position = ll
+                if (existing.icon != icon) existing.icon = icon
+                val newTitle = c.callsign ?: c.uid
+                if (existing.title != newTitle) existing.title = newTitle
             }
         }
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
@@ -1,0 +1,249 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.Style
+import org.maplibre.android.style.expressions.Expression
+import org.maplibre.android.style.layers.PropertyFactory.iconAllowOverlap
+import org.maplibre.android.style.layers.PropertyFactory.iconIgnorePlacement
+import org.maplibre.android.style.layers.PropertyFactory.iconImage
+import org.maplibre.android.style.layers.PropertyFactory.iconSize
+import org.maplibre.android.style.layers.PropertyFactory.textAllowOverlap
+import org.maplibre.android.style.layers.PropertyFactory.textAnchor
+import org.maplibre.android.style.layers.PropertyFactory.textColor
+import org.maplibre.android.style.layers.PropertyFactory.textField
+import org.maplibre.android.style.layers.PropertyFactory.textHaloColor
+import org.maplibre.android.style.layers.PropertyFactory.textHaloWidth
+import org.maplibre.android.style.layers.PropertyFactory.textIgnorePlacement
+import org.maplibre.android.style.layers.PropertyFactory.textOffset
+import org.maplibre.android.style.layers.PropertyFactory.textSize
+import org.maplibre.android.style.layers.SymbolLayer
+import org.maplibre.android.style.sources.GeoJsonSource
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconCache
+import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
+
+/**
+ * Experimental GeoJSON-source-driven contacts layer. Holds a single
+ * [GeoJsonSource] of feature points + one [SymbolLayer] that draws
+ * the MIL-STD-2525 icon for each contact via a data-driven
+ * `icon-image` expression. One GL upload per [update] call instead
+ * of N marker mutations — the path TAKAware, ATAK, and most
+ * production map clients use to handle hundreds of CoT contacts.
+ *
+ * History to be aware of: an earlier GeoJsonSource + CircleLayer
+ * attempt was reverted in commit 0813351 because the Adreno 610
+ * fragment pipeline silently failed to paint registered layers
+ * (the layer was queryable but never drew pixels). LocationComponent
+ * — which uses [Style.addImage] with a bitmap — has always rendered
+ * correctly on the same driver, so we exercise the same image
+ * registration path here. If this layer also fails to paint on
+ * Adreno 610, the user-prefs toggle [UserPrefs.experimentalSymbolLayer]
+ * lets the operator fall back to the working Marker-annotation
+ * [ContactLayer] without a rebuild.
+ *
+ * Lifecycle contract:
+ *  1. Caller invokes [installInto] once after the [Style] is loaded,
+ *     passing the [Context] used for SVG rasterisation. Registers
+ *     the source + layer + a pre-warmed set of base SIDC images.
+ *  2. Caller invokes [update] with the current contacts collection
+ *     whenever the contact store changes. Each unique SIDC seen for
+ *     the first time is rasterised and registered via [Style.addImage]
+ *     on the fly; subsequent updates reuse the registered image.
+ *  3. The instance is single-style-scoped. If the map style is
+ *     re-loaded the caller must construct a fresh instance and
+ *     re-install.
+ */
+class ContactSymbolLayer {
+
+    companion object {
+        private const val TAG = "ContactSymbolLayer"
+
+        // Source + layer ids — exposed for tests and for callers
+        // that need to query the style by id (e.g. visibility
+        // toggling without recreating the layer).
+        const val SOURCE_ID = "omnitak-contacts-source"
+        const val SYMBOL_LAYER_ID = "omnitak-contacts-symbols"
+        const val LABEL_LAYER_ID = "omnitak-contacts-labels"
+
+        // Feature property keys.
+        const val PROP_UID = "uid"
+        const val PROP_SIDC = "sidc"
+        const val PROP_CALLSIGN = "callsign"
+        const val PROP_AFFILIATION = "affiliation"
+        const val PROP_TYPE = "cotType"
+
+        // Pixel size the cache rasterises at. 64 matches the legacy
+        // Marker path and is the canonical milsymbol size.
+        private const val ICON_PIXEL_SIZE = 64
+
+        // Image name prefix in [Style.addImage]. Keyed by SIDC so
+        // each distinct symbol is uploaded exactly once per style.
+        const val ICON_IMAGE_PREFIX = "milstd-"
+    }
+
+    private var installed: Boolean = false
+    private val registeredSidcs: MutableSet<String> = mutableSetOf()
+
+    /**
+     * Wire the source + layer into [style] and pre-warm the cache
+     * with a small set of common SIDCs so the first contact sighting
+     * doesn't pay the SVG rasterisation cost on the rendering frame.
+     * Idempotent — calling on the same style twice is a no-op.
+     */
+    fun installInto(style: Style, context: Context) {
+        if (installed) return
+        installed = true
+
+        // Empty FeatureCollection — populated by the first [update] call.
+        val source = GeoJsonSource(SOURCE_ID, emptyFeatureCollectionJson())
+        style.addSource(source)
+
+        val symbolLayer = SymbolLayer(SYMBOL_LAYER_ID, SOURCE_ID).withProperties(
+            iconImage(Expression.concat(Expression.literal(ICON_IMAGE_PREFIX), Expression.get(PROP_SIDC))),
+            // Slight visual scale-down so the 64 px raster reads as a
+            // map marker, not a sticker. Matches the legacy MarkerOptions
+            // sizing on the Annotation path.
+            iconSize(0.6f),
+            iconAllowOverlap(true),
+            iconIgnorePlacement(true),
+        )
+        style.addLayer(symbolLayer)
+
+        val labelLayer = SymbolLayer(LABEL_LAYER_ID, SOURCE_ID).withProperties(
+            textField(Expression.get(PROP_CALLSIGN)),
+            textSize(10f),
+            textColor("#FFFFFF"),
+            textHaloColor("#000000"),
+            textHaloWidth(1.2f),
+            textOffset(arrayOf(0f, 1.4f)),
+            textAnchor("top"),
+            textAllowOverlap(false),
+            textIgnorePlacement(false),
+        )
+        style.addLayer(labelLayer)
+
+        // Pre-warm common SIDCs so the first sighting of a friend
+        // / hostile / unknown / multirotor doesn't rasterize on the
+        // render frame. Adding these to the style up front also
+        // exercises the same code path on the Adreno 610 driver
+        // that LocationComponent's foregroundName uses — if any of
+        // these fail to register, we know the GL bug applies and
+        // can fall back to the Marker path before any contacts
+        // even arrive.
+        for (cotType in PRE_WARM_COT_TYPES) {
+            registerSidcImage(style, context, MilStdIconService.getSidc(cotType))
+        }
+    }
+
+    /**
+     * Push the current contacts list to the GeoJsonSource. Any SIDC
+     * not yet registered in [Style] is rasterised + added before the
+     * source is updated. Contacts with NaN lat/lon are skipped.
+     *
+     * @return number of distinct SIDCs newly registered on this call
+     *   (useful for tests + diagnostics).
+     */
+    fun update(map: MapLibreMap, context: Context, contacts: Collection<CoTEvent>): Int {
+        val style = map.style ?: return 0
+        if (!installed) {
+            Log.w(TAG, "update() before installInto() — no-op")
+            return 0
+        }
+
+        // First pass: make sure every SIDC referenced by the
+        // FeatureCollection has its image registered. Skip rows
+        // with bad coordinates.
+        var newlyRegistered = 0
+        val features = JSONArray()
+        for (c in contacts) {
+            if (c.lat.isNaN() || c.lon.isNaN()) continue
+            val sidc = MilStdIconService.getSidc(c.type)
+            if (registerSidcImage(style, context, sidc)) newlyRegistered++
+            features.put(featureJson(c, sidc))
+        }
+
+        val fc = JSONObject().apply {
+            put("type", "FeatureCollection")
+            put("features", features)
+        }
+        val source = style.getSourceAs<GeoJsonSource>(SOURCE_ID)
+        source?.setGeoJson(fc.toString())
+        return newlyRegistered
+    }
+
+    /**
+     * Register the icon for [sidc] in [style] if it isn't already.
+     * Returns true if this call added a new image; false if it was
+     * already present.
+     */
+    private fun registerSidcImage(style: Style, context: Context, sidc: String): Boolean {
+        if (sidc in registeredSidcs) return false
+        val cotType = cotTypeForSidc(sidc)
+        val bitmap = MilStdIconCache.bitmapFor(context, cotType, ICON_PIXEL_SIZE)
+            ?: MilStdIconCache.bitmapFor(context, "a-u-A", ICON_PIXEL_SIZE)
+            ?: run {
+                // Both the specific SIDC and the unknown-air fallback
+                // failed to rasterise — should be unreachable since
+                // the floor 108-entry asset bundle is part of the apk.
+                // Log + skip so a missing-asset regression doesn't
+                // crash the layer.
+                Log.w(TAG, "no bitmap available for sidc=$sidc; skipping addImage")
+                return false
+            }
+        style.addImage(ICON_IMAGE_PREFIX + sidc, bitmap)
+        registeredSidcs.add(sidc)
+        return true
+    }
+
+    /**
+     * Reverse-resolve a SIDC back to a plausible CoT type so we can
+     * call [MilStdIconCache.bitmapFor] (which takes cotType, not
+     * SIDC). Uses the service's existing reverse map when present;
+     * falls back to plain "a-u-A" so we still register something.
+     */
+    private fun cotTypeForSidc(sidc: String): String {
+        return MilStdIconService.getDefinitionBySidc(sidc)?.value ?: "a-u-A"
+    }
+
+    private fun featureJson(c: CoTEvent, sidc: String): JSONObject {
+        return JSONObject().apply {
+            put("type", "Feature")
+            put("geometry", JSONObject().apply {
+                put("type", "Point")
+                put("coordinates", JSONArray().apply {
+                    put(c.lon)
+                    put(c.lat)
+                })
+            })
+            put("properties", JSONObject().apply {
+                put(PROP_UID, c.uid)
+                put(PROP_SIDC, sidc)
+                put(PROP_CALLSIGN, c.callsign ?: c.uid)
+                put(PROP_AFFILIATION, c.affiliation.code.toString())
+                put(PROP_TYPE, c.type)
+            })
+        }
+    }
+
+    private fun emptyFeatureCollectionJson(): String =
+        """{"type":"FeatureCollection","features":[]}"""
+}
+
+/** CoT types whose icons we register at install time so the first
+ *  sighting doesn't rasterise on the render frame. Chosen to cover
+ *  the common contact mix: friend/hostile/neutral/unknown ground +
+ *  the RID UAS multirotor + fixed-wing default. */
+private val PRE_WARM_COT_TYPES: List<String> = listOf(
+    "a-f-G-U",
+    "a-h-G-U",
+    "a-n-G-U",
+    "a-u-G-U",
+    "a-f-G-U-C-I",
+    "a-u-A",
+    "a-u-A-M-H-Q",
+    "a-u-A-M-F-Q",
+)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/FemaMarkerPaletteSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/FemaMarkerPaletteSheet.kt
@@ -1,0 +1,272 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.maplibre.android.geometry.LatLng
+import soy.engindearing.omnitak.mobile.data.FemaIconCatalog
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalSurface
+
+/** Result handed back when the operator picks a FEMA icon and taps Drop. */
+data class FemaMarkerSelection(
+    val icon: FemaIconCatalog.FemaIcon,
+    val name: String,
+    val remarks: String,
+)
+
+/**
+ * FEMA / IC marker palette. Modal bottom sheet — never compresses the
+ * full-screen map (per `feedback_omnitak_fullscreen_map`).
+ *
+ * 5 category sections, each a small grid of icon tiles. Picking a tile
+ * reveals the name + remarks fields and the Drop button. Drop hands
+ * the selection back; caller is responsible for ingesting the marker.
+ *
+ * Closes the UI half of #29; the catalog is in [FemaIconCatalog].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FemaMarkerPaletteSheet(
+    visible: Boolean,
+    latLng: LatLng?,
+    defaultName: String = "",
+    onConfirm: (FemaMarkerSelection) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (!visible) return
+    val state = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    var picked by remember { mutableStateOf<FemaIconCatalog.FemaIcon?>(null) }
+    var name by remember(picked) { mutableStateOf(picked?.label ?: defaultName) }
+    var remarks by remember { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = state,
+        containerColor = TacticalBackground,
+        scrimColor = Color.Black.copy(alpha = 0.35f),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+        ) {
+            Text(
+                "FEMA / IC Markers",
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Text(
+                "SAR / DISASTER RESPONSE",
+                color = Color(0xFFFFEB3B),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+            Text(
+                "Tap an icon, then Drop. Round-trips over CoT as a friendly ground installation with a FEMA usericon.",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.65f),
+                fontSize = 11.sp,
+                modifier = Modifier.padding(top = 2.dp, bottom = 8.dp),
+            )
+            latLng?.let {
+                Text(
+                    "%.5f, %.5f".format(it.latitude, it.longitude),
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            FemaIconCatalog.Category.entries.forEach { category ->
+                CategorySection(
+                    category = category,
+                    picked = picked,
+                    onPick = { picked = it },
+                )
+                Spacer(Modifier.height(12.dp))
+            }
+
+            picked?.let { selected ->
+                Spacer(Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Marker name") },
+                    singleLine = true,
+                    colors = paletteFieldColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = remarks,
+                    onValueChange = { remarks = it },
+                    label = { Text("Remarks (optional)") },
+                    singleLine = false,
+                    minLines = 2,
+                    colors = paletteFieldColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                Button(
+                    onClick = {
+                        onConfirm(
+                            FemaMarkerSelection(
+                                icon = selected,
+                                name = name.ifBlank { selected.label },
+                                remarks = remarks,
+                            )
+                        )
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = TacticalAccent,
+                        contentColor = TacticalBackground,
+                    ),
+                    modifier = Modifier.fillMaxWidth().height(56.dp),
+                ) {
+                    Text(
+                        "Drop ${selected.label}",
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun CategorySection(
+    category: FemaIconCatalog.Category,
+    picked: FemaIconCatalog.FemaIcon?,
+    onPick: (FemaIconCatalog.FemaIcon) -> Unit,
+) {
+    val icons = FemaIconCatalog.iconsIn(category)
+    if (icons.isEmpty()) return
+
+    Text(
+        category.displayName.uppercase(),
+        color = category.accent,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 6.dp),
+    )
+
+    // Single row of tiles per category — FlowRow would be ideal but
+    // sticking to a LazyVerticalGrid with fixed cell count keeps the
+    // tile sizing predictable across category counts.
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        userScrollEnabled = false,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height((((icons.size + 2) / 3) * 100).dp),
+    ) {
+        items(icons, key = { it.kind.name }) { icon ->
+            IconTile(icon = icon, isPicked = picked?.kind == icon.kind, onPick = onPick)
+        }
+    }
+}
+
+@Composable
+private fun IconTile(
+    icon: FemaIconCatalog.FemaIcon,
+    isPicked: Boolean,
+    onPick: (FemaIconCatalog.FemaIcon) -> Unit,
+) {
+    val border = if (isPicked) BorderStroke(2.dp, icon.category.accent) else null
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (isPicked) icon.category.accent.copy(alpha = 0.18f) else TacticalSurface)
+            .then(if (border != null) Modifier.border(border, RoundedCornerShape(10.dp)) else Modifier)
+            .clickable { onPick(icon) }
+            .padding(8.dp)
+            .fillMaxWidth()
+            .height(86.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .padding(top = 4.dp),
+        ) {
+            Icon(
+                imageVector = icon.image,
+                contentDescription = icon.label,
+                tint = icon.category.accent,
+                modifier = Modifier.size(32.dp),
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = icon.label,
+            color = MaterialTheme.colorScheme.onBackground,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+        )
+    }
+}
+
+@Composable
+private fun paletteFieldColors() = TextFieldDefaults.colors(
+    focusedTextColor = MaterialTheme.colorScheme.onBackground,
+    unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+    focusedContainerColor = TacticalSurface,
+    unfocusedContainerColor = TacticalSurface,
+    focusedIndicatorColor = TacticalAccent,
+    unfocusedIndicatorColor = TacticalAccent.copy(alpha = 0.4f),
+    focusedLabelColor = TacticalAccent,
+    unfocusedLabelColor = TacticalAccent.copy(alpha = 0.6f),
+    cursorColor = TacticalAccent,
+)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/LassoActionsSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/LassoActionsSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FileUpload
+import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.HighlightOff
@@ -56,6 +57,10 @@ fun LassoActionsSheet(
     onSendToContacts: () -> Unit,
     onBulkDelete: () -> Unit,
     onClear: () -> Unit,
+    // Non-null when at least one enrolled+enabled TLS server is
+    // configured; null hides the row so we don't dangle a button
+    // operators can't use. #30 slice 3.
+    onUploadToServer: (() -> Unit)? = null,
 ) {
     val sheet = rememberModalBottomSheetState()
     ModalBottomSheet(
@@ -97,6 +102,15 @@ fun LassoActionsSheet(
                 onClick = onAddToDataPackage,
             )
             HorizontalDivider(modifier = Modifier.padding(start = 76.dp), color = Color.White.copy(alpha = 0.08f))
+
+            onUploadToServer?.let { upload ->
+                ActionRow(
+                    icon = Icons.Filled.CloudUpload,
+                    title = "Upload to TAK Server…",
+                    onClick = upload,
+                )
+                HorizontalDivider(modifier = Modifier.padding(start = 76.dp), color = Color.White.copy(alpha = 0.08f))
+            }
 
             ActionRow(
                 icon = Icons.Filled.FileUpload,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/RadialMenu.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/RadialMenu.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
-import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
 import kotlin.math.cos
 import kotlin.math.roundToInt
 import kotlin.math.sin
@@ -103,7 +102,6 @@ fun RadialMenu(
                         scaleY = scale
                     }
                     .clip(CircleShape)
-                    .background(TacticalBackground)
                     .border(2.dp, ringTint, CircleShape)
                     .clickable(enabled = action.enabled) {
                         onSelect(action)
@@ -127,7 +125,7 @@ fun RadialMenu(
                 .offset { IntOffset(cx, cy) }
                 .size(48.dp)
                 .clip(CircleShape)
-                .background(TacticalBackground)
+                .border(2.dp, TacticalAccent, CircleShape)
                 .clickable(onClick = onDismiss),
             contentAlignment = Alignment.Center,
         ) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
@@ -79,6 +79,12 @@ fun ChatScreen(initialConversationId: String? = null) {
     val prefs by app.userPrefsStore.prefs.collectAsState(initial = UserPrefs())
     val chatScope = rememberCoroutineScope()
 
+    // Persist the canonical EUD UID on first chat-tab open even if PPLI
+    // hasn't run yet (no server connected, no GPS fix). This is the same
+    // UID PPLI uses — sending two different UIDs to a TAK server makes
+    // ATAK render the operator as two separate contacts (#9).
+    LaunchedEffect(Unit) { app.userPrefsStore.ensureSelfUid() }
+
     // Multi-server: resolve a serverId → display name so chat can badge which
     // server a message/thread came from. Badges only show when >1 server is
     // configured, otherwise they're noise.
@@ -118,7 +124,7 @@ fun ChatScreen(initialConversationId: String? = null) {
         ConversationDetailView(
             conversation = convo,
             messages = messages,
-            selfUid = selfUidFor(prefs),
+            selfUid = prefs.selfUid,
             selfCallsign = prefs.callsign,
             onBack = { selectedConversation = null },
             onSend = { text -> sendChat(app, convo, prefs, text, chatScope) },
@@ -460,14 +466,6 @@ private fun formatTime(iso: String): String = runCatching {
     LOCAL_TIME_FMT.format(Instant.parse(iso))
 }.getOrElse { iso }
 
-/**
- * Derive a stable self-UID from the operator's callsign + team so it
- * survives app restarts without needing a separate setting. Real
- * device UIDs come from the presence CoT once that lands in a later slice.
- */
-private fun selfUidFor(prefs: UserPrefs): String =
-    "OMNITAK-ANDROID-${prefs.callsign}-${prefs.team}"
-
 private fun sendChat(
     app: OmniTAKApp,
     convo: ChatConversation,
@@ -475,8 +473,26 @@ private fun sendChat(
     text: String,
     scope: kotlinx.coroutines.CoroutineScope,
 ) {
-    val senderUid = selfUidFor(prefs)
+    // Single EUD UID across PPLI + GeoChat + markers. Reuses the one
+    // SelfPositionBroadcaster mints on first PPLI; if we send chat
+    // before any PPLI has run (offline-typed message, fresh install)
+    // ensureSelfUid lazily generates + persists one so the wire never
+    // carries an ad-hoc identifier. Fixes #9 (two-contact ghost on
+    // receiving ATAK clients).
     val now = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
+    scope.launch {
+        sendChatInner(app, convo, prefs, text, now)
+    }
+}
+
+private suspend fun sendChatInner(
+    app: OmniTAKApp,
+    convo: ChatConversation,
+    prefs: UserPrefs,
+    text: String,
+    now: String,
+) {
+    val senderUid = app.userPrefsStore.ensureSelfUid()
 
     // GAP-122 / GAP-124 — Mesh conversations route through
     // MeshtasticManager (portnum 1) instead of the TAK server's CoT
@@ -502,14 +518,12 @@ private fun sendChat(
             isFromSelf = true,
         )
         app.chatStore.markOutgoing(outgoing)
-        scope.launch {
-            val sent = app.meshtastic.sendMeshChat(text, channelIndex, toNodeId)
-            app.chatStore.updateMessageStatus(
-                conversationId = convo.id,
-                messageId = msgId,
-                status = if (sent) ChatStatus.SENT else ChatStatus.FAILED,
-            )
-        }
+        val sent = app.meshtastic.sendMeshChat(text, channelIndex, toNodeId)
+        app.chatStore.updateMessageStatus(
+            conversationId = convo.id,
+            messageId = msgId,
+            status = if (sent) ChatStatus.SENT else ChatStatus.FAILED,
+        )
         return
     }
 
@@ -540,14 +554,12 @@ private fun sendChat(
     )
     app.chatStore.markOutgoing(message)
 
-    scope.launch {
-        // Route to the conversation's origin server for per-server DMs;
-        // group/broadcast rooms (serverId == null) fan out to all servers.
-        val sent = app.serverManager.sendCoT(generated.xml, serverId = convo.serverId)
-        app.chatStore.updateMessageStatus(
-            conversationId = convo.id,
-            messageId = generated.messageId,
-            status = if (sent) ChatStatus.SENT else ChatStatus.FAILED,
-        )
-    }
+    // Route to the conversation's origin server for per-server DMs;
+    // group/broadcast rooms (serverId == null) fan out to all servers.
+    val sent = app.serverManager.sendCoT(generated.xml, serverId = convo.serverId)
+    app.chatStore.updateMessageStatus(
+        conversationId = convo.id,
+        messageId = generated.messageId,
+        status = if (sent) ChatStatus.SENT else ChatStatus.FAILED,
+    )
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/EnrollServerScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/EnrollServerScreen.kt
@@ -162,6 +162,9 @@ fun EnrollServerScreen(onDone: () -> Unit) {
                                         password = null,
                                         certificateName = enrolled.certificateName,
                                         certificatePassword = enrolled.certificatePassword,
+                                        // Pin against the enrollment CA on every future
+                                        // connect — replaces dev-mode trust-all (#38).
+                                        caCertificateName = enrolled.caCertificateName,
                                     ),
                                 )
                                 onDone()

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -840,6 +840,45 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                         }
                     }
                 },
+                onUploadToServer = run {
+                    val anyEnabledTls = app.serverManager.servers.collectAsState().value
+                        .any { it.enabled && it.useTLS && it.certificateName != null }
+                    if (!anyEnabledTls || selectedEvents.isEmpty()) {
+                        null
+                    } else {
+                        {
+                            lassoActionsOpen = false
+                            val ctx = appContext
+                            val ts = System.currentTimeMillis()
+                            val pkgName = "lasso-${selectedEvents.size}-$ts"
+                            scope.launch {
+                                val file = withContext(Dispatchers.IO) {
+                                    soy.engindearing.omnitak.mobile.domain.LassoExporters
+                                        .writeMissionPackage(
+                                            context = ctx,
+                                            name = pkgName,
+                                            events = selectedEvents,
+                                        )
+                                }
+                                val creator = app.userPrefsStore.ensureSelfUid()
+                                val outcome = app.missionSyncManager.uploadDataPackage(
+                                    zipBytes = file.readBytes(),
+                                    filename = file.name,
+                                    creatorUid = creator,
+                                )
+                                val msg = when (outcome) {
+                                    is soy.engindearing.omnitak.mobile.domain.UploadOutcome.Hash ->
+                                        "Uploaded → ${outcome.serverName} · hash ${outcome.hash.take(10)}…"
+                                    soy.engindearing.omnitak.mobile.domain.UploadOutcome.NoServer ->
+                                        "No enrolled TAK server to upload to"
+                                    is soy.engindearing.omnitak.mobile.domain.UploadOutcome.Failed ->
+                                        "Upload failed: ${outcome.reason}"
+                                }
+                                toast(msg)
+                            }
+                        }
+                    }
+                },
                 onExportKML = {
                     lassoActionsOpen = false
                     if (selectedEvents.isEmpty()) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.AddLocation
 import androidx.compose.material.icons.filled.FlightTakeoff
 import androidx.compose.material.icons.filled.GridOn
+import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Explore
@@ -134,6 +135,12 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     var radialAnchor by remember { mutableStateOf<Offset?>(null) }
     var radialLatLng by remember { mutableStateOf<LatLng?>(null) }
     var markerSheetLatLng by remember { mutableStateOf<LatLng?>(null) }
+    // #29 — FEMA / IC marker palette. Tap a FEMA action → camera-center is
+    // captured here → palette sheet picks an icon → drop emits the CoT
+    // event with the FEMA cotType + iconsetpath. Independent of the
+    // generic markerSheetLatLng pipeline so the affiliation-based UI
+    // doesn't have to know about FEMA-specific fields.
+    var femaPaletteLatLng by remember { mutableStateOf<LatLng?>(null) }
     var editingMarker by remember { mutableStateOf<CoTEvent?>(null) }
     var recenterTick by remember { mutableStateOf(0) }
     var zoomInTick by remember { mutableStateOf(0) }
@@ -1015,6 +1022,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 ToolEntry("adsb", Icons.Filled.Flight, if (adsbActive) "ADSB on" else "ADSB"),
                 ToolEntry("chat", Icons.Filled.Chat, "Chat"),
                 ToolEntry("missionsync", Icons.Filled.Sync, "Mission Sync"),
+                ToolEntry("fema", Icons.Filled.LocalFireDepartment, "FEMA / IC"),
                 ToolEntry("teams", Icons.Filled.Groups, "Teams"),
                 ToolEntry(
                     "nav",
@@ -1050,6 +1058,12 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                     }
                     "chat" -> onOpenTab("chat")
                     "missionsync" -> onOpenTab("missionsync")
+                    "fema" -> {
+                        val lat = app.mapCameraStore.lastTargetLat
+                        val lon = app.mapCameraStore.lastTargetLon
+                        femaPaletteLatLng = if (lat != null && lon != null) LatLng(lat, lon)
+                        else LatLng(47.6588, -117.4260)
+                    }
                     "teams" -> teamsPanelOpen = true
                     "nav" -> {
                         if (!locationGranted) {
@@ -1295,6 +1309,52 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 markerSheetLatLng = null
                 editingMarker = null
             },
+        )
+
+        soy.engindearing.omnitak.mobile.ui.components.FemaMarkerPaletteSheet(
+            visible = femaPaletteLatLng != null,
+            latLng = femaPaletteLatLng,
+            onConfirm = { picked ->
+                val ll = femaPaletteLatLng
+                if (ll != null) {
+                    val uid = "local-fema-${System.currentTimeMillis()}"
+                    app.contactStore.ingest(
+                        soy.engindearing.omnitak.mobile.data.CoTEvent(
+                            uid = uid,
+                            type = picked.icon.cotType,
+                            lat = ll.latitude,
+                            lon = ll.longitude,
+                            hae = 0.0,
+                            callsign = picked.name,
+                            remarks = picked.remarks,
+                            iconsetPath = picked.icon.iconsetPath,
+                        )
+                    )
+                    // Broadcast to every enabled server so peers with the
+                    // FEMA catalog see the right glyph; receivers without
+                    // it fall back to the friendly-installation render
+                    // ATAK/iTAK does for `a-f-G-I-*`.
+                    scope.launch {
+                        val xml = soy.engindearing.omnitak.mobile.domain.CotBuilders
+                            .rebuildEvent(
+                                soy.engindearing.omnitak.mobile.data.CoTEvent(
+                                    uid = uid,
+                                    type = picked.icon.cotType,
+                                    lat = ll.latitude,
+                                    lon = ll.longitude,
+                                    callsign = picked.name,
+                                    remarks = picked.remarks,
+                                    iconsetPath = picked.icon.iconsetPath,
+                                ),
+                                destUids = emptyList(),
+                            )
+                        runCatching { app.serverManager.sendCoT(xml) }
+                    }
+                    toast("Dropped ${picked.icon.label} “${picked.name}”")
+                }
+                femaPaletteLatLng = null
+            },
+            onDismiss = { femaPaletteLatLng = null },
         )
 
         if (drawingKind != null) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshDeviceSettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshDeviceSettingsScreen.kt
@@ -84,7 +84,9 @@ fun MeshDeviceSettingsScreen(onDone: () -> Unit) {
     val store = app.meshDeviceConfigStore
     val mesh = app.meshtastic
     val saved by store.config.collectAsState(initial = MeshDeviceConfig())
-    val connection by mesh.state.collectAsState()
+    // Transport-aware — TCP or BLE, whichever is the active link.
+    // Was `mesh.state` (TCP-only) which left BLE radios stranded (#36).
+    val connection by mesh.activeConnectionState.collectAsState()
     val scope = rememberCoroutineScope()
 
     // Local draft buffer — text fields edit this, "Save draft" commits

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -358,26 +358,27 @@ private fun settingsFieldColors() = TextFieldDefaults.colors(
 )
 
 /**
- * Standard ATAK CoT team colors. The exact UPPERCASE strings are what
- * ATAK clients expect in `<__group name="..." role="..."/>` — anything
- * else gets rendered as the default cyan team. Hex values are tuned for
- * readability against the OmniTAK dark surface.
+ * Standard ATAK CoT team colors. Title Case matches ATAK / OpenTakServer
+ * (`<__group name="Cyan" role="Team Member"/>`) — OTS's DB keys teams by
+ * the canonical capitalized name and rejects all-caps variants in its web
+ * UI. Hex values are tuned for readability against the OmniTAK dark
+ * surface.
  */
 private val ATAK_TEAM_COLORS: List<Pair<String, Color>> = listOf(
-    "WHITE" to Color(0xFFFFFFFF),
-    "YELLOW" to Color(0xFFFFEB3B),
-    "ORANGE" to Color(0xFFFF9800),
-    "MAGENTA" to Color(0xFFE91E63),
-    "RED" to Color(0xFFF44336),
-    "MAROON" to Color(0xFF8B0000),
-    "PURPLE" to Color(0xFF9C27B0),
-    "DARK BLUE" to Color(0xFF1A237E),
-    "BLUE" to Color(0xFF2196F3),
-    "CYAN" to Color(0xFF00BCD4),
-    "TEAL" to Color(0xFF009688),
-    "GREEN" to Color(0xFF4CAF50),
-    "DARK GREEN" to Color(0xFF1B5E20),
-    "BROWN" to Color(0xFF6D4C41),
+    "White" to Color(0xFFFFFFFF),
+    "Yellow" to Color(0xFFFFEB3B),
+    "Orange" to Color(0xFFFF9800),
+    "Magenta" to Color(0xFFE91E63),
+    "Red" to Color(0xFFF44336),
+    "Maroon" to Color(0xFF8B0000),
+    "Purple" to Color(0xFF9C27B0),
+    "Dark Blue" to Color(0xFF1A237E),
+    "Blue" to Color(0xFF2196F3),
+    "Cyan" to Color(0xFF00BCD4),
+    "Teal" to Color(0xFF009688),
+    "Green" to Color(0xFF4CAF50),
+    "Dark Green" to Color(0xFF1B5E20),
+    "Brown" to Color(0xFF6D4C41),
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -385,7 +386,7 @@ private val ATAK_TEAM_COLORS: List<Pair<String, Color>> = listOf(
 private fun TeamColorDropdown(value: String, onSelect: (String) -> Unit) {
     var expanded by remember { mutableStateOf(false) }
     val current = ATAK_TEAM_COLORS.firstOrNull { it.first.equals(value, ignoreCase = true) }
-        ?: ("CYAN" to Color(0xFF00BCD4))
+        ?: ("Cyan" to Color(0xFF00BCD4))
 
     ExposedDropdownMenuBox(
         expanded = expanded,

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/CaTrustTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/CaTrustTest.kt
@@ -1,0 +1,161 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.BasicConstraints
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.cert.CertPathValidatorException
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import java.util.Date
+
+/**
+ * #38 / GAP-106 — locks the CA-pinning contract used by [TAKConnection]
+ * to replace the dev-mode trust-all manager.
+ *
+ * Tests use BouncyCastle (already a runtime dep) to mint a tiny CA + a
+ * server cert signed by it + an unrelated CA, so the trust manager's
+ * accept/reject path is exercised against real X.509 material rather
+ * than mocks.
+ */
+class CaTrustTest {
+
+    @Test fun encode_decode_roundtrip_preserves_single_cert() {
+        val ca = makeSelfSignedCa("CN=Test CA 1")
+        val pem = CaTrust.encodePemChain(listOf(ca.cert))
+        val pemStr = String(pem)
+        assertTrue("must contain BEGIN", pemStr.contains("-----BEGIN CERTIFICATE-----"))
+        assertTrue("must contain END", pemStr.contains("-----END CERTIFICATE-----"))
+
+        val parsed = CaTrust.decodePemChain(pem)
+        assertEquals(1, parsed.size)
+        assertArrayEquals(ca.cert.encoded, parsed[0].encoded)
+    }
+
+    @Test fun encode_decode_roundtrip_preserves_chain_order() {
+        val ca0 = makeSelfSignedCa("CN=Root 0")
+        val ca1 = makeSelfSignedCa("CN=Root 1")
+        val pem = CaTrust.encodePemChain(listOf(ca0.cert, ca1.cert))
+
+        val parsed = CaTrust.decodePemChain(pem)
+        assertEquals(2, parsed.size)
+        assertArrayEquals(ca0.cert.encoded, parsed[0].encoded)
+        assertArrayEquals(ca1.cert.encoded, parsed[1].encoded)
+    }
+
+    @Test fun decode_empty_input_returns_empty_list() {
+        assertEquals(0, CaTrust.decodePemChain(ByteArray(0)).size)
+    }
+
+    @Test fun decode_garbage_returns_empty_list() {
+        assertEquals(0, CaTrust.decodePemChain("not a pem file".toByteArray()).size)
+    }
+
+    @Test fun trustManagerFor_accepts_cert_signed_by_pinned_ca() {
+        val ca = makeSelfSignedCa("CN=Pinned CA")
+        val leaf = makeLeafCert("CN=tak.test.local", issuedBy = ca)
+
+        val tm = CaTrust.trustManagerFor(listOf(ca.cert))
+        // checkServerTrusted throws on rejection; success = no throw.
+        tm.checkServerTrusted(arrayOf(leaf, ca.cert), "RSA")
+    }
+
+    @Test fun trustManagerFor_rejects_cert_signed_by_unrelated_ca() {
+        val pinnedCa = makeSelfSignedCa("CN=Pinned CA")
+        val attackerCa = makeSelfSignedCa("CN=Attacker CA")
+        val attackerLeaf = makeLeafCert("CN=tak.test.local", issuedBy = attackerCa)
+
+        val tm = CaTrust.trustManagerFor(listOf(pinnedCa.cert))
+        try {
+            tm.checkServerTrusted(arrayOf(attackerLeaf, attackerCa.cert), "RSA")
+            fail("Trust manager must reject cert signed by an unpinned CA")
+        } catch (expected: CertificateException) {
+            // Path validation will raise CertPathValidatorException wrapped in
+            // CertificateException — both shapes are acceptable receipts.
+            val msg = generateSequence(expected as Throwable, Throwable::cause)
+                .joinToString("; ") { "${it.javaClass.simpleName}: ${it.message}" }
+            assertTrue(
+                "Rejection should mention trust anchors / path / unable to find / signature, got: $msg",
+                msg.contains("anchor", ignoreCase = true) ||
+                    msg.contains("path", ignoreCase = true) ||
+                    msg.contains("unable to find", ignoreCase = true) ||
+                    msg.contains("signature", ignoreCase = true),
+            )
+        }
+    }
+
+    @Test fun systemTrustManager_is_nonnull_and_has_accepted_issuers() {
+        val tm = CaTrust.systemTrustManager()
+        assertNotNull(tm)
+        // The JVM/Android system trust store always has at least the
+        // baseline public CAs; an empty list would indicate the factory
+        // didn't initialize properly.
+        assertTrue(
+            "system trust manager should have at least one accepted issuer",
+            tm.acceptedIssuers.isNotEmpty(),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun trustManagerFor_empty_list_throws() {
+        CaTrust.trustManagerFor(emptyList())
+    }
+
+    // ------------------------------------------------------------------
+    // helpers — tiny self-signed CAs + leaves via BouncyCastle
+    // ------------------------------------------------------------------
+
+    private data class IssuedCert(val cert: X509Certificate, val keyPair: KeyPair)
+
+    private fun makeSelfSignedCa(dn: String): IssuedCert {
+        val kp = newKeyPair()
+        val now = Date()
+        val later = Date(now.time + 365L * 24 * 60 * 60 * 1000)
+        val builder: X509v3CertificateBuilder = JcaX509v3CertificateBuilder(
+            X500Name(dn),
+            BigInteger.valueOf(System.nanoTime()),
+            now, later,
+            X500Name(dn),
+            kp.public,
+        ).addExtension(Extension.basicConstraints, true, BasicConstraints(true))
+        val signer = JcaContentSignerBuilder("SHA256WithRSA").build(kp.private)
+        val holder = builder.build(signer)
+        val cert = JcaX509CertificateConverter().getCertificate(holder)
+        return IssuedCert(cert, kp)
+    }
+
+    private fun makeLeafCert(subjectDn: String, issuedBy: IssuedCert): X509Certificate {
+        val kp = newKeyPair()
+        val now = Date()
+        val later = Date(now.time + 90L * 24 * 60 * 60 * 1000)
+        val builder = JcaX509v3CertificateBuilder(
+            issuedBy.cert,
+            BigInteger.valueOf(System.nanoTime() + 1),
+            now, later,
+            X500Name(subjectDn),
+            kp.public,
+        )
+        val signer = JcaContentSignerBuilder("SHA256WithRSA").build(issuedBy.keyPair.private)
+        val holder = builder.build(signer)
+        return JcaX509CertificateConverter().getCertificate(holder)
+    }
+
+    private fun newKeyPair(): KeyPair {
+        val gen = KeyPairGenerator.getInstance("RSA")
+        gen.initialize(2048)
+        return gen.generateKeyPair()
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/FemaIconCatalogTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/FemaIconCatalogTest.kt
@@ -1,0 +1,97 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #29 / iOS PR for #13 — locks the FEMA / IC catalog contract so the
+ * Android emission matches the iOS one byte-for-byte. Cross-platform
+ * round-trip of a SAR marker depends on:
+ *   1. Same `Kind.raw` strings (used in iconsetpath segment)
+ *   2. Same `cotType` per kind
+ *   3. Same `iconsetPath` format (`COT_MAPPING_FEMA/<category>/<kind>`)
+ */
+class FemaIconCatalogTest {
+
+    @Test fun catalog_has_exactly_twelve_entries_matching_ios() {
+        assertEquals(12, FemaIconCatalog.all.size)
+    }
+
+    @Test fun every_kind_is_indexed() {
+        FemaIconCatalog.Kind.entries.forEach { kind ->
+            assertNotNull(
+                "missing FemaIcon for $kind",
+                FemaIconCatalog.iconFor(kind),
+            )
+        }
+    }
+
+    @Test fun cot_types_are_unique() {
+        val types = FemaIconCatalog.all.map { it.cotType }
+        assertEquals(
+            "duplicate cotType in catalog: ${types.groupingBy { it }.eachCount().filter { it.value > 1 }}",
+            types.size,
+            types.toSet().size,
+        )
+    }
+
+    @Test fun iconsetpath_format_is_cot_mapping_fema() {
+        FemaIconCatalog.all.forEach { icon ->
+            assertTrue(
+                "iconsetPath ${icon.iconsetPath} must start with COT_MAPPING_FEMA/",
+                icon.iconsetPath.startsWith("COT_MAPPING_FEMA/"),
+            )
+            // category and kind segments must round-trip back through
+            // iconByIconsetPath
+            assertEquals(
+                "iconsetPath ${icon.iconsetPath} must round-trip via iconByIconsetPath",
+                icon.kind,
+                FemaIconCatalog.iconByIconsetPath(icon.iconsetPath)?.kind,
+            )
+        }
+    }
+
+    @Test fun ios_parity_specific_mappings() {
+        // Spot-check the mappings against the iOS catalog so a renamed
+        // Kind on either platform breaks this test loudly.
+        val cp = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.COMMAND_POST)!!
+        assertEquals("a-f-G-I-U-T", cp.cotType)
+        assertEquals("COT_MAPPING_FEMA/incidentCommand/command_post", cp.iconsetPath)
+
+        val lz = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.HELICOPTER_LZ)!!
+        assertEquals("a-f-G-I-X-H", lz.cotType)
+        assertEquals("COT_MAPPING_FEMA/aviation/helicopter_lz", lz.iconsetPath)
+
+        val ft = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.FIRE_TRUCK)!!
+        assertEquals("a-f-G-E-V-F-R", ft.cotType)
+
+        val ch = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.COMMUNICATIONS_HUB)!!
+        assertEquals("a-f-G-I-U-C", ch.cotType)
+        assertEquals("COT_MAPPING_FEMA/support/communications_hub", ch.iconsetPath)
+    }
+
+    @Test fun iconsIn_filters_to_category() {
+        val medical = FemaIconCatalog.iconsIn(FemaIconCatalog.Category.MEDICAL)
+        assertEquals(2, medical.size)
+        assertTrue(medical.all { it.category == FemaIconCatalog.Category.MEDICAL })
+
+        val command = FemaIconCatalog.iconsIn(FemaIconCatalog.Category.INCIDENT_COMMAND)
+        assertEquals(2, command.size)
+    }
+
+    @Test fun iconByIconsetPath_rejects_non_fema_paths() {
+        assertNull(FemaIconCatalog.iconByIconsetPath("COT_MAPPING_2525B/a-f/a-f-G-U-C"))
+        assertNull(FemaIconCatalog.iconByIconsetPath(""))
+        assertNull(FemaIconCatalog.iconByIconsetPath("COT_MAPPING_FEMA/medical/unknown_kind"))
+    }
+
+    @Test fun iconByRaw_matches_kind_raw_values() {
+        FemaIconCatalog.all.forEach { icon ->
+            assertEquals(icon.kind, FemaIconCatalog.iconByRaw(icon.kind.raw)?.kind)
+        }
+        assertNull(FemaIconCatalog.iconByRaw("definitely_not_a_kind"))
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/TakRestApiClientWriteTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/TakRestApiClientWriteTest.kt
@@ -1,0 +1,169 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #30 slice 1 — pure-format tests for the Mission Authoring write
+ * endpoints. The wire-level send is integration-tested against the
+ * local tak57 docker; this slice locks in the encoding contract.
+ */
+class TakRestApiClientWriteTest {
+
+    // ── extractHash — three known Marti response shapes ─────────────
+
+    @Test fun extractHash_from_canonical_url() {
+        val hash = TakRestApiClient.extractHash(
+            "https://server.example.com:8443/Marti/sync/content?hash=ABC123DEF456"
+        )
+        assertEquals("ABC123DEF456", hash)
+    }
+
+    @Test fun extractHash_from_url_with_extra_query_params() {
+        val hash = TakRestApiClient.extractHash(
+            "https://server/Marti/sync/content?foo=bar&hash=DEADBEEF&baz=qux"
+        )
+        assertEquals("DEADBEEF", hash)
+    }
+
+    @Test fun extractHash_from_token_form_older_marti() {
+        // Older Marti builds occasionally return the bare `hash=...`
+        // token without the full URL prefix. iOS supports this form
+        // case-insensitively in the same fallback branch.
+        val hash = TakRestApiClient.extractHash("hash=A1B2C3")
+        assertEquals("A1B2C3", hash)
+    }
+
+    @Test fun extractHash_handles_whitespace() {
+        val hash = TakRestApiClient.extractHash(
+            "   https://server/Marti/sync/content?hash=WHITESPACE   \n"
+        )
+        assertEquals("WHITESPACE", hash)
+    }
+
+    @Test fun extractHash_returns_null_on_garbage() {
+        assertNull(TakRestApiClient.extractHash(""))
+        assertNull(TakRestApiClient.extractHash("server error"))
+        assertNull(TakRestApiClient.extractHash("https://server/Marti/sync/content"))
+    }
+
+    // ── urlSegment — mission names with awkward characters ──────────
+
+    @Test fun urlSegment_encodes_spaces_as_percent_twenty() {
+        // Spaces must be %20 (not '+') inside path segments — '+' is
+        // legal in query strings only, and Marti's route parser doesn't
+        // decode it back to space in the path.
+        assertEquals("SAR%20Op%20Alpha", TakRestApiClient.urlSegment("SAR Op Alpha"))
+    }
+
+    @Test fun urlSegment_encodes_reserved_characters() {
+        assertEquals("op%2Falpha", TakRestApiClient.urlSegment("op/alpha"))
+        assertEquals("op%26b", TakRestApiClient.urlSegment("op&b"))
+        assertEquals("op%3Falpha", TakRestApiClient.urlSegment("op?alpha"))
+    }
+
+    @Test fun urlSegment_unicode_round_trip() {
+        assertEquals("%E6%97%A5%E6%9C%AC", TakRestApiClient.urlSegment("日本"))
+    }
+
+    // ── encodeQuery — list-of-pairs to `?k=v&k=v` ───────────────────
+
+    @Test fun encodeQuery_empty_returns_empty_string() {
+        assertEquals("", TakRestApiClient.encodeQuery(emptyList()))
+    }
+
+    @Test fun encodeQuery_preserves_pair_order_and_encodes_values() {
+        val q = TakRestApiClient.encodeQuery(
+            listOf("creatorUid" to "ANDROID-1", "tool" to "public", "description" to "hello world")
+        )
+        assertEquals("?creatorUid=ANDROID-1&tool=public&description=hello+world", q)
+    }
+
+    @Test fun encodeQuery_repeats_keys_for_group_lists() {
+        // Marti accepts repeated `group=` params for multi-group missions.
+        val q = TakRestApiClient.encodeQuery(
+            listOf("group" to "TEAM-A", "group" to "TEAM-B", "group" to "TEAM-C")
+        )
+        assertEquals("?group=TEAM-A&group=TEAM-B&group=TEAM-C", q)
+    }
+
+    // ── jsonEscape — protect against quote/control injection ────────
+
+    @Test fun jsonEscape_passes_through_safe_strings() {
+        assertEquals("ABC123", TakRestApiClient.jsonEscape("ABC123"))
+    }
+
+    @Test fun jsonEscape_escapes_quotes_and_backslash() {
+        assertEquals("""foo\"bar""", TakRestApiClient.jsonEscape("""foo"bar"""))
+        assertEquals("""foo\\bar""", TakRestApiClient.jsonEscape("""foo\bar"""))
+    }
+
+    @Test fun jsonEscape_escapes_control_characters() {
+        assertEquals("a\\nb", TakRestApiClient.jsonEscape("a\nb"))
+        assertEquals("a\\u0001b", TakRestApiClient.jsonEscape("ab"))
+    }
+
+    // ── buildMultipartPackage — wire shape Marti expects ────────────
+
+    @Test fun buildMultipartPackage_contains_required_headers_and_payload() {
+        val zip = byteArrayOf(0x50, 0x4B, 0x03, 0x04, 0x42, 0x42, 0x42)
+        val body = TakRestApiClient.buildMultipartPackage(
+            boundary = "test-boundary",
+            filename = "search-area.zip",
+            zipBytes = zip,
+        )
+        val text = String(body, Charsets.UTF_8)
+        assertTrue("boundary delimiter", text.contains("--test-boundary\r\n"))
+        assertTrue(
+            "Content-Disposition with assetfile name + filename",
+            text.contains("""Content-Disposition: form-data; name="assetfile"; filename="search-area.zip""""),
+        )
+        assertTrue(
+            "zip content-type header",
+            text.contains("Content-Type: application/x-zip-compressed\r\n"),
+        )
+        assertTrue("body ends with boundary terminator", text.endsWith("--test-boundary--\r\n"))
+        // Sanity: the zip magic bytes are in the body.
+        assertTrue(
+            "zip payload present",
+            body.toList().windowed(zip.size).any { it.toByteArray().contentEquals(zip) },
+        )
+    }
+
+    @Test fun buildMultipartPackage_strips_quotes_from_filename() {
+        // Defensive — operator-supplied filenames shouldn't break the
+        // Content-Disposition header.
+        val body = TakRestApiClient.buildMultipartPackage(
+            boundary = "b",
+            filename = """bad"name.zip""",
+            zipBytes = byteArrayOf(),
+        )
+        val text = String(body, Charsets.UTF_8)
+        assertFalse(
+            "filename should have its embedded quote stripped",
+            text.contains("""filename="bad"name.zip""""),
+        )
+        assertTrue(
+            "filename written sans embedded quote",
+            text.contains("""filename="badname.zip""""),
+        )
+    }
+
+    // ── MissionBbox — query-string format Marti expects ─────────────
+
+    @Test fun missionBbox_query_format_no_spaces() {
+        val bbox = MissionBbox(
+            minLat = 47.6,
+            minLon = -117.5,
+            maxLat = 47.7,
+            maxLon = -117.4,
+        )
+        assertEquals("47.6,-117.5,47.7,-117.4", bbox.queryValue)
+    }
+
+    private fun List<Byte>.toByteArray(): ByteArray = ByteArray(size) { this[it] }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconServiceTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconServiceTest.kt
@@ -199,13 +199,25 @@ class MilStdIconServiceTest {
     // ---- Drone story regression -----------------------------------------
 
     @Test
-    fun `unknown UAS multirotor falls back to unknown air via truncation`() {
-        // a-u-A-M-H-Q (Remote ID drone classification) isn't in the
-        // hardcoded floor verbatim, but a-u-A is — should truncate to
-        // it, not the generic unknown-ground default. After Phase C's
-        // catalogue loads at runtime, this same input resolves to the
-        // catalogue entry SUAPMHQ----- directly.
-        assertEquals("SUA---------", MilStdIconService.getSidc("a-u-A-M-H-Q"))
+    fun `unknown UAS multirotor resolves to the multirotor SIDC in the floor`() {
+        // a-u-A-M-H-Q is the Remote ID multirotor classification. It now
+        // lives in the hardcoded floor so RID tracks render with the
+        // correct multirotor glyph without depending on Phase C's JSON
+        // catalogue loading first.
+        assertEquals("SUAPMHQ----", MilStdIconService.getSidc("a-u-A-M-H-Q"))
+    }
+
+    @Test
+    fun `unknown UAS fixed wing resolves to the fixed-wing SIDC in the floor`() {
+        assertEquals("SUAPMFQ----", MilStdIconService.getSidc("a-u-A-M-F-Q"))
+    }
+
+    @Test
+    fun `unknown UAS without a multirotor or fixed-wing suffix truncates to unknown air`() {
+        // A future RID classification we don't have an entry for yet
+        // should still resolve to something — truncation walks back to
+        // a-u-A and the generic unknown-air SIDC.
+        assertEquals("SUA---------", MilStdIconService.getSidc("a-u-A-M-X-Q"))
     }
 
     // ---- Phase C — runtime catalogue replacement ------------------------

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuildersUserIconTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuildersUserIconTest.kt
@@ -1,0 +1,64 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+
+/**
+ * #29 — CotBuilders.rebuildEvent must emit `<usericon iconsetpath="…">`
+ * when the source CoTEvent carries one. Without that, receiving ATAK
+ * has no way to render the FEMA glyph and falls all the way back to
+ * the generic friendly-installation default.
+ */
+class CotBuildersUserIconTest {
+
+    @Test fun rebuildEvent_emits_usericon_when_iconsetPath_present() {
+        val event = CoTEvent(
+            uid = "test-fema-cp",
+            type = "a-f-G-I-U-T",
+            lat = 47.6588,
+            lon = -117.4260,
+            callsign = "CP-1",
+            iconsetPath = "COT_MAPPING_FEMA/incidentCommand/command_post",
+        )
+        val xml = CotBuilders.rebuildEvent(event, destUids = emptyList())
+        assertTrue(
+            "missing usericon tag in:\n$xml",
+            xml.contains("""<usericon iconsetpath="COT_MAPPING_FEMA/incidentCommand/command_post"/>"""),
+        )
+    }
+
+    @Test fun rebuildEvent_omits_usericon_when_iconsetPath_null() {
+        val event = CoTEvent(
+            uid = "test-plain",
+            type = "a-f-G-U-C",
+            lat = 47.6588,
+            lon = -117.4260,
+            callsign = "PLAIN",
+        )
+        val xml = CotBuilders.rebuildEvent(event, destUids = emptyList())
+        assertFalse(
+            "unexpected usericon tag in plain-marker XML:\n$xml",
+            xml.contains("<usericon"),
+        )
+    }
+
+    @Test fun rebuildEvent_xml_escapes_iconsetPath() {
+        // Defensive — iconsetPath values should never contain quotes in
+        // practice, but the emitter has to escape just in case so a
+        // pathological payload can't break the XML doc.
+        val event = CoTEvent(
+            uid = "u",
+            type = "a-f-G-I-U-T",
+            lat = 0.0,
+            lon = 0.0,
+            iconsetPath = """foo"bar""",
+        )
+        val xml = CotBuilders.rebuildEvent(event, destUids = emptyList())
+        assertTrue(
+            "iconsetPath quote not escaped in:\n$xml",
+            xml.contains("""foo&quot;bar"""),
+        )
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManagerActiveStateTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManagerActiveStateTest.kt
@@ -1,0 +1,19 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #36 — Device Settings observes `activeConnectionState` instead of
+ * `state` (TCP-only). With no transport selected yet — the cold-start
+ * shape — the flow must report Disconnected. Without that guarantee the
+ * screen would default to "Connected" and surface a useless push
+ * button, or trip a null cast in the connection-label `when`.
+ */
+class MeshtasticManagerActiveStateTest {
+
+    @Test fun initial_value_is_disconnected_when_no_transport_active() {
+        val mgr = MeshtasticManager()
+        assertEquals(ConnectionState.Disconnected, mgr.activeConnectionState.value)
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJsonTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJsonTest.kt
@@ -1,0 +1,135 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.CoTAffiliation
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+
+class CesiumEntityJsonTest {
+
+    private fun parse(json: String): JSONArray = JSONArray(json)
+
+    @Test
+    fun `self entity has kind self and no sidc`() {
+        val json = parse(buildCesiumEntitiesJson(
+            contacts = emptyList(),
+            selfLat = 47.65,
+            selfLon = -117.42,
+            selfCallsign = "OMNI-1",
+        ))
+        assertEquals(1, json.length())
+        val self = json.getJSONObject(0)
+        assertEquals("__self__", self.getString("uid"))
+        assertEquals("self", self.getString("kind"))
+        assertFalse("self should NOT carry a sidc (uses affiliation frame)", self.has("sidc"))
+    }
+
+    @Test
+    fun `RID multirotor contact gets SUAPMHQ multirotor SIDC`() {
+        // RemoteIdToCoTConverter emits a-u-A-M-H-Q for multirotor drones.
+        // The catalogue maps it to SUAPMHQ---- which milsymbol can render
+        // as the proper MIL-STD-2525 multirotor UAS glyph in Cesium.
+        val drone = CoTEvent(
+            uid = "RID-MAVIC3-ABC",
+            type = "a-u-A-M-H-Q",
+            lat = 47.65,
+            lon = -117.42,
+            hae = 120.0,
+            callsign = "DRONE-MAVIC3-ABC",
+        )
+        val json = parse(buildCesiumEntitiesJson(
+            contacts = listOf(drone),
+            selfLat = null,
+            selfLon = null,
+            selfCallsign = "OMNI-1",
+        ))
+        assertEquals(1, json.length())
+        val e = json.getJSONObject(0)
+        assertEquals("RID-MAVIC3-ABC", e.getString("uid"))
+        assertEquals("contact", e.getString("kind"))
+        assertEquals("u", e.getString("affiliation"))
+        assertEquals("SUAPMHQ----", e.getString("sidc"))
+        assertEquals("DRONE-MAVIC3-ABC", e.getString("callsign"))
+    }
+
+    @Test
+    fun `RID fixed-wing contact gets SUAPMFQ fixed-wing SIDC`() {
+        val drone = CoTEvent(
+            uid = "RID-FW-1",
+            type = "a-u-A-M-F-Q",
+            lat = 47.65,
+            lon = -117.42,
+            hae = 500.0,
+            callsign = "DRONE-FW-1",
+        )
+        val json = parse(buildCesiumEntitiesJson(
+            contacts = listOf(drone),
+            selfLat = null, selfLon = null, selfCallsign = "OMNI-1",
+        ))
+        val e = json.getJSONObject(0)
+        assertEquals("SUAPMFQ----", e.getString("sidc"))
+    }
+
+    @Test
+    fun `friendly infantry contact gets SFGPUCI SIDC`() {
+        val troop = CoTEvent(
+            uid = "TROOP-1",
+            type = "a-f-G-U-C-I",
+            lat = 47.65,
+            lon = -117.42,
+            callsign = "ALPHA-1",
+        )
+        val json = parse(buildCesiumEntitiesJson(
+            contacts = listOf(troop),
+            selfLat = null, selfLon = null, selfCallsign = "OMNI-1",
+        ))
+        val e = json.getJSONObject(0)
+        assertEquals("f", e.getString("affiliation"))
+        assertEquals("SFGPUCI----", e.getString("sidc"))
+    }
+
+    @Test
+    fun `contacts with NaN lat lon are skipped`() {
+        val bad = CoTEvent(
+            uid = "BAD",
+            type = "a-u-A",
+            lat = Double.NaN,
+            lon = Double.NaN,
+            callsign = "BAD",
+        )
+        val good = CoTEvent(
+            uid = "GOOD",
+            type = "a-u-A",
+            lat = 47.65,
+            lon = -117.42,
+            callsign = "GOOD",
+        )
+        val json = parse(buildCesiumEntitiesJson(
+            contacts = listOf(bad, good),
+            selfLat = null, selfLon = null, selfCallsign = "OMNI-1",
+        ))
+        assertEquals(1, json.length())
+        assertEquals("GOOD", json.getJSONObject(0).getString("uid"))
+    }
+
+    @Test
+    fun `hae of zero is omitted (legacy CoT renders on-ground)`() {
+        val ground = CoTEvent(
+            uid = "G",
+            type = "a-f-G-U",
+            lat = 47.65,
+            lon = -117.42,
+            hae = 0.0,
+            callsign = "G",
+        )
+        val json = parse(buildCesiumEntitiesJson(
+            contacts = listOf(ground),
+            selfLat = null, selfLon = null, selfCallsign = "OMNI-1",
+        ))
+        val e = json.getJSONObject(0)
+        assertFalse("hae==0 should be omitted so heightReference CLAMP_TO_GROUND fires", e.has("hae"))
+    }
+}

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -1,0 +1,194 @@
+# OmniTAK Android — Plugin SDK Authoring (RFC)
+
+Status: **Draft / RFC**. Pairs with the iOS plugin SDK shipped in
+`OmniTAK-iOS` (`OmniTAKPlugin` protocol + `PluginRegistry`). This document
+proposes the Android-side equivalent. **No runtime SDK code lands in this
+PR** — only the design.
+
+## Goals
+
+1. Mirror the iOS plugin shape closely enough that an author can port a
+   plugin between platforms in a day.
+2. Stay Play-Store-compliant. No DEX class loading, no remote code download.
+3. Keep the registry in-process and dependency-light.
+4. Make ADS-B (already a self-contained feature on Android) the canonical
+   reference plugin once the SDK is implemented.
+
+## Non-goals (for now)
+
+- Runtime/downloadable plugins (Play policy gets dicey on dynamic code
+  loading; revisit if there's user demand).
+- Cross-process plugins (no AIDL boundary).
+- Sandboxing — every plugin runs in the host process, with the host's
+  permissions. Authoring guide will say so.
+
+## Bundling model
+
+Pick **option 3 — compile-time Kotlin modules with a registry pattern**
+(matches the iOS architecture closest):
+
+```
+:app                       <- main application module
+:plugins:plugin-sdk        <- public interfaces + PluginHost API
+:plugins:example-adsb      <- reference plugin
+:plugins:meshtastic        <- if/when we extract Meshtastic as a plugin
+```
+
+Plugins are Gradle modules under `:plugins:*`. The app module declares
+`implementation(project(":plugins:example-adsb"))` for each plugin to
+include. This gives:
+
+- Clear module boundary (lint, compile-time enforcement of the SDK
+  surface)
+- Plugins can declare their own deps (e.g. ADS-B's OpenSky HTTP client)
+  without polluting the main app's classpath
+- Authors can fork the repo, drop a plugin module under `plugins/` and
+  add one line to settings.gradle.kts and one line to app/build.gradle.kts
+
+Future option (deferred): publish the SDK as a Maven artifact so authors
+can build out-of-tree plugins and have us include them at app build time.
+
+## Public SDK surface (proposed)
+
+In `plugins/plugin-sdk/src/main/kotlin/soy/engindearing/omnitak/plugin/`:
+
+```kotlin
+/**
+ * Implement this interface to ship a plugin. Mirrors iOS
+ * OmniTAKPlugin protocol.
+ */
+interface OmniTAKPlugin {
+    val pluginId: String              // reverse-DNS, e.g. "soy.engindearing.adsb"
+    val displayName: String           // shown in PluginsListScreen
+    val pluginVersion: String         // semver
+    val pluginAuthor: String
+    val pluginDescription: String
+
+    /** Called once at process start, after the host is fully initialised.
+     *  Plugins should register all their hooks via [host] here. */
+    fun activate(host: PluginHost)
+
+    /** Called when the user disables the plugin in PluginsListScreen.
+     *  Plugins should unregister hooks and stop background work. */
+    fun deactivate()
+
+    /** Optional Compose-based settings UI shown in the plugin detail
+     *  page. Returning null means "no settings to configure". */
+    fun settingsContent(): (@Composable () -> Unit)? = null
+}
+
+/**
+ * Plugins receive this in [activate] and use it to register hooks.
+ * Mirrors iOS PluginHost.
+ */
+interface PluginHost {
+    /** Compose layer that renders below the main TacticalMap chrome.
+     *  Plugins typically draw their own GeoJsonSource + Layer here. */
+    fun registerMapOverlay(overlay: @Composable () -> Unit)
+
+    /** Adds an entry to the long-press radial menu. */
+    fun registerRadialAction(action: RadialAction, onSelect: (LatLng) -> Unit)
+
+    /** Called for every inbound CoT event after the core ContactStore
+     *  ingests it. Return true to mark "consumed". */
+    fun registerCoTHandler(handler: (CoTEvent) -> Boolean)
+
+    /** Adds a row to the Settings screen, navigating to the plugin's
+     *  [OmniTAKPlugin.settingsContent] when tapped. */
+    fun registerSettingsRow(label: String, icon: ImageVector)
+}
+```
+
+## Registry
+
+`plugins/plugin-sdk/src/main/kotlin/.../PluginRegistry.kt`:
+
+```kotlin
+/**
+ * Singleton populated at app start. App reads the
+ * "plugin_<id>_enabled" SharedPreferences flag to decide whether to
+ * activate(); user toggles it from PluginsListScreen.
+ */
+object PluginRegistry {
+    private val plugins = mutableListOf<OmniTAKPlugin>()
+    private val activated = mutableSetOf<String>()
+
+    fun register(plugin: OmniTAKPlugin) { plugins += plugin }
+    fun all(): List<OmniTAKPlugin> = plugins.toList()
+
+    fun activateEnabled(host: PluginHost, prefs: SharedPreferences) {
+        for (p in plugins) {
+            val key = "plugin_${p.pluginId}_enabled"
+            // Default true on first run so first-time users see plugin
+            // features without hunting in Settings.
+            if (prefs.getBoolean(key, true) && p.pluginId !in activated) {
+                p.activate(host)
+                activated += p.pluginId
+            }
+        }
+    }
+
+    fun deactivate(pluginId: String) {
+        plugins.firstOrNull { it.pluginId == pluginId }?.deactivate()
+        activated -= pluginId
+    }
+}
+```
+
+App entry (in `OmniTAKApp.onCreate()`) calls `loadBundledPlugins()`:
+
+```kotlin
+private fun loadBundledPlugins() {
+    PluginRegistry.register(soy.engindearing.adsb.AdsbPlugin())
+    // future: more bundled plugins
+    PluginRegistry.activateEnabled(host = AppPluginHost(this), prefs = pluginPrefs)
+}
+```
+
+## Reference plugin: extracting ADS-B
+
+ADS-B today lives in `data/AdsbService.kt` + `ui/components/AircraftLayer.kt`.
+To make it a plugin:
+
+1. New module `plugins/example-adsb/`.
+2. Move `AdsbService` + `AircraftLayer` + the OpenSky client into it.
+3. Add an `AdsbPlugin: OmniTAKPlugin` that:
+   - registers `AircraftLayer` as a map overlay via `host.registerMapOverlay`
+   - exposes a Settings row "ADS-B" via `host.registerSettingsRow`
+4. Remove the ADS-B-specific code from `:app` (just the imports and the
+   tools-drawer action — the plugin re-adds those via the SDK).
+
+This is the canonical example because:
+- Self-contained (one HTTP client, one map layer, no cross-cutting deps)
+- Already gated behind a user toggle (the tools-drawer "ADSB" button)
+- Has its own Settings surface
+- Mirrors what the iOS team did exactly
+
+## What lands in this issue
+
+This RFC. **No SDK code yet** — the next PR (and a separate issue) does:
+
+- [ ] Add `:plugins:plugin-sdk` module with the interfaces above.
+- [ ] Add `:plugins:example-adsb` and move ADS-B into it.
+- [ ] Wire `loadBundledPlugins()` from `OmniTAKApp.onCreate()`.
+- [ ] PluginsListScreen reading from `PluginRegistry`, toggling
+      `plugin_<id>_enabled`.
+- [ ] README pointer to this doc.
+
+## Open questions
+
+1. Should the plugin SDK module be published as a Maven artifact?
+   (Probably yes once it's stable, but not in v0.4.)
+2. How do plugins persist their own state? Suggest: each plugin owns
+   its own DataStore, namespaced by `pluginId`. SDK doesn't need to
+   provide one.
+3. Do we need a plugin lifecycle on connection state? (The ADS-B
+   plugin doesn't care, but a "auto-route to TAK" plugin might.) Defer
+   until we hit a real plugin that needs it.
+
+## Compatibility note
+
+Authors writing both iOS and Android plugins should keep `pluginId`
+identical across platforms. Settings tied to `pluginId` (e.g. "ADS-B
+update interval") can then sync via TAK data packages or QR codes
+without per-platform key remapping.


### PR DESCRIPTION
Eight fixes from the issue-cleanup sweep on 2026-05-26.

## What's in

- **#16 radial menu — remove grey backplate** (`RadialMenu.kt`).
- **#17 OpenTopoMap default basemap** (`UserPrefs.kt`).
- **#41 canonical team casing for OTS compat** (`UserPrefs.kt`, `SettingsScreen.kt`).
- **#23 contact marker flicker** (`ContactLayer.kt`). In-place setters replace `removeMarker + addMarker`.
- **#36 Meshtastic Device Settings "No device connected"** (`MeshtasticManager.kt`, `MeshDeviceSettingsScreen.kt`). New transport-aware `activeConnectionState`.
- **#38 CA pin verifier** (`CaTrust.kt`, `CSREnrollmentService.kt`, `EnrollServerScreen.kt`, `TAKConnection.kt`). No trust-all path remains. 8 BC-backed unit tests.
- **#9 chat shows 'sent' but appears as 2nd contact** (`UserPrefs.kt`, `ChatScreen.kt`). Single EUD UID across PPLI + GeoChat.
- **#22 plugin SDK RFC** (`docs/PLUGIN_AUTHORING.md`). Design doc for the Android plugin SDK paired with iOS PR C — bundling model (compile-time `:plugins:*` modules), Play-Store-compliant non-goals (no DEX, no remote download), host API surface. Cherry-picked from `pr-android-sweep` (e45bb39). No runtime SDK code lands here; this closes the rfc-level scope of the issue and unblocks follow-up implementation tickets.

## Verification

- `./gradlew :app:assembleDebug` ✅
- `./gradlew :app:testDebugUnitTest` ✅ (incl. `CaTrustTest`, `MeshtasticManagerActiveStateTest`)
- Manual on `engie_emulator`: #16 / #17 / #41 / #36 verified
- Manual against local **tak57** docker (10.0.2.2):
  - **#38** — enroll → CA pin written → connect with pinned trust. Swap pin → handshake rejected with "Trust anchor for certification path not found". Restore → reconnect.
  - **#23** — 1 Hz PPLI pump drove 41 contact updates with no crash, no visible flicker.
  - **#9** — TAK Server subscription log shows OMNI-1 consistently bound to `ANDROID-e10fb99e-…` across reconnects + a broadcast chat. No second subscription with `OMNITAK-ANDROID-<callsign>-<team>` appears.

Screenshots / pump scripts: `/tmp/omnitak-verify/`.

Closes #9
Closes #16
Closes #17
Closes #22
Closes #23
Closes #36
Closes #38
Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)