### PR TITLE
feat(uas): MPEG-TS UDP video + low-latency MediaCodec tuning

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/RawH264UdpPlayer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/RawH264UdpPlayer.kt
@@ -146,6 +146,17 @@ class RawH264UdpPlayer(
                 // csd-0 and csd-1 must include the start code prefix.
                 setByteBuffer("csd-0", ByteBuffer.wrap(withStartCode(s)))
                 setByteBuffer("csd-1", ByteBuffer.wrap(withStartCode(p)))
+                // Low-latency hints. Hint 1: tell the codec to buy a
+                // single input buffer instead of the default 4–5,
+                // trading throughput for end-to-end latency — right
+                // call for live FPV. Some codecs honor KEY_LATENCY,
+                // some only honor KEY_LOW_LATENCY (API 30+); set both
+                // and let the decoder pick. Silently ignored by codec
+                // impls that don't support either, so no harm.
+                setInteger(MediaFormat.KEY_LATENCY, 1)
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                    setInteger(MediaFormat.KEY_LOW_LATENCY, 1)
+                }
             }
             val c = MediaCodec.createDecoderByType(MediaFormat.MIMETYPE_VIDEO_AVC)
             c.configure(format, surface, null, 0)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/VideoSource.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/uas/VideoSource.kt
@@ -12,11 +12,17 @@ package soy.engindearing.omnitak.mobile.data.uas
  *    RubyFPV "Video Forward To USB Device: Raw (H264)" and any
  *    similar long-range FPV ground station that doesn't expose RTSP.
  *    Decoded by MediaCodec directly.
+ *  - [MpegTsUdp]: H264 elementary stream wrapped in MPEG-TS, delivered
+ *    as UDP datagrams to [port]. This is what ATAK UAS Tool consumes
+ *    and what RubyFPV operators produce via the canonical gstreamer
+ *    pipeline (h264parse → mpegtsmux → udpsink). Decoded by Media3
+ *    ExoPlayer + UdpDataSource + TsExtractor.
  */
 sealed class VideoSource {
     object None : VideoSource()
     data class Rtsp(val url: String) : VideoSource()
     data class RawH264Udp(val port: Int) : VideoSource()
+    data class MpegTsUdp(val port: Int) : VideoSource()
 
     val isActive: Boolean get() = this !is None
 
@@ -26,5 +32,8 @@ sealed class VideoSource {
 
         fun rawH264Udp(port: Int): VideoSource =
             if (port in 1..65535) RawH264Udp(port) else None
+
+        fun mpegTsUdp(port: Int): VideoSource =
+            if (port in 1..65535) MpegTsUdp(port) else None
     }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/UasVideoPip.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/UasVideoPip.kt
@@ -43,8 +43,15 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.common.MediaItem
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.UdpDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.rtsp.RtspMediaSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory
+import androidx.media3.extractor.ts.TsExtractor
 import androidx.media3.ui.PlayerView
 import soy.engindearing.omnitak.mobile.data.uas.RawH264UdpPlayer
 import soy.engindearing.omnitak.mobile.data.uas.VideoSource
@@ -93,6 +100,7 @@ fun UasVideoPip(
         when (source) {
             is VideoSource.Rtsp -> RtspSurface(source.url, Modifier.fillMaxSize())
             is VideoSource.RawH264Udp -> RawH264UdpSurface(source.port, Modifier.fillMaxSize())
+            is VideoSource.MpegTsUdp -> MpegTsUdpSurface(source.port, Modifier.fillMaxSize())
             is VideoSource.None -> Unit
         }
 
@@ -296,4 +304,77 @@ private fun RawH264UdpSurface(port: Int, modifier: Modifier = Modifier) {
             }
         }
     }
