### PR TITLE
chore: release 0.33.1 (vc83)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 82
-        versionName = "0.33.0"
+        versionCode = 83
+        versionName = "0.33.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactLayer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactLayer.kt
@@ -6,7 +6,6 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.maplibre.android.maps.MapLibreMap
 import org.maplibre.android.style.sources.GeoJsonSource
-import org.maplibre.geojson.FeatureCollection
 import soy.engindearing.omnitak.mobile.data.CoTAffiliation
 import soy.engindearing.omnitak.mobile.data.CoTEvent
 
@@ -23,6 +22,13 @@ import soy.engindearing.omnitak.mobile.data.CoTEvent
  * report from P-E on TAK Discord 2026-05-27. This path mirrors how AircraftLayer
  * feeds the aircraft-src source and is consistent with the inline-style approach
  * that avoids the MapLibre-Android addLayer GL quirk on Adreno 610.
+ *
+ * NOTE on setGeoJson path: we call `GeoJsonSource.setGeoJson(String)` directly
+ * rather than `setGeoJson(FeatureCollection.fromJson(...))`. The FeatureCollection
+ * overload has a null-guard that silently no-ops when `features()` returns null
+ * (which Gson-based fromJson can produce for malformed input), and then calls
+ * nativeSetFeatureCollection(null) — rendering nothing. The String overload calls
+ * nativeSetGeoJsonString directly, bypassing the Java-layer guard entirely.
  *
  * [previewColor] is kept for callers (e.g. MarkerEditSheet) that need an
  * affiliation color outside the map.
@@ -45,19 +51,24 @@ object ContactLayer {
             Log.w(TAG, "contacts-src not found in style — skipping update")
             return
         }
-        val fc = toFeatureCollection(contacts)
-        src.setGeoJson(FeatureCollection.fromJson(fc.toString()))
+
+        val fcJson = toFeatureCollectionJson(contacts)
+
+        // Use the String overload — goes straight to nativeSetGeoJsonString, bypasses
+        // the FeatureCollection Java-layer null-guard that can silently no-op.
+        src.setGeoJson(fcJson)
+
         if (contacts.isNotEmpty()) {
-            Log.d(TAG, "pushed ${contacts.size} contacts to $SOURCE_ID")
+            Log.i(TAG, "pushed ${contacts.size} contacts to $SOURCE_ID")
         }
     }
 
     fun clear(map: MapLibreMap) {
         val src = map.style?.getSourceAs<GeoJsonSource>(SOURCE_ID) ?: return
-        src.setGeoJson(FeatureCollection.fromJson("""{"type":"FeatureCollection","features":[]}"""))
+        src.setGeoJson("""{"type":"FeatureCollection","features":[]}""")
     }
 
-    private fun toFeatureCollection(contacts: Collection<CoTEvent>): JSONObject {
+    private fun toFeatureCollectionJson(contacts: Collection<CoTEvent>): String {
         val features = JSONArray()
         for (c in contacts) {
             if (c.lat.isNaN() || c.lon.isNaN()) continue
@@ -66,6 +77,7 @@ object ContactLayer {
         return JSONObject()
             .put("type", "FeatureCollection")
             .put("features", features)
+            .toString()
     }
 
     private fun featureFor(c: CoTEvent): JSONObject {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
@@ -186,11 +186,6 @@ class ContactSymbolLayer {
         val bitmap = MilStdIconCache.bitmapFor(context, cotType, ICON_PIXEL_SIZE)
             ?: MilStdIconCache.bitmapFor(context, "a-u-A", ICON_PIXEL_SIZE)
             ?: run {
-                // Both the specific SIDC and the unknown-air fallback
-                // failed to rasterise — should be unreachable since
-                // the floor 108-entry asset bundle is part of the apk.
-                // Log + skip so a missing-asset regression doesn't
-                // crash the layer.
                 Log.w(TAG, "no bitmap available for sidc=$sidc; skipping addImage")
                 return false
             }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -104,6 +104,13 @@ fun TacticalMap(
     val currentStyleReady by rememberUpdatedState(onStyleReady)
     val currentTerrain3d by rememberUpdatedState(terrain3d)
 
+    // ContactSymbolLayer uses Style.addImage (bitmap) + SymbolLayer — the path
+    // LocationComponent uses and that renders on Adreno 610 / SwiftShader when
+    // CircleLayer circle-color expressions silently fail (GL fragment pipeline bug).
+    // Keyed on styleJson so a basemap swap (style reload) gets a fresh instance
+    // with a clean installed=false state.
+    val contactSymbolLayer = remember(styleJson) { ContactSymbolLayer() }
+
     val mapView = remember {
         MapLibre.getInstance(context)
         MapView(context).apply {
@@ -119,6 +126,12 @@ fun TacticalMap(
                     .build()
                 map.setStyle(Style.Builder().fromJson(styleJson)) { style ->
                     ContactLayer.update(map, context, currentContacts)
+                    // Install bitmap-icon symbol layer alongside the inline circle layer.
+                    // The CircleLayer circle-color expression silently fails on Adreno 610
+                    // and SwiftShader — ContactSymbolLayer uses Style.addImage (the same
+                    // path LocationComponent uses) which renders correctly on both drivers.
+                    contactSymbolLayer.installInto(style, context)
+                    contactSymbolLayer.update(map, context, currentContacts)
                     MeasurementLayer.update(map, currentMeasurementPoints)
                     DrawingLayer.update(map, currentDrawings)
                     currentGridCenter?.let { GridLayer.update(map, it) }
@@ -259,7 +272,10 @@ fun TacticalMap(
     // caller's collection reference changes.
     DisposableEffect(mapView, contacts) {
         mapView.getMapAsync { map ->
-            if (map.style != null) ContactLayer.update(map, context, contacts)
+            if (map.style != null) {
+                ContactLayer.update(map, context, contacts)
+                contactSymbolLayer.update(map, context, contacts)
+            }
         }
         onDispose { }
     }
@@ -275,6 +291,8 @@ fun TacticalMap(
             if (map.style != null && map.style?.json != styleJson) {
                 map.setStyle(Style.Builder().fromJson(styleJson)) { style ->
                     ContactLayer.update(map, context, currentContacts)
+                    contactSymbolLayer.installInto(style, context)
+                    contactSymbolLayer.update(map, context, currentContacts)
                     MeasurementLayer.update(map, currentMeasurementPoints)
                     DrawingLayer.update(map, currentDrawings)
                     currentGridCenter?.let { GridLayer.update(map, it) }
@@ -666,7 +684,7 @@ private const val TACTICAL_STYLE_OVERLAYS = """,
         "circle-radius": 10,
         "circle-stroke-width": 2,
         "circle-stroke-color": "#0A1628",
-        "circle-color": ["coalesce", ["get", "color"], "#B39DDB"]
+        "circle-color": ["to-color", ["coalesce", ["get", "color"], "#B39DDB"]]
       }
     },
     {


### PR DESCRIPTION
Version bump following fix #57 (contacts/markers render on Adreno 610 / SwiftShader).

- versionName: 0.33.0 → 0.33.1
- versionCode: 82 → 83

Artifacts staged locally at `playstore-assets/OmniTAK-0.33.1-vc83.aab` (46 MB) and `OmniTAK-0.33.1-vc83.apk` (58 MB). Both are .gitignored — upload AAB to Play Console manually.