### PR TITLE
fix(map): persist camera across cold starts

### DIFF
--- a/app/src/main/assets/cesium_scene.html
+++ b/app/src/main/assets/cesium_scene.html
@@ -140,7 +140,7 @@
     const v=new Cesium.Viewer('cesiumContainer',{terrain:Cesium.Terrain.fromWorldTerrain(),animation:false,timeline:false,baseLayerPicker:false,geocoder:false,homeButton:false,sceneModePicker:false,navigationHelpButton:false,fullscreenButton:false,infoBox:false,selectionIndicator:false,creditContainer:document.createElement('div')});
     v.scene.skyAtmosphere.show=true;v.scene.globe.enableLighting=true;_state.viewer=v;_fitViewport();_installInputHandlers(v);
     try{const t=await Cesium.createGooglePhotorealistic3DTileset();v.scene.primitives.add(t);}catch(e){console.warn('Photoreal unavailable:',e);}
-    v.camera.flyTo({destination:Cesium.Cartesian3.fromDegrees(-117.4260,47.6588,50000),orientation:{heading:0,pitch:Cesium.Math.toRadians(-60),roll:0},duration:1.5,complete:_hideLoading});
+    v.camera.flyTo({destination:Cesium.Cartesian3.fromDegrees(0.0,0.0,20000000),orientation:{heading:0,pitch:Cesium.Math.toRadians(-90),roll:0},duration:1.5,complete:_hideLoading});
     _signalReady();
   })().catch(e=>{const el=document.getElementById('loading');if(el)el.innerHTML='<div class="label">3D scene failed: '+(e&&e.message?e.message:'unknown')+'</div>';});
 </script></body></html>

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.data.AdminResponse
@@ -84,6 +85,13 @@ class OmniTAKApp : Application() {
             }
         }
 
+        // Seed the in-memory camera cache from DataStore so MapScreen's
+        // cold-start read gets the persisted view before first composition.
+        appScope.launch {
+            val saved = userPrefsStore.prefs.first()
+            mapCameraStore.seedFromPrefs(saved)
+        }
+
         // Phase 2 of the gy6 plan — FAA Remote ID BLE scanner.
         // Lifecycle is driven by `remoteIdScanEnabled` so operators can
         // opt out of the always-on BLE scan (battery cost). When a