+}
+
+/**
+ * MPEG-TS over UDP video receiver. Wraps Media3 ExoPlayer with a
+ * [UdpDataSource] data source and a [TsExtractor] so an ATAK-UAS-Tool /
+ * RubyFPV gstreamer pipeline ("h264parse → mpegtsmux → udpsink") plays
+ * directly with no glue on the operator's side.
+ *
+ * Load control is tightened from the ExoPlayer defaults — for a live
+ * UDP feed we want ~50 ms target buffer, not the 2 s default — so the
+ * end-to-end latency stays under 200 ms when the network is clean.
+ */
+@Composable
+private fun MpegTsUdpSurface(port: Int, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val player = remember(port) {
+        val loadControl = DefaultLoadControl.Builder()
+            // (minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs)
+            // Aggressive low-latency tuning — drop frames over rebuffering.
+            .setBufferDurationsMs(50, 250, 50, 50)
+            .build()
+        val udpFactory = DataSource.Factory {
+            // UdpDataSource(maxPacketSize) — 4096 is enough for MPEG-TS
+            // packets (typically 188 × N per datagram, max 1500 MTU).
+            UdpDataSource(/* maxPacketSize = */ 4096)
+        }
+        val extractorsFactory = DefaultExtractorsFactory()
+            .setTsExtractorMode(TsExtractor.MODE_SINGLE_PMT)
+            // Allow non-IDR keyframes — RubyFPV / gst pipelines often
+            // emit MPEG-TS without strict IDR markers, and ExoPlayer's
+            // default behavior is to refuse to start playback until it
+            // sees one. With this flag it accepts any I-slice as the
+            // first decodable frame.
+            .setTsExtractorFlags(DefaultTsPayloadReaderFactory.FLAG_ALLOW_NON_IDR_KEYFRAMES)
+        val mediaSource = ProgressiveMediaSource.Factory(udpFactory, extractorsFactory)
+            .createMediaSource(MediaItem.fromUri("udp://0.0.0.0:$port"))
+        ExoPlayer.Builder(context)
+            .setLoadControl(loadControl)
+            .build()
+            .apply {
+                setMediaSource(mediaSource)
+                prepare()
+                playWhenReady = true
+            }
+    }
+
+    DisposableEffect(player) { onDispose { player.release() } }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_STOP -> player.pause()
+                Lifecycle.Event.ON_START -> player.play()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            PlayerView(ctx).apply {
+                useController = false
+                setShowBuffering(PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
+                this.player = player
+            }
+        },
+        update = { it.player = player },
+    )
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/UASScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/UASScreen.kt
@@ -93,6 +93,9 @@ fun UASScreen(onDone: () -> Unit) {
     var udpPortText by remember(currentSource) {
         mutableStateOf(((currentSource as? VideoSource.RawH264Udp)?.port ?: 5000).toString())
     }
+    var tsUdpPortText by remember(currentSource) {
+        mutableStateOf(((currentSource as? VideoSource.MpegTsUdp)?.port ?: 5010).toString())
+    }
     // Picker mode is sticky to whatever source is active (or RTSP as a
     // default). Switching the chip rewrites uas.videoSource immediately
     // so the PIP re-binds without an explicit "apply".
@@ -100,6 +103,7 @@ fun UASScreen(onDone: () -> Unit) {
         mutableStateOf(
             when (currentSource) {
                 is VideoSource.RawH264Udp -> VideoMode.RawH264Udp
+                is VideoSource.MpegTsUdp -> VideoMode.MpegTsUdp
                 else -> VideoMode.Rtsp
             },
         )
@@ -273,6 +277,19 @@ fun UASScreen(onDone: () -> Unit) {
                         selectedLabelColor = TacticalBackground,
                     ),
                 )
+                FilterChip(
+                    selected = videoMode == VideoMode.MpegTsUdp,
+                    onClick = {
+                        videoMode = VideoMode.MpegTsUdp
+                        val port = tsUdpPortText.toIntOrNull() ?: 5010
+                        uas.setVideoSource(VideoSource.mpegTsUdp(port))
+                    },
+                    label = { Text("MPEG-TS UDP") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = TacticalAccent,
+                        selectedLabelColor = TacticalBackground,
+                    ),
+                )
             }
 
             when (videoMode) {
@@ -330,6 +347,40 @@ fun UASScreen(onDone: () -> Unit) {
                             uas.setVideoSource(VideoSource.rawH264Udp(5000))
                         }) { Text("RubyFPV default (5000)") }
                         if (currentSource is VideoSource.RawH264Udp) {
+                            OutlinedButton(onClick = {
+                                uas.setVideoSource(VideoSource.None)
+                            }) { Text("Stop", color = HostileRed) }
+                        }
+                    }
+                }
+                VideoMode.MpegTsUdp -> {
+                    TextField(
+                        value = tsUdpPortText,
+                        onValueChange = {
+                            tsUdpPortText = it.filter(Char::isDigit).take(5)
+                            val port = tsUdpPortText.toIntOrNull() ?: 0
+                            uas.setVideoSource(VideoSource.mpegTsUdp(port))
+                        },
+                        label = { Text("UDP port") },
+                        placeholder = { Text("5010 — canonical RubyFPV/gst pipeline") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    )
+                    Text(
+                        "MPEG-TS over UDP. Same wire format ATAK UAS Tool accepts. " +
+                            "Use this with the canonical RubyFPV pipeline " +
+                            "(h264parse → mpegtsmux → udpsink). Decoded by ExoPlayer + " +
+                            "TsExtractor with non-IDR keyframe tolerance.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(onClick = {
+                            tsUdpPortText = "5010"
+                            uas.setVideoSource(VideoSource.mpegTsUdp(5010))
+                        }) { Text("ATAK/gst default (5010)") }
+                        if (currentSource is VideoSource.MpegTsUdp) {
                             OutlinedButton(onClick = {
                                 uas.setVideoSource(VideoSource.None)
                             }) { Text("Stop", color = HostileRed) }
@@ -464,5 +515,5 @@ private fun CommandBtn(
 /** UI-only picker state — what kind of video source the operator is
  *  currently editing. Mapped to [VideoSource] when the operator
  *  applies the chip / fills the field. */
-private enum class VideoMode { Rtsp, RawH264Udp }
+private enum class VideoMode { Rtsp, RawH264Udp, MpegTsUdp }
 


### PR DESCRIPTION
Closes #60 (MPEG-TS UDP backend), closes #61 (low-latency tuning).

## Context

Foxbat (Discord, MESH) found his own path to RubyFPV video on **ATAK UAS Tool**: a gstreamer pipeline on the Pi that emits MPEG-TS over UDP, which ATAK accepts. OmniTAK's pipe didn't accept MPEG-TS — only RTSP (since day one) and Raw H264 UDP (added in #56). This PR closes the parity gap and tunes both UDP paths for live FPV latency.

## What ships

**MPEG-TS over UDP (third VideoSource backend)**
- `VideoSource.MpegTsUdp(port)` sealed-class case
- `MpegTsUdpSurface` composable using Media3 ExoPlayer + `UdpDataSource` + `ProgressiveMediaSource` with `TsExtractor`
- `TsExtractor.MODE_SINGLE_PMT` + `FLAG_ALLOW_NON_IDR_KEYFRAMES` so gst-emitted streams without strict IDR markers play
- Tight `DefaultLoadControl` buffer (50, 250, 50, 50) — drops frames over rebuffering, targets ~200 ms end-to-end
- UASScreen gains a third FilterChip with port 5010 default (matches Foxbat's pipeline) and ATAK-parity descriptor copy

**Low-latency MediaCodec tuning (raw H264 path)**
- `MediaFormat.KEY_LATENCY = 1` always
- `MediaFormat.KEY_LOW_LATENCY = 1` on API 30+ (Android 11+)
- Cuts ~2-3 frames of decoder buffer. Silently ignored by codec impls that don't support either, so no harm.

## Verification

- ✅ `./gradlew :app:assembleDebug :app:testDebugUnitTest` — clean
- ✅ End-to-end on emulator (Android 14, `c2.goldfish.h264.decoder`):
  ```
  ffmpeg -re -f lavfi -i testsrc -c:v libx264 -tune zerolatency -profile:v baseline \
    -x264-params "keyint=30:repeat-headers=1" -f mpegts udp://127.0.0.1:5010?pkt_size=1316
  ```
  → emulator console `redir add udp:5010:5010` → ExoPlayer pulls via UdpDataSource → TsExtractor demuxes → MediaCodec renders the testsrc rainbow in the PIP
- ✅ Raw H264 UDP path still decodes (regression check) — `KEY_LATENCY` keys are additive

## Notes for reviewers

- `FLAG_ALLOW_NON_IDR_KEYFRAMES` is on `DefaultTsPayloadReaderFactory`, not `TsExtractor` (one of those Media3 import-where-you-don't-expect things)
- Default port 5010 was chosen to match Foxbat's working gstreamer pipeline, not arbitrary
- iOS parity issue (OmniTAK-iOS#40) covers Raw H264 UDP; will add MPEG-TS to that scope on the iOS side too

## Follow-ups (not in this PR)

- Persist `videoSource` across app restarts (in-memory today)
- ExoPlayer `KEY_LOW_LATENCY` hint via track selector parameters for the MPEG-TS path on API 30+
- iOS MPEG-TS UDP via `VTDecompressionSession` + AVFoundation MPEG-TS reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)