### PR TITLE
fix(chat): show known contacts as chat targets

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ChatStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ChatStore.kt
@@ -50,6 +50,17 @@ class ChatStore {
     }
 
     /**
+     * Seed a full [ChatConversation] if no entry exists for its id yet.
+     * Used by ChatScreen to promote a contact stub (built from ContactStore)
+     * into a real backing conversation with participant metadata so that
+     * the send path can resolve the recipient UID and callsign.
+     */
+    fun upsertConversationIfMissing(conversation: ChatConversation) {
+        if (_conversations.value.containsKey(conversation.id)) return
+        _conversations.value = _conversations.value + (conversation.id to conversation)
+    }
+
+    /**
      * GAP-123 — create the conversation if missing, OR rename it if the
      * existing title is still the placeholder we seeded before the radio
      * told us its real channel name. Used when admin-port channel reads

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.OmniTAKApp
 import soy.engindearing.omnitak.mobile.data.ChatConversation
 import soy.engindearing.omnitak.mobile.data.ChatMessage
+import soy.engindearing.omnitak.mobile.data.ChatParticipant
 import soy.engindearing.omnitak.mobile.data.ChatRoom
 import soy.engindearing.omnitak.mobile.data.ChatStatus
 import soy.engindearing.omnitak.mobile.data.ChatXml
@@ -77,6 +78,7 @@ fun ChatScreen(initialConversationId: String? = null) {
     val conversations by app.chatStore.conversations.collectAsState()
     val messagesByConvo by app.chatStore.messagesByConversation.collectAsState()
     val prefs by app.userPrefsStore.prefs.collectAsState(initial = UserPrefs())
+    val contacts by app.contactStore.contacts.collectAsState()
     val chatScope = rememberCoroutineScope()
 
     // Persist the canonical EUD UID on first chat-tab open even if PPLI
@@ -104,10 +106,62 @@ fun ChatScreen(initialConversationId: String? = null) {
         app.chatStore.markRead(id)
     }
 
+    // Merge conversations with ContactStore contacts. Contacts that don't
+    // already have a DM thread appear as "No messages yet" entries so the
+    // user can initiate a message — matching Civtak / iTak behavior.
+    // Own UID is excluded (don't show yourself as a contact to chat with).
+    val mergedConversations = remember(conversations, contacts, prefs.selfUid) {
+        val selfUid = prefs.selfUid
+        val existing = conversations.values.toList()
+
+        // Collect UIDs that already have a direct-message thread so stubs
+        // aren't created for contacts you've already chatted with.
+        val coveredUids = existing
+            .filter { !it.isGroup }
+            .flatMap { it.participants }
+            .map { it.uid }
+            .toSet()
+
+        val contactStubs = contacts.values
+            .filter { contact -> contact.uid != selfUid && contact.uid !in coveredUids }
+            .map { contact ->
+                // Use the same deterministic conversation-id formula as
+                // ChatRoom.directConversationId so that when a real GeoChat
+                // arrives later the stub seamlessly promotes to a real thread.
+                val convoId = ChatRoom.directConversationId(selfUid, contact.uid)
+                ChatConversation(
+                    id = convoId,
+                    title = contact.callsign ?: contact.uid,
+                    isGroup = false,
+                    participants = listOf(
+                        ChatParticipant(
+                            uid = contact.uid,
+                            callsign = contact.callsign ?: contact.uid,
+                        ),
+                    ),
+                )
+            }
+
+        // Real threads (with activity) sorted newest-first; contact stubs
+        // sorted alphabetically below them.
+        existing.sortedByDescending { it.lastActivityIso ?: "" } +
+            contactStubs.sortedBy { it.title.lowercase() }
+    }
+
     if (selectedConversation == null) {
         ConversationListView(
-            conversations = conversations.values.sortedByDescending { it.lastActivityIso ?: "" },
+            conversations = mergedConversations,
             onSelect = { id ->
+                // If the tapped entry is a contact stub (no real conversation
+                // exists yet), seed the full stub into ChatStore so the detail
+                // view and the send path have a backing record with participant
+                // metadata (needed to resolve the recipient UID on send).
+                if (!conversations.containsKey(id)) {
+                    val stub = mergedConversations.find { it.id == id }
+                    if (stub != null) {
+                        app.chatStore.upsertConversationIfMissing(stub)
+                    }
+                }
                 app.chatStore.markRead(id)
                 selectedConversation = id
             },

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/ChatStoreTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/ChatStoreTest.kt
@@ -1,7 +1,11 @@
 package soy.engindearing.omnitak.mobile.domain
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.ChatConversation
+import soy.engindearing.omnitak.mobile.data.ChatParticipant
 
 /**
  * GAP-123 — verifies the upsertOrRename behavior used to fold
@@ -32,5 +36,38 @@ class ChatStoreTest {
         val after = store.conversations.value["MESH-CH0"]
         // Same instance — no churn for redundant updates.
         assertEquals(before, after)
+    }
+
+    // --- ContactStore merge behavior (P-E bug: contacts not shown in chat) ---
+
+    @Test fun upsertConversation_full_object_seeds_with_participants() {
+        val store = ChatStore()
+        val stub = ChatConversation(
+            id = "DM-uid-peer",
+            title = "EAGLE-1",
+            isGroup = false,
+            participants = listOf(ChatParticipant(uid = "uid-peer", callsign = "EAGLE-1")),
+        )
+        store.upsertConversationIfMissing(stub)
+        val convo = store.conversations.value["DM-uid-peer"]
+        assertNotNull(convo)
+        assertEquals("EAGLE-1", convo?.title)
+        assertEquals(1, convo?.participants?.size)
+        assertEquals("uid-peer", convo?.participants?.first()?.uid)
+    }
+
+    @Test fun upsertConversation_full_object_no_op_when_exists() {
+        val store = ChatStore()
+        store.upsertConversationIfMissing("DM-uid-peer", "EAGLE-1", isGroup = false)
+        val before = store.conversations.value["DM-uid-peer"]
+        val stub = ChatConversation(
+            id = "DM-uid-peer",
+            title = "EAGLE-1-renamed",
+            isGroup = false,
+        )
+        store.upsertConversationIfMissing(stub)
+        // Pre-existing entry must not be replaced.
+        val after = store.conversations.value["DM-uid-peer"]
+        assertEquals(before?.title, after?.title)
     }
 }


### PR DESCRIPTION
## Summary
Chat contacts list now shows every known EUD, not just those you've already messaged.
- ChatScreen merges ChatStore conversations + ContactStore contacts, de-duped by UID
- Tapping a contact-without-conversation opens a fresh thread
- Matches Civtak / iTak behavior

## Reporter
Reported by P-E on TAK Discord 2026-05-27: "Chat doesn't show any of my other EUDs as contact (they show up as contacts in Civtak)".

## Test plan
- [ ] Receive PPLI from a callsign that has never sent a chat → callsign appears in chat picker
- [ ] Tap that callsign → empty thread opens, can send msg
- [ ] Own UID excluded