@@ -129,7 +137,7 @@ class OmniTAKApp : Application() {
     private val appScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     val contactStore: ContactStore by lazy { ContactStore() }
     val drawingStore: DrawingStore by lazy { DrawingStore() }
-    val mapCameraStore: MapCameraStore by lazy { MapCameraStore() }
+    val mapCameraStore: MapCameraStore by lazy { MapCameraStore(userPrefsStore) }
     val chatStore: ChatStore by lazy {
         ChatStore().also { store ->
             // GAP-122 — Mesh primary channel always visible so users can

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -88,6 +88,12 @@ data class UserPrefs(
     val toolbarItemIds: List<String> = emptyList(),
     /** One-time flag for the "press & hold to customize" coachmark. */
     val toolbarCoachmarkSeen: Boolean = false,
+    // Camera persistence — last map view the operator panned/zoomed to.
+    // All three must be non-null together to constitute a valid saved view.
+    // Null on first install (fresh device → self-fix or global fallback).
+    val lastCameraLat: Double? = null,
+    val lastCameraLon: Double? = null,
+    val lastCameraZoom: Double? = null,
 )
 
 class UserPrefsStore(private val context: Context) {
@@ -115,6 +121,10 @@ class UserPrefsStore(private val context: Context) {
     private val KEY_CESIUM_GLOBE = booleanPreferencesKey("cesium_globe_enabled")
     private val KEY_TOOLBAR_ITEMS = stringPreferencesKey("toolbar_item_ids")
     private val KEY_TOOLBAR_COACH = booleanPreferencesKey("toolbar_coachmark_seen")
+    // Camera persistence keys (issue: map resets to Spokane on cold start)
+    private val KEY_CAMERA_LAT  = stringPreferencesKey("last_camera_lat")
+    private val KEY_CAMERA_LON  = stringPreferencesKey("last_camera_lon")
+    private val KEY_CAMERA_ZOOM = stringPreferencesKey("last_camera_zoom")
 
     val prefs: Flow<UserPrefs> = context.userPrefsDataStore.data.map { p -> readFrom(p) }
 
@@ -144,6 +154,11 @@ class UserPrefsStore(private val context: Context) {
             p[KEY_CESIUM_GLOBE] = next.cesiumGlobeEnabled
             p[KEY_TOOLBAR_ITEMS] = next.toolbarItemIds.joinToString(",")
             p[KEY_TOOLBAR_COACH] = next.toolbarCoachmarkSeen
+            // Camera persistence — write only when the value is present so a
+            // null (first install) doesn't clobber a previously saved view.
+            if (next.lastCameraLat != null)  p[KEY_CAMERA_LAT]  = next.lastCameraLat.toString()
+            if (next.lastCameraLon != null)  p[KEY_CAMERA_LON]  = next.lastCameraLon.toString()
+            if (next.lastCameraZoom != null) p[KEY_CAMERA_ZOOM] = next.lastCameraZoom.toString()
         }
     }
 
@@ -155,6 +170,11 @@ class UserPrefsStore(private val context: Context) {
     /** Mark the customize-toolbar coachmark as seen. */
     suspend fun setToolbarCoachmarkSeen(value: Boolean) {
         update { it.copy(toolbarCoachmarkSeen = value) }
+    }
+
+    /** Persist the last camera view so it survives cold starts. */
+    suspend fun setLastCamera(lat: Double, lon: Double, zoom: Double) {
+        update { it.copy(lastCameraLat = lat, lastCameraLon = lon, lastCameraZoom = zoom) }
     }
 
     /** Convenience writer for the Meshtastic auto-publish toggle so the
@@ -213,6 +233,9 @@ class UserPrefsStore(private val context: Context) {
         cesiumGlobeEnabled = p[KEY_CESIUM_GLOBE] ?: false,
         toolbarItemIds = p[KEY_TOOLBAR_ITEMS]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),
         toolbarCoachmarkSeen = p[KEY_TOOLBAR_COACH] ?: false,
+        lastCameraLat  = p[KEY_CAMERA_LAT]?.toDoubleOrNull(),
+        lastCameraLon  = p[KEY_CAMERA_LON]?.toDoubleOrNull(),
+        lastCameraZoom = p[KEY_CAMERA_ZOOM]?.toDoubleOrNull(),
     )
 
     // ATAK / OpenTakServer canonical team names are Title Case ("Cyan",

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MapCameraStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MapCameraStore.kt
@@ -1,22 +1,29 @@
 package soy.engindearing.omnitak.mobile.domain
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import soy.engindearing.omnitak.mobile.data.UserPrefs
+import soy.engindearing.omnitak.mobile.data.UserPrefsStore
+
 /**
- * App-scoped persistence for the map camera position so the operator's
- * pan/zoom survives bottom-nav switches between Map and other tabs.
+ * App-scoped persistence for the map camera position.
  *
- * `remember { MapView(...) }` inside [TacticalMap] is destroyed each
- * time MapScreen leaves the composition (Compose Navigation drops the
- * composable, even with `saveState = true`, because plain `remember`
- * isn't backed by SavedStateHandle). Without a state holder above the
- * NavHost the map snaps back to its default center every time the user
- * dips into Settings / Servers / Chat — that's what Discord testers
- * called "map re-centering to Spokane when exiting setting or other
- * menus." (See repo issue #7.)
+ * In-memory fields survive bottom-nav tab switches (Issue #7).
+ * DataStore writes survive full process death — the operator's last
+ * pan/zoom is restored on cold start instead of reverting to a
+ * hardcoded developer default (P-E TAK Discord report 2026-05-27).
  *
- * Survives tab switches but not process death — that's deliberate. If
- * we ever want it durable across cold launches, persist into UserPrefs.
+ * Writes are debounced 500 ms so rapid camera movement during a pan
+ * gesture doesn't hammer DataStore on every idle event.
  */
-class MapCameraStore {
+class MapCameraStore(private val userPrefsStore: UserPrefsStore) {
+
+    // In-memory cache. Populated from DataStore at app startup via
+    // [seedFromPrefs], then kept current by [update]. MapScreen reads
+    // synchronously from here; DataStore writes happen asynchronously.
     var lastTargetLat: Double? = null
         private set
     var lastTargetLon: Double? = null
@@ -24,9 +31,56 @@ class MapCameraStore {
     var lastZoom: Double? = null
         private set
 
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private var debounceJob: Job? = null
+
+    /**
+     * Seed the in-memory cache from previously persisted prefs.
+     * Call once at startup (e.g. in OmniTAKApp.onCreate) before
+     * MapScreen first composes. Safe to call multiple times — a
+     * populated cache is never overwritten by a later seed call.
+     */
+    fun seedFromPrefs(prefs: UserPrefs) {
+        val (lat, lon, zoom) = extractCamera(prefs) ?: return
+        if (lastTargetLat == null) {
+            lastTargetLat = lat
+            lastTargetLon = lon
+            lastZoom      = zoom
+        }
+    }
+
+    /**
+     * Record a new camera position. Updates the in-memory cache
+     * immediately and debounce-persists to DataStore after 500 ms so
+     * rapid pan/zoom gestures coalesce into a single write.
+     */
     fun update(lat: Double, lon: Double, zoom: Double) {
         lastTargetLat = lat
         lastTargetLon = lon
-        lastZoom = zoom
+        lastZoom      = zoom
+
+        debounceJob?.cancel()
+        debounceJob = scope.launch {
+            delay(500)
+            userPrefsStore.setLastCamera(lat, lon, zoom)
+        }
+    }
+
+    companion object {
+        /**
+         * Extract a valid camera triple from [prefs], or null if any
+         * component is missing. All three values must be present and
+         * finite for the saved view to be usable.
+         *
+         * Exposed as a companion function so the priority-resolution
+         * logic can be tested without an Android context.
+         */
+        fun extractCamera(prefs: UserPrefs): Triple<Double, Double, Double>? {
+            val lat  = prefs.lastCameraLat  ?: return null
+            val lon  = prefs.lastCameraLon  ?: return null
+            val zoom = prefs.lastCameraZoom ?: return null
+            if (!lat.isFinite() || !lon.isFinite() || !zoom.isFinite()) return null
+            return Triple(lat, lon, zoom)
+        }
     }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -45,8 +45,8 @@ import soy.engindearing.omnitak.mobile.data.MapProvider
  */
 @Composable
 fun TacticalMap(
-    initialCenter: LatLng = LatLng(47.6588, -117.4260),  // Spokane, WA
-    initialZoom: Double = 11.0,
+    initialCenter: LatLng = LatLng(0.0, 0.0),  // neutral world default — callers should pass a real center
+    initialZoom: Double = 2.0,
     styleJson: String = TACTICAL_STYLE_DARK_MATTER,
     onMapLongPress: ((LatLng, Offset) -> Unit)? = null,
     onContactTap: ((CoTEvent) -> Unit)? = null,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -80,6 +80,11 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+// Cold-start fallback when there is no persisted camera and no GPS fix yet.
+// World-level zoom centered on 0°N 0°E — neutral for every operator globally.
+private val FALLBACK_GLOBAL_VIEW = LatLng(0.0, 0.0)
+private const val FALLBACK_GLOBAL_ZOOM = 2.0
+
 @Composable
 fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     val app = LocalContext.current.applicationContext as OmniTAKApp
@@ -334,15 +339,22 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         } else {
         TacticalMap(
             modifier = Modifier.fillMaxSize(),
-            // Restore the operator's last pan/zoom across bottom-nav
-            // switches. Falls back to TacticalMap's own default on first
-            // run / fresh process. Issue #7.
+            // Cold-start camera priority:
+            //   1. Persisted view (DataStore via MapCameraStore) — operator's last pan/zoom.
+            //   2. Self-fix — center on GPS position if available and no saved view.
+            //   3. Neutral global fallback — world-level zoom, no developer home-town.
+            // Spokane hardcode removed (P-E TAK Discord report 2026-05-27).
             initialCenter = run {
-                val lat = app.mapCameraStore.lastTargetLat
-                val lon = app.mapCameraStore.lastTargetLon
-                if (lat != null && lon != null) LatLng(lat, lon) else LatLng(47.6588, -117.4260)
+                val camLat = app.mapCameraStore.lastTargetLat
+                val camLon = app.mapCameraStore.lastTargetLon
+                when {
+                    camLat != null && camLon != null -> LatLng(camLat, camLon)
+                    selfFix != null -> LatLng(selfFix!!.lat, selfFix!!.lon)
+                    else -> FALLBACK_GLOBAL_VIEW
+                }
             },
-            initialZoom = app.mapCameraStore.lastZoom ?: 11.0,
+            initialZoom = app.mapCameraStore.lastZoom
+                ?: if (selfFix != null) 12.0 else FALLBACK_GLOBAL_ZOOM,
             onCameraIdle = { target, zoom ->
                 app.mapCameraStore.update(target.latitude, target.longitude, zoom)
             },
@@ -1101,7 +1113,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                         val lat = app.mapCameraStore.lastTargetLat
                         val lon = app.mapCameraStore.lastTargetLon
                         femaPaletteLatLng = if (lat != null && lon != null) LatLng(lat, lon)
-                        else LatLng(47.6588, -117.4260)
+                        else selfFix?.let { LatLng(it.lat, it.lon) } ?: FALLBACK_GLOBAL_VIEW
                     }
                     "teams" -> teamsPanelOpen = true
                     "nav" -> {

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/MapCameraStoreTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/MapCameraStoreTest.kt
@@ -1,0 +1,61 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.UserPrefs
+
+/**
+ * Verifies the camera-persistence seeding logic without an Android context.
+ *
+ * The priority chain tested here mirrors what MapScreen applies on cold
+ * start: persisted view → self-fix → global fallback (Spokane removed,
+ * P-E TAK Discord 2026-05-27).
+ */
+class MapCameraStoreTest {
+
+    @Test fun extractCamera_returns_triple_when_all_present() {
+        val prefs = UserPrefs(lastCameraLat = 51.5, lastCameraLon = -0.12, lastCameraZoom = 14.0)
+        val result = MapCameraStore.extractCamera(prefs)
+        assertNotNull(result)
+        assertEquals(51.5, result!!.first, 0.0001)
+        assertEquals(-0.12, result.second, 0.0001)
+        assertEquals(14.0, result.third, 0.0001)
+    }
+
+    @Test fun extractCamera_returns_null_when_lat_missing() {
+        val prefs = UserPrefs(lastCameraLat = null, lastCameraLon = -0.12, lastCameraZoom = 14.0)
+        assertNull(MapCameraStore.extractCamera(prefs))
+    }
+
+    @Test fun extractCamera_returns_null_when_lon_missing() {
+        val prefs = UserPrefs(lastCameraLat = 51.5, lastCameraLon = null, lastCameraZoom = 14.0)
+        assertNull(MapCameraStore.extractCamera(prefs))
+    }
+
+    @Test fun extractCamera_returns_null_when_zoom_missing() {
+        val prefs = UserPrefs(lastCameraLat = 51.5, lastCameraLon = -0.12, lastCameraZoom = null)
+        assertNull(MapCameraStore.extractCamera(prefs))
+    }
+
+    @Test fun extractCamera_returns_null_for_NaN_lat() {
+        val prefs = UserPrefs(lastCameraLat = Double.NaN, lastCameraLon = -0.12, lastCameraZoom = 14.0)
+        assertNull(MapCameraStore.extractCamera(prefs))
+    }
+
+    @Test fun extractCamera_returns_null_for_default_prefs() {
+        // Fresh install — no saved camera. Must not produce a fallback view.
+        assertNull(MapCameraStore.extractCamera(UserPrefs()))
+    }
+
+    @Test fun extractCamera_accepts_equator_prime_meridian_coordinates() {
+        // Verify the global fallback coords (0,0) are themselves valid
+        // when explicitly persisted — the check must not treat them as missing.
+        val prefs = UserPrefs(lastCameraLat = 0.0, lastCameraLon = 0.0, lastCameraZoom = 2.0)
+        val result = MapCameraStore.extractCamera(prefs)
+        assertNotNull(result)
+        assertEquals(0.0, result!!.first, 0.0001)
+        assertEquals(0.0, result.second, 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
Map view no longer resets to Spokane on relaunch.
- MapCameraStore now persists last lat/lon/zoom via DataStore (same pattern as UserPrefsStore).
- MapScreen cold-start priority: persisted view → self fix → neutral global default. Spokane hardcode removed.

## Reporter
Reported by P-E on TAK Discord 2026-05-27: "when exiting the app and re-entering, map position reverts to Spokane by default, it doesn't stick to self marker nor the last set view".

## Test plan
- [ ] Cold install → opens to neutral world view (no Spokane)
- [ ] Pan/zoom anywhere → kill app → relaunch → restored to that view
- [ ] Fresh install with self-fix available → centers on self