### PR TITLE
feat(uas): raw H264 UDP video source for RubyFPV compat

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/H264NalSplitter.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/H264NalSplitter.kt
@@ -1,0 +1,108 @@
+package soy.engindearing.omnitak.mobile.data.uas
+
+import java.io.ByteArrayOutputStream
+
+/**
+ * Splits an H264 Annex B byte stream into NAL units.
+ *
+ * Annex B framing: each NAL unit is preceded by a start code,
+ * either `00 00 01` (3 bytes) or `00 00 00 01` (4 bytes). The NAL
+ * payload runs until the next start code.
+ *
+ * Bytes are fed in via [push]. Each call returns 0+ complete NAL
+ * units that were closed by the just-received bytes (i.e. a fresh
+ * start code arrived after their payload). The trailing partial
+ * NAL is held until the next push; this is correct for live
+ * streaming where we never see EOF.
+ *
+ * Bytes before the very first start code are discarded — they're
+ * either decoder garbage or the tail of a NAL we joined mid-stream
+ * and can't decode anyway. After that, the splitter locks on and
+ * NAL emission is deterministic.
+ *
+ * The decoder owns emulation-prevention removal; this splitter only
+ * needs to find the framing boundaries. Trailing `0x00` cabac
+ * padding between NAL units is absorbed into the next start code
+ * (treated as the 4-byte form), which is benign for H264 RBSP per
+ * the spec.
+ */
+class H264NalSplitter {
+    private val buf = ByteArrayOutputStream()
+
+    /** Length of the leading start code in [buf], or 0 when no start
+     *  code has been seen yet. */
+    private var headerLen = 0
+
+    /**
+     * Feed bytes from the network. Returns NAL unit payloads (no
+     * start code prefix) that were finalized by this push.
+     */
+    fun push(bytes: ByteArray, offset: Int = 0, length: Int = bytes.size): List<ByteArray> {
+        buf.write(bytes, offset, length)
+        return drain()
+    }
+
+    /** Drop all buffered state. Use on reconnect / stream restart. */
+    fun reset() {
+        buf.reset()
+        headerLen = 0
+    }
+
+    private fun drain(): List<ByteArray> {
+        val data = buf.toByteArray()
+        val out = mutableListOf<ByteArray>()
+
+        // Where the current in-progress NAL's payload begins in `data`.
+        // -1 means we haven't locked onto the first start code yet.
+        var payloadStart = if (headerLen > 0) headerLen else -1
+        var lastFoundAt = -1
+        var lastFoundLen = 0
+        var i = if (headerLen > 0) headerLen else 0
+
+        while (i + 2 < data.size) {
+            if (data[i] == 0.toByte() && data[i + 1] == 0.toByte() && data[i + 2] == 1.toByte()) {
+                // Walk back over any leading 0x00s so a 4-byte start
+                // code (00 00 00 01) is detected as one start code
+                // instead of [trailing-pad-of-prev-NAL] + [3-byte-sc].
+                val floor = if (payloadStart >= 0) payloadStart else 0
+                var actualStart = i
+                while (actualStart > floor && data[actualStart - 1] == 0.toByte()) {
+                    actualStart--
+                }
+                val scLen = i + 3 - actualStart
+
+                if (payloadStart >= 0 && actualStart > payloadStart) {
+                    out += data.copyOfRange(payloadStart, actualStart)
+                }
+                lastFoundAt = actualStart
+                lastFoundLen = scLen
+                payloadStart = i + 3
+                i += 3
+            } else {
+                i++
+            }
+        }
+
+        when {
+            lastFoundAt >= 0 -> {
+                // Retain from the last start code onward — the in-progress
+                // NAL needs to survive until the next push closes it.
+                val tail = data.copyOfRange(lastFoundAt, data.size)
+                buf.reset()
+                buf.write(tail)
+                headerLen = lastFoundLen
+            }
+            headerLen == 0 && data.size > 3 -> {
+                // Still searching for the first start code; retain only
+                // the last 3 bytes so a start code straddling chunks is
+                // still detectable on the next push.
+                val tail = data.copyOfRange(data.size - 3, data.size)
+                buf.reset()
+                buf.write(tail)
+            }
+            // else: leading start code + partial payload, no new start
+            // code yet — keep buf intact for the next push.
+        }
+        return out
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/RawH264UdpPlayer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/RawH264UdpPlayer.kt
@@ -1,0 +1,350 @@
+package soy.engindearing.omnitak.mobile.data.uas
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.util.Log
+import android.view.Surface
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import kotlin.concurrent.thread
+
+/**
+ * Plays a raw H264 Annex B byte stream delivered over UDP, decoding
+ * through [MediaCodec] directly to an Android [Surface].
+ *
+ * Wire format (matches RubyFPV "Video Forward To USB Device: Raw H264"):
+ *   - one or more H264 NAL units per UDP datagram
+ *   - Annex B framing (0x00 0x00 0x00 0x01 or 0x00 0x00 0x01 start codes)
+ *   - no RTP header, no MPEG-TS framing, no timestamps
+ *   - NAL units may span multiple datagrams
+ *
+ * Lifecycle: [start] binds the socket and spins up two threads (one
+ * for UDP read, one for MediaCodec output rendering). [stop] tears
+ * everything down. Safe to call [stop] from any thread; idempotent.
+ *
+ * Errors are reported via [onError] so the host composable can show
+ * a banner instead of crashing the app. Socket bind failure (port in
+ * use) is the most common one — the operator can pick a different port.
+ */
+class RawH264UdpPlayer(
+    private val port: Int,
+    private val surface: Surface,
+    private val onError: (Throwable) -> Unit = {},
+    private val onFirstFrame: () -> Unit = {},
+) {
+    @Volatile private var running = false
+    private var socket: DatagramSocket? = null
+    private var codec: MediaCodec? = null
+    private var readerThread: Thread? = null
+    private var renderThread: Thread? = null
+    private val splitter = H264NalSplitter()
+    private var sps: ByteArray? = null
+    private var pps: ByteArray? = null
+    private var codecConfigured = false
+    @Volatile private var firstFrameRendered = false
+
+    fun start() {
+        if (running) return
+        running = true
+        // Capture the constructor param into a local so the `apply`
+        // block below doesn't shadow it with DatagramSocket.getPort()
+        // (which returns -1 on an unbound socket and made bind() blow
+        // up with "port out of range: -1").
+        val bindPort = port
+        try {
+            val sock = DatagramSocket(null)
+            sock.reuseAddress = true
+            sock.bind(InetSocketAddress(bindPort))
+            sock.soTimeout = 500
+            sock.receiveBufferSize = 1 shl 20
+            socket = sock
+            Log.i(TAG, "bound UDP 0.0.0.0:$bindPort")
+        } catch (t: Throwable) {
+            running = false
+            Log.e(TAG, "bind failed on port $bindPort", t)
+            onError(t)
+            return
+        }
+        readerThread = thread(name = "h264-udp-reader-$bindPort", isDaemon = true) { readLoop() }
+    }
+
+    fun stop() {
+        if (!running) return
+        running = false
+        try { socket?.close() } catch (_: Throwable) {}
+        try { codec?.signalEndOfInputStream() } catch (_: Throwable) {}
+        try { codec?.stop() } catch (_: Throwable) {}
+        try { codec?.release() } catch (_: Throwable) {}
+        codec = null
+        readerThread?.interrupt()
+        renderThread?.interrupt()
+        readerThread = null
+        renderThread = null
+        splitter.reset()
+        sps = null
+        pps = null
+        codecConfigured = false
+    }
+
+    private fun readLoop() {
+        val sock = socket ?: return
+        val buf = ByteArray(64 * 1024)
+        val pkt = DatagramPacket(buf, buf.size)
+        while (running) {
+            try {
+                sock.receive(pkt)
+                val nals = splitter.push(buf, 0, pkt.length)
+                for (nal in nals) handleNal(nal)
+            } catch (_: java.net.SocketTimeoutException) {
+                // expected — lets us re-check `running` periodically
+            } catch (_: java.net.SocketException) {
+                // socket closed during stop(), exit cleanly
+                return
+            } catch (t: Throwable) {
+                Log.w(TAG, "udp read error", t)
+                onError(t)
+                return
+            }
+        }
+    }
+
+    private fun handleNal(nal: ByteArray) {
+        if (nal.isEmpty()) return
+        val type = nal[0].toInt() and 0x1F
+        when (type) {
+            NAL_SPS -> {
+                sps = nal
+                tryConfigureCodec()
+            }
+            NAL_PPS -> {
+                pps = nal
+                tryConfigureCodec()
+            }
+            NAL_AUD, NAL_SEI -> {
+                // Non-VCL — skip. AUD/SEI not required by decoder.
+            }
+            else -> {
+                if (!codecConfigured) return // can't decode VCL until SPS+PPS in hand
+                feedDecoder(nal, isKeyFrame = type == NAL_IDR)
+            }
+        }
+    }
+
+    private fun tryConfigureCodec() {
+        if (codecConfigured) return
+        val s = sps ?: return
+        val p = pps ?: return
+        try {
+            // We must know width/height to configure the decoder. Parse
+            // the SPS to extract resolution. If parsing fails, fall back
+            // to a sensible default and let the decoder reconfigure
+            // itself from in-band SPS — most MediaCodec impls do.
+            val dims = SpsParser.parseDimensions(s) ?: Dimensions(1280, 720)
+            val format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC, dims.width, dims.height).apply {
+                // csd-0 and csd-1 must include the start code prefix.
+                setByteBuffer("csd-0", ByteBuffer.wrap(withStartCode(s)))
+                setByteBuffer("csd-1", ByteBuffer.wrap(withStartCode(p)))
+            }
+            val c = MediaCodec.createDecoderByType(MediaFormat.MIMETYPE_VIDEO_AVC)
+            c.configure(format, surface, null, 0)
+            c.start()
+            codec = c
+            codecConfigured = true
+            renderThread = thread(name = "h264-udp-render-$port", isDaemon = true) { renderLoop() }
+            Log.i(TAG, "decoder configured ${dims.width}x${dims.height}")
+        } catch (t: Throwable) {
+            Log.e(TAG, "decoder configure failed", t)
+            onError(t)
+        }
+    }
+
+    private fun feedDecoder(nal: ByteArray, isKeyFrame: Boolean) {
+        val c = codec ?: return
+        try {
+            val idx = c.dequeueInputBuffer(10_000) // 10 ms
+            if (idx < 0) return // drop frame if decoder is stalled — better than backing up
+            val input = c.getInputBuffer(idx) ?: return
+            input.clear()
+            // MediaCodec accepts raw NAL bytes with the start code prefix.
+            val framed = withStartCode(nal)
+            input.put(framed)
+            val flags = if (isKeyFrame) MediaCodec.BUFFER_FLAG_KEY_FRAME else 0
+            c.queueInputBuffer(idx, 0, framed.size, presentationTimeUs(), flags)
+        } catch (t: Throwable) {
+            Log.w(TAG, "feed error", t)
+        }
+    }
+
+    private fun renderLoop() {
+        val c = codec ?: return
+        val info = MediaCodec.BufferInfo()
+        while (running) {
+            try {
+                val idx = c.dequeueOutputBuffer(info, 10_000)
+                when {
+                    idx >= 0 -> {
+                        c.releaseOutputBuffer(idx, true) // render to surface
+                        if (!firstFrameRendered) {
+                            firstFrameRendered = true
+                            try { onFirstFrame() } catch (_: Throwable) {}
+                        }
+                    }
+                    idx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                        Log.i(TAG, "decoder output format: ${c.outputFormat}")
+                    }
+                    // INFO_TRY_AGAIN_LATER and other negatives: just spin.
+                }
+            } catch (_: IllegalStateException) {
+                // Codec released while we were dequeueing — exit.
+                return
+            } catch (t: Throwable) {
+                Log.w(TAG, "render error", t)
+            }
+        }
+    }
+
+    private fun presentationTimeUs(): Long {
+        // No PTS in raw H264. Monotonic clock works for live playback —
+        // MediaCodec just renders as fast as it can decode.
+        return System.nanoTime() / 1000L
+    }
+
+    private fun withStartCode(nal: ByteArray): ByteArray {
+        val out = ByteArray(nal.size + 4)
+        out[0] = 0; out[1] = 0; out[2] = 0; out[3] = 1
+        System.arraycopy(nal, 0, out, 4, nal.size)
+        return out
+    }
+
+    companion object {
+        private const val TAG = "RawH264UdpPlayer"
+        private const val NAL_IDR = 5
+        private const val NAL_SEI = 6
+        private const val NAL_SPS = 7
+        private const val NAL_PPS = 8
+        private const val NAL_AUD = 9
+    }
+}
+
+internal data class Dimensions(val width: Int, val height: Int)
+
+/**
+ * Minimal SPS parser that extracts the encoded picture dimensions.
+ * Just enough to seed [MediaFormat] before configure(); the decoder
+ * itself handles the full bitstream.
+ *
+ * H264 SPS payload after the NAL header byte:
+ *   profile_idc (u8), constraint_set_flags (u8), level_idc (u8),
+ *   then exp-Golomb fields including pic_width_in_mbs_minus1 and
+ *   pic_height_in_map_units_minus1 which give the dimensions in
+ *   16-px macroblocks (with adjustments for interlaced + cropping).
+ *
+ * We deliberately skip cropping/interlace — the decoder will report
+ * the true crop rect via [MediaCodec.INFO_OUTPUT_FORMAT_CHANGED] once
+ * frames flow.
+ */
+internal object SpsParser {
+    fun parseDimensions(sps: ByteArray): Dimensions? {
+        if (sps.size < 4) return null
+        return try {
+            // Strip NAL header byte + emulation prevention bytes (00 00 03 -> 00 00).
+            val rbsp = stripEmulationPrevention(sps, 1)
+            val br = BitReader(rbsp)
+            val profileIdc = br.readByte()
+            br.readByte() // constraint_set_flags
+            br.readByte() // level_idc
+            br.readUE()   // seq_parameter_set_id
+
+            if (profileIdc in arrayOf(100, 110, 122, 244, 44, 83, 86, 118, 128, 138, 139, 134, 135)) {
+                val chromaFormatIdc = br.readUE()
+                if (chromaFormatIdc == 3) br.readBit() // separate_colour_plane_flag
+                br.readUE() // bit_depth_luma_minus8
+                br.readUE() // bit_depth_chroma_minus8
+                br.readBit() // qpprime_y_zero_transform_bypass_flag
+                val seqScalingMatrix = br.readBit()
+                if (seqScalingMatrix == 1) {
+                    // Skip scaling list — operator video rarely uses it; if it shows up
+                    // we'll fall back to the default dims and let MediaCodec reconfigure.
+                    return null
+                }
+            }
+            br.readUE() // log2_max_frame_num_minus4
+            val pocType = br.readUE()
+            when (pocType) {
+                0 -> br.readUE() // log2_max_pic_order_cnt_lsb_minus4
+                1 -> {
+                    br.readBit() // delta_pic_order_always_zero_flag
+                    br.readSE() // offset_for_non_ref_pic
+                    br.readSE() // offset_for_top_to_bottom_field
+                    val numRefFrames = br.readUE()
+                    repeat(numRefFrames) { br.readSE() }
+                }
+            }
+            br.readUE() // num_ref_frames
+            br.readBit() // gaps_in_frame_num_value_allowed_flag
+            val picWidthInMbs = br.readUE() + 1
+            val picHeightInMapUnits = br.readUE() + 1
+            val frameMbsOnly = br.readBit()
+            val height = (2 - frameMbsOnly) * picHeightInMapUnits * 16
+            val width = picWidthInMbs * 16
+            if (width <= 0 || height <= 0 || width > 8192 || height > 8192) null
+            else Dimensions(width, height)
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun stripEmulationPrevention(data: ByteArray, from: Int): ByteArray {
+        val out = ArrayList<Byte>(data.size - from)
+        var i = from
+        var zeroes = 0
+        while (i < data.size) {
+            val byte = data[i]
+            if (zeroes >= 2 && byte == 0x03.toByte()) {
+                zeroes = 0
+            } else {
+                out.add(byte)
+                zeroes = if (byte == 0.toByte()) zeroes + 1 else 0
+            }
+            i++
+        }
+        return ByteArray(out.size) { out[it] }
+    }
+}
+
+internal class BitReader(private val data: ByteArray) {
+    private var bytePos = 0
+    private var bitPos = 0
+
+    fun readBit(): Int {
+        if (bytePos >= data.size) throw IndexOutOfBoundsException()
+        val v = (data[bytePos].toInt() ushr (7 - bitPos)) and 1
+        bitPos++
+        if (bitPos == 8) { bitPos = 0; bytePos++ }
+        return v
+    }
+
+    fun readByte(): Int {
+        var v = 0
+        repeat(8) { v = (v shl 1) or readBit() }
+        return v
+    }
+
+    /** Unsigned exp-Golomb. */
+    fun readUE(): Int {
+        var leadingZeros = 0
+        while (leadingZeros < 32 && readBit() == 0) leadingZeros++
+        if (leadingZeros == 0) return 0
+        var v = 0
+        repeat(leadingZeros) { v = (v shl 1) or readBit() }
+        return (1 shl leadingZeros) - 1 + v
+    }
+
+    /** Signed exp-Golomb. */
+    fun readSE(): Int {
+        val v = readUE()
+        return if (v and 1 == 1) (v + 1) / 2 else -(v / 2)
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/VideoSource.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/VideoSource.kt
@@ -1,0 +1,30 @@
+package soy.engindearing.omnitak.mobile.data.uas
+
+/**
+ * Where the live drone camera stream is coming from.
+ *
+ *  - [None]: no video. PIP not rendered.
+ *  - [Rtsp]: RTSP URL the operator configured. Decoded by Media3
+ *    ExoPlayer + RtspMediaSource, RTP-over-TCP forced (see
+ *    UasVideoPip for the rationale).
+ *  - [RawH264Udp]: raw H264 Annex B NAL units delivered as UDP
+ *    datagrams to [port] on any local interface. Compatible with
+ *    RubyFPV "Video Forward To USB Device: Raw (H264)" and any
+ *    similar long-range FPV ground station that doesn't expose RTSP.
+ *    Decoded by MediaCodec directly.
+ */
+sealed class VideoSource {
+    object None : VideoSource()
+    data class Rtsp(val url: String) : VideoSource()
+    data class RawH264Udp(val port: Int) : VideoSource()
+
+    val isActive: Boolean get() = this !is None
+
+    companion object {
+        fun rtsp(url: String): VideoSource =
+            if (url.isBlank()) None else Rtsp(url.trim())
+
+        fun rawH264Udp(port: Int): VideoSource =
+            if (port in 1..65535) RawH264Udp(port) else None
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/UASManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/UASManager.kt
@@ -25,6 +25,7 @@ import soy.engindearing.omnitak.mobile.data.uas.CruiseAltitude
 import soy.engindearing.omnitak.mobile.data.uas.DroneState
 import soy.engindearing.omnitak.mobile.data.uas.MavlinkConnection
 import soy.engindearing.omnitak.mobile.data.uas.MissionPhase
+import soy.engindearing.omnitak.mobile.data.uas.VideoSource
 import soy.engindearing.omnitak.mobile.data.uas.MissionStore
 import soy.engindearing.omnitak.mobile.data.uas.TerrainSampler
 import soy.engindearing.omnitak.mobile.data.uas.WaypointMission
@@ -104,11 +105,20 @@ class UASManager(
     private val _followMeActive = MutableStateFlow(false)
     val followMeActive: StateFlow<Boolean> = _followMeActive.asStateFlow()
 
-    /** Operator-supplied RTSP URL for the drone's camera. Blank = no
-     *  video PIP rendered. Set from UAS Quick Connect screen. */
-    private val _rtspUrl = MutableStateFlow("")
-    val rtspUrl: StateFlow<String> = _rtspUrl.asStateFlow()
-    fun setRtspUrl(url: String) { _rtspUrl.value = url.trim() }
+    /** Where the drone's live camera stream comes from. [VideoSource.None]
+     *  = no video PIP rendered. Set from UAS Quick Connect screen.
+     *
+     *  Two modes today:
+     *   - RTSP (operator URL) — common with off-the-shelf vehicles.
+     *   - Raw H264 UDP (port) — RubyFPV / long-range FPV ground
+     *     stations that deliver Annex B NAL units over UDP. */
+    private val _videoSource = MutableStateFlow<VideoSource>(VideoSource.None)
+    val videoSource: StateFlow<VideoSource> = _videoSource.asStateFlow()
+    fun setVideoSource(source: VideoSource) { _videoSource.value = source }
+
+    /** Convenience setter for the common RTSP case (used by the Quick
+     *  Connect screen's preset/clear buttons). */
+    fun setRtspUrl(url: String) { setVideoSource(VideoSource.rtsp(url)) }
 
     /** Soft geofence radius (meters from home) — fly-here, pursue, and
      *  missions reject targets outside this radius. 0 = disabled. Set

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/UasVideoPip.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/UasVideoPip.kt
@@ -1,14 +1,13 @@
 package soy.engindearing.omnitak.mobile.ui.components
 
-import android.view.View
+import android.view.SurfaceHolder
+import android.view.SurfaceView
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -28,7 +27,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,35 +43,34 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.common.MediaItem
-import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.rtsp.RtspMediaSource
 import androidx.media3.ui.PlayerView
+import soy.engindearing.omnitak.mobile.data.uas.RawH264UdpPlayer
+import soy.engindearing.omnitak.mobile.data.uas.VideoSource
 
 /**
- * Picture-in-picture live video for the drone camera. RTSP via
- * Media3 ExoPlayer + the RtspMediaSource. The URL is operator-supplied
- * (Settings → UAS → Video URL or per-session field on the Quick
- * Connect screen).
+ * Picture-in-picture live video for the drone camera. Two source
+ * modes are supported (see [VideoSource]):
+ *
+ *  - **RTSP** (default): Media3 ExoPlayer + RtspMediaSource. URL is
+ *    operator-supplied. RTP-over-TCP forced — UDP/RTP works on a LAN
+ *    but breaks through SSH tunnels (no UDP forwarding) and through
+ *    many home routers (inter-VLAN UDP block); TCP is universally
+ *    compatible, ~10 ms more latency, fine for ops video.
+ *  - **Raw H264 UDP**: receives Annex B NAL units over a UDP port and
+ *    decodes via MediaCodec direct-to-Surface. Used by RubyFPV and
+ *    similar long-range FPV ground stations that don't speak RTSP.
  *
  * Layout:
  *  - Compact (default): 160 × 90 dp 16:9 box, bottom-right of the map.
  *  - Expanded: 320 × 180 dp. Tap fullscreen icon to toggle.
- *  - Close icon: tears down the player and dismisses the PIP for this
+ *  - Close icon tears down the player and dismisses the PIP for this
  *    session (caller is responsible for re-showing on URL change).
- *
- * Player is paused / released on the host's onStop and resumed on
- * onStart so the RTSP socket doesn't leak when the operator backgrounds
- * the app.
- *
- * NOTE: forces RTSP TCP transport. UDP/RTP works on a LAN but breaks
- * through SSH tunnels (no UDP forwarding) and through many home
- * routers (inter-VLAN UDP block) — TCP is the universally compatible
- * choice, ~10 ms more latency, fine for ops video.
  */
 @Composable
 fun UasVideoPip(
-    rtspUrl: String,
+    source: VideoSource,
     onDismiss: () -> Unit,
     onPhoto: () -> Unit = {},
     onToggleRecord: (Boolean) -> Unit = {},
@@ -81,47 +78,11 @@ fun UasVideoPip(
     onGimbalNadir: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    if (rtspUrl.isBlank()) return
-    val context = LocalContext.current
-    val lifecycleOwner = LocalLifecycleOwner.current
+    if (!source.isActive) return
     var expanded by remember { mutableStateOf(false) }
-
-    // Build the player once per URL; rebuild on URL change.
-    val player = remember(rtspUrl) {
-        ExoPlayer.Builder(context).build().apply {
-            val factory = RtspMediaSource.Factory()
-                .setForceUseRtpTcp(true) // see note above — TCP-only RTP
-                .setTimeoutMs(8_000)
-            val mediaSource = factory.createMediaSource(MediaItem.fromUri(rtspUrl))
-            setMediaSource(mediaSource)
-            prepare()
-            playWhenReady = true
-        }
-    }
-
-    // Release the player when the URL changes or the composable leaves
-    // the composition. ExoPlayer holds native resources — the leak
-    // shows up as a "Player still active in onCleared" log.
-    DisposableEffect(player) {
-        onDispose { player.release() }
-    }
-
-    // Pause when the host goes to background so the RTSP socket doesn't
-    // chew battery; resume on foreground.
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            when (event) {
-                Lifecycle.Event.ON_STOP -> player.pause()
-                Lifecycle.Event.ON_START -> player.play()
-                else -> {}
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
-
     var recording by remember { mutableStateOf(false) }
     val widthDp = if (expanded) 320.dp else 160.dp
+
     Box(
         modifier = modifier
             .width(widthDp)
@@ -129,20 +90,12 @@ fun UasVideoPip(
             .clip(RoundedCornerShape(8.dp))
             .background(Color.Black),
     ) {
-        AndroidView(
-            modifier = Modifier.fillMaxSize(),
-            factory = { ctx ->
-                PlayerView(ctx).apply {
-                    useController = false
-                    setShowBuffering(PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
-                    this.player = player
-                }
-            },
-            update = { it.player = player },
-        )
+        when (source) {
+            is VideoSource.Rtsp -> RtspSurface(source.url, Modifier.fillMaxSize())
+            is VideoSource.RawH264Udp -> RawH264UdpSurface(source.port, Modifier.fillMaxSize())
+            is VideoSource.None -> Unit
+        }
 
-        // Live label (top-left) so the operator can tell at a glance
-        // that this is the drone camera vs a map inset.
         Box(
             modifier = Modifier
                 .align(Alignment.TopStart)
@@ -159,7 +112,6 @@ fun UasVideoPip(
             )
         }
 
-        // Recording dot indicator (top-left under LIVE) when recording.
         if (recording) {
             Box(
                 modifier = Modifier
@@ -170,7 +122,6 @@ fun UasVideoPip(
             )
         }
 
-        // Action row (top-right): expand/collapse, close.
         Row(
             modifier = Modifier.align(Alignment.TopEnd).padding(2.dp),
             horizontalArrangement = Arrangement.spacedBy(0.dp),
@@ -187,9 +138,6 @@ fun UasVideoPip(
             }
         }
 
-        // Camera / gimbal controls (bottom edge of PIP). Only show in
-        // expanded mode — the 160×90 compact size is too small for
-        // four reliable tap targets.
         if (expanded) {
             Row(
                 modifier = Modifier
@@ -222,6 +170,129 @@ fun UasVideoPip(
                 IconButton(onClick = onGimbalNadir, modifier = Modifier.size(32.dp)) {
                     Icon(Icons.Filled.PlayCircle, contentDescription = "Gimbal nadir (-90°)", tint = Color.White)
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RtspSurface(rtspUrl: String, modifier: Modifier = Modifier) {
+    if (rtspUrl.isBlank()) return
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val player = remember(rtspUrl) {
+        ExoPlayer.Builder(context).build().apply {
+            val factory = RtspMediaSource.Factory()
+                .setForceUseRtpTcp(true)
+                .setTimeoutMs(8_000)
+            setMediaSource(factory.createMediaSource(MediaItem.fromUri(rtspUrl)))
+            prepare()
+            playWhenReady = true
+        }
+    }
+
+    DisposableEffect(player) { onDispose { player.release() } }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_STOP -> player.pause()
+                Lifecycle.Event.ON_START -> player.play()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            PlayerView(ctx).apply {
+                useController = false
+                setShowBuffering(PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
+                this.player = player
+            }
+        },
+        update = { it.player = player },
+    )
+}
+
+@Composable
+private fun RawH264UdpSurface(port: Int, modifier: Modifier = Modifier) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val playerHolder = remember(port) { arrayOfNulls<RawH264UdpPlayer>(1) }
+    var lastError by remember(port) { mutableStateOf<String?>(null) }
+
+    DisposableEffect(port) {
+        onDispose {
+            playerHolder[0]?.stop()
+            playerHolder[0] = null
+        }
+    }
+
+    DisposableEffect(lifecycleOwner, port) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_STOP -> {
+                    playerHolder[0]?.stop()
+                    playerHolder[0] = null
+                }
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    Box(modifier = modifier) {
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { ctx ->
+                SurfaceView(ctx).apply {
+                    // MapLibre owns the primary SurfaceView; additional
+                    // SurfaceViews go behind it by default. Z-order this
+                    // one as a media overlay so the video PIP composes
+                    // above the map.
+                    setZOrderMediaOverlay(true)
+                    holder.addCallback(object : SurfaceHolder.Callback {
+                        override fun surfaceCreated(holder: SurfaceHolder) {
+                            playerHolder[0]?.stop()
+                            val player = RawH264UdpPlayer(
+                                port = port,
+                                surface = holder.surface,
+                                onError = { e -> lastError = e.message ?: e::class.simpleName },
+                            )
+                            playerHolder[0] = player
+                            player.start()
+                        }
+
+                        override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {}
+
+                        override fun surfaceDestroyed(holder: SurfaceHolder) {
+                            playerHolder[0]?.stop()
+                            playerHolder[0] = null
+                        }
+                    })
+                }
+            },
+        )
+        val err = lastError
+        if (err != null) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(4.dp)
+                    .background(Color(0xCC000000), RoundedCornerShape(4.dp))
+                    .padding(horizontal = 6.dp, vertical = 3.dp),
+            ) {
+                Text(
+                    text = "UDP $port — $err",
+                    color = Color(0xFFFF6B6B),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontFamily = FontFamily.Monospace,
+                )
             }
         }
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -716,10 +716,10 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             )
         }
 
-        // -------- Live video PIP — bottom-right when RTSP URL set + connected --------
-        val rtspUrl by uas.rtspUrl.collectAsState()
+        // -------- Live video PIP — bottom-right when a video source is set + connected --------
+        val videoSource by uas.videoSource.collectAsState()
         var videoVisible by remember { mutableStateOf(true) }
-        if (droneState.isConnected() && rtspUrl.isNotBlank() && videoVisible) {
+        if (droneState.isConnected() && videoSource.isActive && videoVisible) {
             androidx.compose.foundation.layout.Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -727,7 +727,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 contentAlignment = Alignment.BottomEnd,
             ) {
                 soy.engindearing.omnitak.mobile.ui.components.UasVideoPip(
-                    rtspUrl = rtspUrl,
+                    source = videoSource,
                     onDismiss = { videoVisible = false },
                     onPhoto = {
                         scope.launch { uas.takePhoto() }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/UASScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/UASScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.OmniTAKApp
 import soy.engindearing.omnitak.mobile.data.uas.MavlinkConnection
+import soy.engindearing.omnitak.mobile.data.uas.VideoSource
 import soy.engindearing.omnitak.mobile.ui.theme.HostileRed
 import soy.engindearing.omnitak.mobile.ui.theme.NeutralYellow
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
@@ -85,8 +86,24 @@ fun UASScreen(onDone: () -> Unit) {
     var portText by remember { mutableStateOf("14550") }
     var callsign by remember { mutableStateOf("OmniTAK-UAS") }
 
-    val currentRtsp by uas.rtspUrl.collectAsState()
-    var rtspText by remember(currentRtsp) { mutableStateOf(currentRtsp) }
+    val currentSource by uas.videoSource.collectAsState()
+    var rtspText by remember(currentSource) {
+        mutableStateOf((currentSource as? VideoSource.Rtsp)?.url.orEmpty())
+    }
+    var udpPortText by remember(currentSource) {
+        mutableStateOf(((currentSource as? VideoSource.RawH264Udp)?.port ?: 5000).toString())
+    }
+    // Picker mode is sticky to whatever source is active (or RTSP as a
+    // default). Switching the chip rewrites uas.videoSource immediately
+    // so the PIP re-binds without an explicit "apply".
+    var videoMode by remember {
+        mutableStateOf(
+            when (currentSource) {
+                is VideoSource.RawH264Udp -> VideoMode.RawH264Udp
+                else -> VideoMode.Rtsp
+            },
+        )
+    }
     val currentGeofence by uas.geofenceMeters.collectAsState()
     var geofenceText by remember(currentGeofence) { mutableStateOf(currentGeofence.toString()) }
     val failsafes by uas.failsafeParams.collectAsState()
@@ -218,25 +235,106 @@ fun UASScreen(onDone: () -> Unit) {
             HorizontalDivider(color = TacticalSurface)
 
             // -------- Live video (optional) --------
-            TextField(
-                value = rtspText,
-                onValueChange = { rtspText = it.trim(); uas.setRtspUrl(rtspText) },
-                label = { Text("Video URL (RTSP)") },
-                placeholder = { Text("rtsp://10.0.2.2:8555/test  •  blank to hide") },
-                singleLine = true,
+            // Source picker. RTSP is the historical default; Raw H264
+            // UDP supports RubyFPV and similar long-range FPV ground
+            // stations that don't expose RTSP (issue #55).
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-            )
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = {
-                    rtspText = "rtsp://10.0.2.2:8555/test"
-                    uas.setRtspUrl(rtspText)
-                }) { Text("Use SITL test stream") }
-                if (rtspText.isNotBlank()) {
-                    OutlinedButton(onClick = {
-                        rtspText = ""
-                        uas.setRtspUrl("")
-                    }) { Text("Clear", color = HostileRed) }
+            ) {
+                Text(
+                    "Video",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                )
+                FilterChip(
+                    selected = videoMode == VideoMode.Rtsp,
+                    onClick = {
+                        videoMode = VideoMode.Rtsp
+                        uas.setVideoSource(VideoSource.rtsp(rtspText))
+                    },
+                    label = { Text("RTSP") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = TacticalAccent,
+                        selectedLabelColor = TacticalBackground,
+                    ),
+                )
+                FilterChip(
+                    selected = videoMode == VideoMode.RawH264Udp,
+                    onClick = {
+                        videoMode = VideoMode.RawH264Udp
+                        val port = udpPortText.toIntOrNull() ?: 5000
+                        uas.setVideoSource(VideoSource.rawH264Udp(port))
+                    },
+                    label = { Text("Raw H264 UDP") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = TacticalAccent,
+                        selectedLabelColor = TacticalBackground,
+                    ),
+                )
+            }
+
+            when (videoMode) {
+                VideoMode.Rtsp -> {
+                    TextField(
+                        value = rtspText,
+                        onValueChange = {
+                            rtspText = it.trim()
+                            uas.setVideoSource(VideoSource.rtsp(rtspText))
+                        },
+                        label = { Text("Video URL (RTSP)") },
+                        placeholder = { Text("rtsp://10.0.2.2:8555/test  •  blank to hide") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(onClick = {
+                            rtspText = "rtsp://10.0.2.2:8555/test"
+                            uas.setVideoSource(VideoSource.rtsp(rtspText))
+                        }) { Text("Use SITL test stream") }
+                        if (rtspText.isNotBlank()) {
+                            OutlinedButton(onClick = {
+                                rtspText = ""
+                                uas.setVideoSource(VideoSource.None)
+                            }) { Text("Clear", color = HostileRed) }
+                        }
+                    }
+                }
+                VideoMode.RawH264Udp -> {
+                    TextField(
+                        value = udpPortText,
+                        onValueChange = {
+                            udpPortText = it.filter(Char::isDigit).take(5)
+                            val port = udpPortText.toIntOrNull() ?: 0
+                            uas.setVideoSource(VideoSource.rawH264Udp(port))
+                        },
+                        label = { Text("UDP port") },
+                        placeholder = { Text("5000 — RubyFPV default") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    )
+                    Text(
+                        "Raw H264 Annex B over UDP. Compatible with RubyFPV " +
+                            "\"Video Forward To USB Device: Raw (H264)\" and similar long-range " +
+                            "FPV ground stations. Bind to 0.0.0.0 on this port — USB tether, " +
+                            "Wi-Fi, and direct LAN all work.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(onClick = {
+                            udpPortText = "5000"
+                            uas.setVideoSource(VideoSource.rawH264Udp(5000))
+                        }) { Text("RubyFPV default (5000)") }
+                        if (currentSource is VideoSource.RawH264Udp) {
+                            OutlinedButton(onClick = {
+                                uas.setVideoSource(VideoSource.None)
+                            }) { Text("Stop", color = HostileRed) }
+                        }
+                    }
                 }
             }
 
@@ -362,3 +460,9 @@ private fun CommandBtn(
         ),
     ) { Text(label) }
 }
+
+/** UI-only picker state — what kind of video source the operator is
+ *  currently editing. Mapped to [VideoSource] when the operator
+ *  applies the chip / fills the field. */
+private enum class VideoMode { Rtsp, RawH264Udp }
+

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/uas/H264NalSplitterTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/uas/H264NalSplitterTest.kt
@@ -1,0 +1,105 @@
+package soy.engindearing.omnitak.mobile.data.uas
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class H264NalSplitterTest {
+    private fun b(vararg ints: Int): ByteArray = ByteArray(ints.size) { ints[it].toByte() }
+
+    @Test fun `single complete nal followed by start code emits one nal`() {
+        val splitter = H264NalSplitter()
+        // [sc, A, B, sc, C] — first NAL closes when second sc arrives
+        val out = splitter.push(b(0x00, 0x00, 0x01, 0xAA, 0xBB, 0x00, 0x00, 0x01, 0xCC))
+        assertEquals(1, out.size)
+        assertArrayEquals(b(0xAA, 0xBB), out[0])
+    }
+
+    @Test fun `incomplete first nal emits nothing`() {
+        val splitter = H264NalSplitter()
+        val out = splitter.push(b(0x00, 0x00, 0x01, 0xAA, 0xBB))
+        assertTrue(out.isEmpty())
+    }
+
+    @Test fun `nal split across two pushes emits on the second`() {
+        val splitter = H264NalSplitter()
+        assertTrue(splitter.push(b(0x00, 0x00, 0x01, 0xAA, 0xBB)).isEmpty())
+        val out = splitter.push(b(0xCC, 0x00, 0x00, 0x01, 0xDD))
+        assertEquals(1, out.size)
+        assertArrayEquals(b(0xAA, 0xBB, 0xCC), out[0])
+    }
+
+    @Test fun `start code straddling chunk boundary is detected`() {
+        val splitter = H264NalSplitter()
+        // First chunk ends mid-start-code; second chunk completes it.
+        // Combined stream: [sc, AA, sc, BB, sc, CC] — AA and BB
+        // complete after push2; CC is still in-progress.
+        assertTrue(splitter.push(b(0x00, 0x00, 0x01, 0xAA, 0x00, 0x00)).isEmpty())
+        val out = splitter.push(b(0x01, 0xBB, 0x00, 0x00, 0x01, 0xCC))
+        assertEquals(2, out.size)
+        assertArrayEquals(b(0xAA), out[0])
+        assertArrayEquals(b(0xBB), out[1])
+    }
+
+    @Test fun `four byte start codes recognized as single start code`() {
+        val splitter = H264NalSplitter()
+        // 4-byte sc, N1, 4-byte sc, N2, 3-byte sc (closing N2)
+        val out = splitter.push(
+            b(
+                0x00, 0x00, 0x00, 0x01, 0x11,
+                0x00, 0x00, 0x00, 0x01, 0x22,
+                0x00, 0x00, 0x01, 0x33,
+            ),
+        )
+        assertEquals(2, out.size)
+        assertArrayEquals(b(0x11), out[0])
+        assertArrayEquals(b(0x22), out[1])
+    }
+
+    @Test fun `garbage before first start code is discarded`() {
+        val splitter = H264NalSplitter()
+        val out = splitter.push(b(0xFF, 0xFE, 0xFD, 0x00, 0x00, 0x01, 0xAA, 0x00, 0x00, 0x01, 0xBB))
+        assertEquals(1, out.size)
+        assertArrayEquals(b(0xAA), out[0])
+    }
+
+    @Test fun `many small chunks one byte at a time still produce correct nals`() {
+        val splitter = H264NalSplitter()
+        val full = b(
+            0x00, 0x00, 0x01, 0xAA, 0xBB,
+            0x00, 0x00, 0x01, 0xCC, 0xDD, 0xEE,
+            0x00, 0x00, 0x01, 0xFF,
+        )
+        val collected = mutableListOf<ByteArray>()
+        for (i in full.indices) {
+            collected += splitter.push(full, i, 1)
+        }
+        assertEquals(2, collected.size)
+        assertArrayEquals(b(0xAA, 0xBB), collected[0])
+        assertArrayEquals(b(0xCC, 0xDD, 0xEE), collected[1])
+    }
+
+    @Test fun `reset clears state`() {
+        val splitter = H264NalSplitter()
+        splitter.push(b(0x00, 0x00, 0x01, 0xAA))
+        splitter.reset()
+        val out = splitter.push(b(0xBB, 0x00, 0x00, 0x01, 0xCC, 0x00, 0x00, 0x01))
+        // Bytes before the first post-reset start code are discarded.
+        assertEquals(1, out.size)
+        assertArrayEquals(b(0xCC), out[0])
+    }
+
+    @Test fun `trailing zero before start code is treated as 4 byte sc not nal payload`() {
+        val splitter = H264NalSplitter()
+        // [sc, A, B, 00, 00, 00, 01, C, sc] — the 0x00 before the
+        // canonical 00 00 01 is cabac padding, not part of NAL1.
+        // NAL1 should emit as just [A, B] (no trailing 0).
+        val out = splitter.push(
+            b(0x00, 0x00, 0x01, 0xAA, 0xBB, 0x00, 0x00, 0x00, 0x01, 0xCC, 0x00, 0x00, 0x01),
+        )
+        assertEquals(2, out.size)
+        assertArrayEquals(b(0xAA, 0xBB), out[0])
+        assertArrayEquals(b(0xCC), out[1])
+    }
+}


### PR DESCRIPTION
Closes #55.

## What

OmniTAK's UAS video PIP was RTSP-only. This adds a second backend: raw H264 Annex B over UDP, decoded directly by MediaCodec. Wired up because a Discord tester (Foxbat, MESH) hit a wall running RubyFPV on a Pi ground station — RubyFPV's "Video Forward To USB Device: Raw (H264)" mode emits raw NAL units over UDP, with no RTSP option.

## Architecture

```
VideoSource (sealed)
  ├── None
  ├── Rtsp(url)                    → ExoPlayer + RtspMediaSource (existing)
  └── RawH264Udp(port)             → RawH264UdpPlayer (new)
```

`RawH264UdpPlayer` chain:
- `DatagramSocket` bound to `0.0.0.0:port` — works for USB-RNDIS tether, Wi-Fi, or LAN
- `H264NalSplitter` reframes NAL units across UDP packet boundaries (3/4-byte start codes, cabac padding)
- `SpsParser` reads dimensions from the first SPS
- `MediaCodec` H264 decoder rendering direct-to-Surface
- `SurfaceView` with `setZOrderMediaOverlay(true)` so it composes above MapLibre's primary SurfaceView

`UASScreen` gains a FilterChip picker (RTSP / Raw H264 UDP) with a dynamic field — URL field for RTSP, port field for Raw. Default port is 5000, matching RubyFPV's USB Port Number default.

## Verification

- ✅ `./gradlew :app:assembleDebug` — clean
- ✅ `./gradlew :app:testDebugUnitTest` — 9 splitter tests pass (straddling packets, 3/4-byte start codes, byte-at-a-time chunks, cabac padding, reset)
- ✅ End-to-end on emulator (Android 14, `c2.goldfish.h264.decoder`):
  - `pymavlink` heartbeat sender → drone shows as connected
  - `ffmpeg -re -f lavfi -i testsrc -c:v libx264 -profile:v baseline -bsf:v h264_mp4toannexb -f h264 'udp://127.0.0.1:5000?pkt_size=1024'` → forwarded via emulator console `redir add udp:5000:5000` → live testsrc rainbow pattern rendering in the PIP

## Notes for reviewers

- **The Kotlin `apply` gotcha at `RawH264UdpPlayer:54`** — `DatagramSocket(null).apply { bind(InetSocketAddress(port)) }` resolves `port` to `DatagramSocket.getPort()` (= -1 unbound), shadowing the ctor param. Fixed by capturing into a local `val bindPort = port` before the apply scope. Comment in code explains.
- **Z-order**: a second SurfaceView on the same window defaults *behind* the first. `setZOrderMediaOverlay(true)` puts the PIP above MapLibre.
- **Cleanup**: original RTSP path is intact; just lifted into a private `RtspSurface` composable inside `UasVideoPip`.
- iOS parity tracking issue will follow in OmniTAK-iOS.

## Follow-ups (not in this PR)

- Persist `videoSource` across app restarts (today it's in-memory like `rtspUrl` was)
- MPEG-TS over UDP as a third backend if anyone asks
- iOS parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)