### PR TITLE
feat(mesh): off-grid PPLI + GeoChat over Meshtastic (Phase 1)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -25,6 +27,8 @@ import soy.engindearing.omnitak.mobile.domain.DataPackageBootstrap
 import soy.engindearing.omnitak.mobile.domain.DrawingStore
 import soy.engindearing.omnitak.mobile.domain.MapCameraStore
 import soy.engindearing.omnitak.mobile.domain.MeshtasticCoTBridge
+import soy.engindearing.omnitak.mobile.domain.MeshCoTRouter
+import soy.engindearing.omnitak.mobile.domain.SelfPositionBroadcaster
 import soy.engindearing.omnitak.mobile.domain.TAKConnectionService
 import soy.engindearing.omnitak.mobile.domain.MeshtasticManager
 import soy.engindearing.omnitak.mobile.domain.ServerManager
@@ -45,6 +49,12 @@ class OmniTAKApp : Application() {
         // Touches `serverManager` (and through it `userPrefsStore`,
         // `certVault`), so kicking it off here also wakes those lazies.
         DataPackageBootstrap(this, certVault, serverManager).runIfNeeded()
+
+        // Eagerly populate cachedPrefs so non-suspend sinks (cotSink,
+        // mesh broadcast toggles) can read prefs.value immediately.
+        appScope.launch {
+            userPrefsStore.prefs.collect { cachedPrefs.value = it }
+        }
 
         // Issue #5 — start a foreground service while we're holding a
         // connection so Doze doesn't kill the read loop within ~10s of
@@ -92,6 +102,30 @@ class OmniTAKApp : Application() {
             mapCameraStore.seedFromPrefs(saved)
         }
 
+        // Off-grid mesh plan Step 1b — broadcaster is now owned here so it
+        // starts when EITHER a TAK server OR Meshtastic radio is connected.
+        // ServerManager's own startPliBroadcast/stopPliBroadcast is kept
+        // for the server-PPLI path; the app-level broadcaster handles the
+        // COMBINED (server + mesh) lifecycle with mesh TX wired in.
+        // distinctUntilChanged on the derived bool avoids spurious restarts.
+        appScope.launch {
+            combine(
+                serverManager.connectionState,
+                meshtastic.activeConnectionState,
+            ) { serverState, meshState ->
+                serverState is ConnectionState.Connected ||
+                    meshState is ConnectionState.Connected
+            }
+                .distinctUntilChanged()
+                .collect { eitherConnected ->
+                    if (eitherConnected) {
+                        startAppBroadcaster()
+                    } else {
+                        stopAppBroadcaster()
+                    }
+                }
+        }
+
         // Phase 2 of the gy6 plan — FAA Remote ID BLE scanner.
         // Lifecycle is driven by `remoteIdScanEnabled` so operators can
         // opt out of the always-on BLE scan (battery cost). When a
@@ -135,6 +169,10 @@ class OmniTAKApp : Application() {
     // Application-scoped singletons. Screens reach these via
     // LocalContext.current.applicationContext as OmniTAKApp.
     private val appScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    // Eagerly-cached prefs snapshot for non-suspending sinks (cotSink,
+    // mesh broadcast lambdas). Initialized to defaults until DataStore emits.
+    private val cachedPrefs = MutableStateFlow(soy.engindearing.omnitak.mobile.data.UserPrefs())
     val contactStore: ContactStore by lazy { ContactStore() }
     val drawingStore: DrawingStore by lazy { DrawingStore() }
     val mapCameraStore: MapCameraStore by lazy { MapCameraStore(userPrefsStore) }
@@ -153,7 +191,51 @@ class OmniTAKApp : Application() {
             // Phase 4: portnum-72 ATAK-plugin payloads decode straight
             // into CoT events; route them into the same ingest sink the
             // node-table bridge uses so they surface as map contacts.
-            mgr.cotSink = { event -> contactStore.ingest(event) }
+            // Off-grid Phase 1 Step 3: b-t-f events are GeoChat and must
+            // route to chatStore, not contactStore. Self-echo is dropped
+            // (events from our own UID would double-display — mirrors iOS).
+            mgr.cotSink = { event ->
+                // Drop self-echo: skip events whose UID or callsign matches ours.
+                // Uses cachedPrefs.value (non-suspending) since cotSink is a
+                // plain lambda invoked from a coroutine, not a suspend lambda.
+                val selfUid = cachedPrefs.value.selfUid
+                val selfCallsign = cachedPrefs.value.callsign
+                val isSelf = (selfUid.isNotBlank() && event.uid == selfUid) ||
+                    (selfCallsign.isNotBlank() && event.callsign == selfCallsign)
+                if (!isSelf) {
+                    when (MeshCoTRouter.classify(event)) {
+                        MeshCoTRouter.Destination.CHAT -> {
+                            // Convert b-t-f CoTEvent to ChatMessage and ingest.
+                            // Try rawXml first (full GeoChat parse); fall back to
+                            // building a ChatMessage directly from CoTEvent fields.
+                            val selfUidNow = selfUid.ifBlank { null }
+                            val chatMsg = event.rawXml?.let {
+                                runCatching {
+                                    soy.engindearing.omnitak.mobile.data.ChatXml.parse(it, selfUidNow)
+                                }.getOrNull()
+                            } ?: run {
+                                // Manual ChatMessage from CoTEvent fields.
+                                val senderCallsign = event.callsign ?: event.uid
+                                val convId = soy.engindearing.omnitak.mobile.data.ChatRoom.ALL_USERS
+                                soy.engindearing.omnitak.mobile.data.ChatMessage(
+                                    id = event.uid,
+                                    conversationId = convId,
+                                    senderUid = event.uid,
+                                    senderCallsign = senderCallsign,
+                                    text = event.remarks.ifBlank { "[mesh chat]" },
+                                    timeIso = event.timeIso
+                                        ?: java.time.format.DateTimeFormatter.ISO_INSTANT
+                                            .format(java.time.Instant.now()),
+                                    status = soy.engindearing.omnitak.mobile.data.ChatStatus.RECEIVED,
+                                    isFromSelf = false,
+                                )
+                            }
+                            chatStore.ingest(chatMsg)
+                        }
+                        MeshCoTRouter.Destination.CONTACT -> contactStore.ingest(event)
+                    }
+                }
+            }
             // GAP-109 read-back — admin responses to our get_*_request
             // calls fold into the device-config store on a background
             // coroutine. Screen collects from the store and re-renders.
@@ -217,6 +299,42 @@ class OmniTAKApp : Application() {
         soy.engindearing.omnitak.mobile.data.remoteid.RemoteIdScanner(this)
     }
     val certVault: CertVault by lazy { CertVault(this) }
+
+    // Off-grid mesh plan Step 1b — single app-owned broadcaster instance.
+    // Null until startAppBroadcaster() is called. Thread-safe via @Volatile.
+    @Volatile private var appBroadcaster: SelfPositionBroadcaster? = null
+
+    private fun startAppBroadcaster() {
+        if (appBroadcaster != null) return
+        val fixFlow = locationProvider.fix
+        // Eagerly cache the mesh-broadcast prefs as StateFlows so the
+        // lambda getters in SelfPositionBroadcaster can read .value
+        // without suspending — they're called inside a non-suspending context.
+        val broadcastOverMeshFlow = kotlinx.coroutines.flow.MutableStateFlow(true)
+        val meshIntervalMsFlow = kotlinx.coroutines.flow.MutableStateFlow(30_000L)
+        appScope.launch {
+            userPrefsStore.prefs.collect { p ->
+                broadcastOverMeshFlow.value = p.broadcastOverMesh
+                meshIntervalMsFlow.value = p.meshBroadcastIntervalSecs.coerceIn(30, 60).toLong() * 1000L
+            }
+        }
+        appBroadcaster = SelfPositionBroadcaster(
+            scope = appScope,
+            prefsStore = userPrefsStore,
+            sendCoT = { xml -> serverManager.sendCoT(xml) },
+            locationFix = fixFlow,
+            batteryProvider = ::readDeviceBatteryPercent,
+            sendToMesh = { event -> meshtastic.sendCoTOverMesh(event) },
+            meshConnected = { meshtastic.activeConnectionState.value is ConnectionState.Connected },
+            meshBroadcastEnabled = { broadcastOverMeshFlow.value },
+            meshThrottleMs = meshIntervalMsFlow.value,
+        ).also { it.start() }
+    }
+
+    private fun stopAppBroadcaster() {
+        appBroadcaster?.stop()
+        appBroadcaster = null
+    }
     val locationProvider: LocationProvider by lazy { LocationProvider(this) }
     val serverManager: ServerManager by lazy {
         ServerManager(

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AtakPluginParser.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AtakPluginParser.kt
@@ -224,10 +224,13 @@ object AtakPluginParser {
             staleIso = staleIso,
             callsign = callsign,
             remarks = detail.remarks ?: "",
+            // Team (group) data — required for off-grid mesh so receivers
+            // can colour-code contacts by team without a server relay.
+            teamName = detail.groupName,
+            teamRole = detail.groupRole,
             // Preserve the protobuf-derived CoT XML so existing CoT
             // pipelines (ContactStore, marker rendering) can mine the
             // structured Detail fields we don't carry on CoTEvent today.
-            // TODO: widen CoTEvent.detail to carry group/takv/track.
             rawXml = cotXml,
         )
     }
@@ -513,6 +516,9 @@ object AtakPluginParser {
         val ce = extractAttr(xml, "point", "ce")?.toDoubleOrNull() ?: 9_999_999.0
         val le = extractAttr(xml, "point", "le")?.toDoubleOrNull() ?: 9_999_999.0
         val callsign = extractAttr(xml, "contact", "callsign")
+        val remarks = extractInnerText("remarks", xml) ?: ""
+        val teamName = extractAttr(xml, "__group", "name")
+        val teamRole = extractAttr(xml, "__group", "role")
         return CoTEvent(
             uid = uid,
             type = type,
@@ -524,6 +530,9 @@ object AtakPluginParser {
             timeIso = time,
             staleIso = stale,
             callsign = callsign,
+            remarks = remarks,
+            teamName = teamName,
+            teamRole = teamRole,
             rawXml = xml,
         )
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AtakPluginSerializer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AtakPluginSerializer.kt
@@ -149,6 +149,19 @@ object AtakPluginSerializer {
             appendVarint(out, contact.size.toULong())
             out.write(contact)
         }
+        // 2: group (team name + role) — required so receiving ATAK/OmniTAK
+        // shows the operator's team color. Parser already reads group via
+        // parseGroup (field 1=name, field 2=role). Step 4 of off-grid plan.
+        event.teamName?.takeIf { it.isNotEmpty() }?.let { teamName ->
+            val role = event.teamRole ?: "Team Member"
+            val group = ByteArrayOutputStream().apply {
+                appendString(this, field = 1, value = teamName)
+                appendString(this, field = 2, value = role)
+            }.toByteArray()
+            appendTag(out, field = 2, wire = 2)
+            appendVarint(out, group.size.toULong())
+            out.write(group)
+        }
         // 1: xmlDetail — stash remarks here so parsers that ignore
         // structured submessages still see them.
         if (event.remarks.isNotEmpty()) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -3,6 +3,7 @@ package soy.engindearing.omnitak.mobile.data
 import android.content.Context
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -72,6 +73,13 @@ data class UserPrefs(
      *  appear on the map as unknown-air UAS contacts. Default off — opt-in
      *  because BLE scanning has a battery cost. */
     val remoteIdScanEnabled: Boolean = false,
+    /** When true, self-PPLI and GeoChat are also sent over the connected
+     *  Meshtastic radio (portnum-72 TAKMessage). Allows two OmniTAK
+     *  operators with radios to see each other and chat with NO server. */
+    val broadcastOverMesh: Boolean = true,
+    /** How often (seconds) PPLI is sent over the mesh. Coerced to 30..60
+     *  so LoRa bandwidth is respected. */
+    val meshBroadcastIntervalSecs: Int = 30,
     /** 3D terrain map mode — tilts the camera and renders DEM relief
      *  (AWS Terrarium tiles). Parity with the iOS Cesium 3D globe
      *  toggle. Default off — 2D top-down is the tactical default. */
@@ -117,6 +125,8 @@ class UserPrefsStore(private val context: Context) {
     private val KEY_FOLLOW_ME = booleanPreferencesKey("follow_me_active")
     private val KEY_MIL_STD_SELF = booleanPreferencesKey("use_milstd_self_symbol")
     private val KEY_REMOTE_ID_SCAN = booleanPreferencesKey("remote_id_scan_enabled")
+    private val KEY_BROADCAST_OVER_MESH = booleanPreferencesKey("broadcast_over_mesh")
+    private val KEY_MESH_BROADCAST_INTERVAL = intPreferencesKey("mesh_broadcast_interval_secs")
     private val KEY_MAP_3D = booleanPreferencesKey("map_3d_enabled")
     private val KEY_CESIUM_GLOBE = booleanPreferencesKey("cesium_globe_enabled")
     private val KEY_TOOLBAR_ITEMS = stringPreferencesKey("toolbar_item_ids")
@@ -150,6 +160,8 @@ class UserPrefsStore(private val context: Context) {
             p[KEY_FOLLOW_ME] = next.followMeActive
             p[KEY_MIL_STD_SELF] = next.useMilStdSelfSymbol
             p[KEY_REMOTE_ID_SCAN] = next.remoteIdScanEnabled
+            p[KEY_BROADCAST_OVER_MESH] = next.broadcastOverMesh
+            p[KEY_MESH_BROADCAST_INTERVAL] = next.meshBroadcastIntervalSecs.coerceIn(30, 60)
             p[KEY_MAP_3D] = next.map3dEnabled
             p[KEY_CESIUM_GLOBE] = next.cesiumGlobeEnabled
             p[KEY_TOOLBAR_ITEMS] = next.toolbarItemIds.joinToString(",")
@@ -186,6 +198,16 @@ class UserPrefsStore(private val context: Context) {
     /** Convenience writer for the layers-dialog mesh visibility toggle. */
     suspend fun setMeshNodesLayerVisible(value: Boolean) {
         update { it.copy(meshNodesLayerVisible = value) }
+    }
+
+    /** Persist the off-grid mesh broadcast toggle. */
+    suspend fun setBroadcastOverMesh(value: Boolean) {
+        update { it.copy(broadcastOverMesh = value) }
+    }
+
+    /** Persist the mesh PPLI broadcast interval (coerced to 30..60 seconds). */
+    suspend fun setMeshBroadcastIntervalSecs(value: Int) {
+        update { it.copy(meshBroadcastIntervalSecs = value.coerceIn(30, 60)) }
     }
 
     /**
@@ -229,6 +251,8 @@ class UserPrefsStore(private val context: Context) {
         followMeActive = p[KEY_FOLLOW_ME] ?: false,
         useMilStdSelfSymbol = p[KEY_MIL_STD_SELF] ?: true,
         remoteIdScanEnabled = p[KEY_REMOTE_ID_SCAN] ?: false,
+        broadcastOverMesh = p[KEY_BROADCAST_OVER_MESH] ?: true,
+        meshBroadcastIntervalSecs = p[KEY_MESH_BROADCAST_INTERVAL]?.coerceIn(30, 60) ?: 30,
         map3dEnabled = p[KEY_MAP_3D] ?: false,
         cesiumGlobeEnabled = p[KEY_CESIUM_GLOBE] ?: false,
         toolbarItemIds = p[KEY_TOOLBAR_ITEMS]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoTRouter.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoTRouter.kt
@@ -1,0 +1,29 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+
+/**
+ * Pure routing helper for inbound Meshtastic portnum-72 CoT events.
+ *
+ * Classifies whether a decoded [CoTEvent] should be routed to
+ * [ChatStore] (as a GeoChat message) or [ContactStore] (as a map contact).
+ *
+ * Phase 1 off-grid plan (Step 3): a type "b-t-f" event is a GeoChat;
+ * everything else (PPLI "a-f-G-U-C", markers, etc.) is a contact.
+ *
+ * This is intentionally a stateless object — no side-effects, easy to
+ * unit-test without any Android dependencies.
+ */
+object MeshCoTRouter {
+
+    /** Routing destination for an inbound mesh CoT event. */
+    enum class Destination { CHAT, CONTACT }
+
+    /**
+     * Classify [event] into a routing destination.
+     *  - "b-t-f" (Broadcast-TAK-friendly) → [Destination.CHAT]
+     *  - everything else                   → [Destination.CONTACT]
+     */
+    fun classify(event: CoTEvent): Destination =
+        if (event.type == "b-t-f") Destination.CHAT else Destination.CONTACT
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/SelfPositionBroadcaster.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/SelfPositionBroadcaster.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import soy.engindearing.omnitak.mobile.data.CoTEvent
 import soy.engindearing.omnitak.mobile.data.SelfFix
 import soy.engindearing.omnitak.mobile.data.UserPrefs
 import soy.engindearing.omnitak.mobile.data.UserPrefsStore
@@ -45,7 +46,15 @@ class SelfPositionBroadcaster internal constructor(
     private val batteryProvider: () -> Int? = { null },
     private val intervalMs: Long = DEFAULT_INTERVAL_MS,
     private val staleSeconds: Long = DEFAULT_STALE_SECONDS,
+    // Off-grid mesh PPLI support — when non-null, self-position is also
+    // sent over the Meshtastic radio at a throttled rate so two operators
+    // with radios and NO server can still see each other.
+    private val sendToMesh: (suspend (CoTEvent) -> Boolean)? = null,
+    private val meshConnected: () -> Boolean = { false },
+    private val meshBroadcastEnabled: () -> Boolean = { true },
+    private val meshThrottleMs: Long = 30_000L,
 ) {
+    @Volatile private var lastMeshSendMs: Long = 0L
     constructor(
         scope: CoroutineScope,
         prefsStore: UserPrefsStore,
@@ -54,6 +63,10 @@ class SelfPositionBroadcaster internal constructor(
         batteryProvider: () -> Int? = { null },
         intervalMs: Long = DEFAULT_INTERVAL_MS,
         staleSeconds: Long = DEFAULT_STALE_SECONDS,
+        sendToMesh: (suspend (CoTEvent) -> Boolean)? = null,
+        meshConnected: () -> Boolean = { false },
+        meshBroadcastEnabled: () -> Boolean = { true },
+        meshThrottleMs: Long = 30_000L,
     ) : this(
         scope = scope,
         prefsFlow = prefsStore.prefs,
@@ -63,6 +76,10 @@ class SelfPositionBroadcaster internal constructor(
         batteryProvider = batteryProvider,
         intervalMs = intervalMs,
         staleSeconds = staleSeconds,
+        sendToMesh = sendToMesh,
+        meshConnected = meshConnected,
+        meshBroadcastEnabled = meshBroadcastEnabled,
+        meshThrottleMs = meshThrottleMs,
     )
 
     private var job: Job? = null
@@ -141,6 +158,32 @@ class SelfPositionBroadcaster internal constructor(
             Log.d(TAG, "PPLI sent — ${prefs.callsign} @ $lat,$lon")
         } else {
             Log.w(TAG, "PPLI send failed (no socket?)")
+        }
+
+        // Off-grid mesh PPLI — throttled to meshThrottleMs so we don’t
+        // flood LoRa bandwidth. wantAck=false is mandatory (LoRa risk).
+        val meshFn = sendToMesh
+        if (meshFn != null && meshConnected() && meshBroadcastEnabled()) {
+            val now = System.currentTimeMillis()
+            if (now - lastMeshSendMs >= meshThrottleMs) {
+                val meshEvent = CoTEvent(
+                    uid = prefs.selfUid.ifBlank { "ANDROID-fallback" },
+                    type = "a-f-G-U-C",
+                    lat = lat,
+                    lon = lon,
+                    hae = hae,
+                    ce = ce,
+                    callsign = prefs.callsign,
+                    teamName = prefs.team,
+                )
+                val meshOk = meshFn(meshEvent)
+                if (meshOk) {
+                    lastMeshSendMs = now
+                    Log.d(TAG, "Mesh PPLI sent — ${prefs.callsign} @ $lat,$lon")
+                } else {
+                    Log.w(TAG, "Mesh PPLI send failed")
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ServerManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ServerManager.kt
@@ -216,23 +216,18 @@ class ServerManager(
         }
     }
 
+    // Off-grid mesh plan Step 1b: PPLI broadcaster ownership moved to
+    // OmniTAKApp so it starts when EITHER a server OR mesh radio is
+    // connected. ServerManager's PLI methods are retained as stubs to
+    // preserve the call sites (stateJobs collectors call them); they are
+    // intentional no-ops — the app-level broadcaster handles everything.
     private fun startPliBroadcast() {
-        if (pliBroadcaster != null || userPrefsStore == null) return
-        // GAP-030b — thread the live FusedLocationProviderClient fix
-        // through so PPLI carries real GPS instead of a SF default.
-        // Empty StateFlow when no provider is wired (older callers/tests).
-        val fixFlow = locationProvider?.fix
-            ?: kotlinx.coroutines.flow.MutableStateFlow(null)
-        pliBroadcaster = SelfPositionBroadcaster(
-            scope = scope,
-            prefsStore = userPrefsStore,
-            sendCoT = { xml -> sendCoT(xml) },
-            locationFix = fixFlow,
-            batteryProvider = batteryProvider,
-        ).also { it.start() }
+        // Intentional no-op: broadcaster is owned by OmniTAKApp.
+        // Left in place so callers in stateJobs collectors compile without change.
     }
 
     private fun stopPliBroadcast() {
+        // Intentional no-op: broadcaster is owned by OmniTAKApp.
         pliBroadcaster?.stop()
         pliBroadcaster = null
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.OmniTAKApp
 import soy.engindearing.omnitak.mobile.data.ChatConversation
@@ -60,6 +61,7 @@ import soy.engindearing.omnitak.mobile.data.ChatParticipant
 import soy.engindearing.omnitak.mobile.data.ChatRoom
 import soy.engindearing.omnitak.mobile.data.ChatStatus
 import soy.engindearing.omnitak.mobile.data.ChatXml
+import soy.engindearing.omnitak.mobile.data.CoTEvent
 import soy.engindearing.omnitak.mobile.data.UserPrefs
 import soy.engindearing.omnitak.mobile.domain.ChatStore
 import soy.engindearing.omnitak.mobile.domain.ServerManager
@@ -611,6 +613,27 @@ private suspend fun sendChatInner(
     // Route to the conversation's origin server for per-server DMs;
     // group/broadcast rooms (serverId == null) fan out to all servers.
     val sent = app.serverManager.sendCoT(generated.xml, serverId = convo.serverId)
+
+    // Off-grid mesh GeoChat — portnum-72 b-t-f TAKMessage so operators
+    // with radios and NO server can exchange chat. Step 2 of off-grid plan.
+    // Keep the existing MESH-CH*/MESH-DM-* portnum-1 path unchanged (above).
+    val meshState = app.meshtastic.activeConnectionState.value
+    val latestPrefs = app.userPrefsStore.prefs.first()
+    if (meshState is soy.engindearing.omnitak.mobile.domain.ConnectionState.Connected &&
+        latestPrefs.broadcastOverMesh
+    ) {
+        val meshCotEvent = CoTEvent(
+            uid = "GeoChat.${senderUid}.${ChatRoom.ALL_USERS}.${generated.messageId}",
+            type = "b-t-f",
+            lat = 0.0,
+            lon = 0.0,
+            callsign = prefs.callsign,
+            remarks = text,
+            teamName = prefs.team,
+        )
+        runCatching { app.meshtastic.sendCoTOverMesh(meshCotEvent) }
+    }
+
     app.chatStore.updateMessageStatus(
         conversationId = convo.id,
         messageId = generated.messageId,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshtasticScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshtasticScreen.kt
@@ -153,6 +153,30 @@ fun MeshtasticScreen(
                             },
                         )
                         DropdownMenuItem(
+                            text = {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(
+                                        "Broadcast over mesh",
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                    if (userPrefs.broadcastOverMesh) {
+                                        Icon(
+                                            Icons.Filled.Check,
+                                            contentDescription = "Enabled",
+                                            tint = TacticalAccent,
+                                        )
+                                    }
+                                }
+                            },
+                            onClick = {
+                                val next = !userPrefs.broadcastOverMesh
+                                coScope.launch {
+                                    app.userPrefsStore.setBroadcastOverMesh(next)
+                                }
+                                menuOpen = false
+                            },
+                        )
+                        DropdownMenuItem(
                             text = { Text("Disconnect") },
                             enabled = anyConnected,
                             onClick = {

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/AtakPluginParserTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/AtakPluginParserTest.kt
@@ -210,5 +210,39 @@ class AtakPluginParserTest {
         }
     }
 
+
+    // region Off-grid mesh tests (Phase 1) ---------------------------------
+
+    @Test fun b_t_f_geochat_xml_parses_callsign_and_remarks() {
+        val xml = "<event version=\"2.0\" uid=\"GeoChat.test.All.abc\" type=\"b-t-f\" how=\"h-g-i-g-o\">"
+            .plus("<point lat=\"0.0\" lon=\"0.0\" hae=\"0.0\" ce=\"9999999\" le=\"9999999\"/>")
+            .plus("<detail><contact callsign=\"MESH-ALPHA\"/>")
+            .plus("<remarks>Hello from mesh</remarks></detail></event>")
+        val event = AtakPluginParser.parse(xml.toByteArray(Charsets.UTF_8))
+        assertNotNull("b-t-f XML must parse", event)
+        event!!
+        assertEquals("b-t-f", event.type)
+        assertEquals("MESH-ALPHA", event.callsign)
+        assertTrue("remarks must contain message", event.remarks.contains("Hello from mesh"))
+    }
+
+    @Test fun b_t_f_protobuf_round_trips_callsign_remarks() {
+        val original = CoTEvent(
+            uid = "GeoChat.ANDROID-x.All Chat Rooms.xyz",
+            type = "b-t-f",
+            lat = 0.0,
+            lon = 0.0,
+            callsign = "BRAVO-2",
+            remarks = "Test mesh message",
+        )
+        val payload = AtakPluginSerializer.serialize(original)
+        val decoded = AtakPluginParser.parse(payload)
+        assertNotNull(decoded)
+        decoded!!
+        assertEquals("b-t-f", decoded.type)
+        assertEquals("BRAVO-2", decoded.callsign)
+        assertTrue(decoded.remarks.contains("Test mesh message"))
+    }
+
     // endregion
 }

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/AtakPluginSerializerGroupTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/AtakPluginSerializerGroupTest.kt
@@ -1,0 +1,112 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Off-grid mesh plan Step 4 — verifies the Group submessage round-trip.
+ *
+ * [AtakPluginSerializer.encodeDetail] must emit a Detail.group (field 2)
+ * with name=teamName and role=teamRole (or "Team Member" default).
+ * [AtakPluginParser] must decode it back via parseGroup so receivers
+ * see the operator's team color.
+ *
+ * Also covers the b-t-f GeoChat round-trip with callsign + remarks.
+ */
+class AtakPluginSerializerGroupTest {
+
+    @Test
+    fun `PPLI round-trips team name`() {
+        val event = CoTEvent(
+            uid = "ANDROID-test",
+            type = "a-f-G-U-C",
+            lat = 47.66,
+            lon = -117.43,
+            callsign = "BRAVO-1",
+            teamName = "Red",
+            teamRole = "Team Lead",
+        )
+        val payload = AtakPluginSerializer.serialize(event)
+        val decoded = AtakPluginParser.parse(payload)
+        assertNotNull("round-trip must parse", decoded)
+        decoded!!
+        assertEquals("Red", decoded.teamName)
+        assertEquals("BRAVO-1", decoded.callsign)
+    }
+
+    @Test
+    fun `PPLI round-trips default team role`() {
+        val event = CoTEvent(
+            uid = "ANDROID-test-2",
+            type = "a-f-G-U-C",
+            lat = 0.0,
+            lon = 0.0,
+            callsign = "ECHO-1",
+            teamName = "Cyan",
+            teamRole = null, // should default to "Team Member"
+        )
+        val payload = AtakPluginSerializer.serialize(event)
+        val decoded = AtakPluginParser.parse(payload)
+        assertNotNull(decoded)
+        // Team name must survive the round-trip
+        assertEquals("Cyan", decoded!!.teamName)
+    }
+
+    @Test
+    fun `b-t-f GeoChat round-trips callsign and remarks`() {
+        val event = CoTEvent(
+            uid = "GeoChat.ANDROID-test.All Chat Rooms.123",
+            type = "b-t-f",
+            lat = 0.0,
+            lon = 0.0,
+            callsign = "ALPHA-1",
+            remarks = "Hello mesh world",
+            teamName = "Green",
+        )
+        val payload = AtakPluginSerializer.serialize(event)
+        val decoded = AtakPluginParser.parse(payload)
+        assertNotNull("b-t-f must round-trip", decoded)
+        decoded!!
+        assertEquals("b-t-f", decoded.type)
+        assertEquals("ALPHA-1", decoded.callsign)
+        assertTrue("remarks must contain message text", decoded.remarks.contains("Hello mesh world"))
+    }
+
+    @Test
+    fun `b-t-f GeoChat round-trips team name`() {
+        val event = CoTEvent(
+            uid = "GeoChat.uid.room.456",
+            type = "b-t-f",
+            lat = 0.0,
+            lon = 0.0,
+            callsign = "DELTA-1",
+            remarks = "Team chat",
+            teamName = "Blue",
+        )
+        val payload = AtakPluginSerializer.serialize(event)
+        val decoded = AtakPluginParser.parse(payload)
+        assertNotNull(decoded)
+        assertEquals("Blue", decoded!!.teamName)
+    }
+
+    @Test
+    fun `no team name emits no group submessage`() {
+        // Events without a team name must still round-trip cleanly;
+        // group should be null after parsing.
+        val event = CoTEvent(
+            uid = "ANDROID-no-team",
+            type = "a-f-G-U-C",
+            lat = 0.0,
+            lon = 0.0,
+            callsign = "NO-TEAM",
+            teamName = null,
+        )
+        val payload = AtakPluginSerializer.serialize(event)
+        val decoded = AtakPluginParser.parse(payload)
+        assertNotNull(decoded)
+        // teamName should be null or blank (no group emitted)
+        assertTrue(decoded!!.teamName.isNullOrBlank())
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefsMeshDefaultsTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefsMeshDefaultsTest.kt
@@ -1,0 +1,52 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Off-grid mesh plan Step 5 — verifies [UserPrefs] defaults for the
+ * new mesh broadcast fields.
+ */
+class UserPrefsMeshDefaultsTest {
+
+    @Test
+    fun `broadcastOverMesh defaults to true`() {
+        assertTrue(
+            "broadcastOverMesh must default to true (opt-in off-grid by default)",
+            UserPrefs().broadcastOverMesh,
+        )
+    }
+
+    @Test
+    fun `meshBroadcastIntervalSecs defaults to 30`() {
+        assertEquals(
+            "meshBroadcastIntervalSecs must default to 30 (minimum LoRa-safe interval)",
+            30,
+            UserPrefs().meshBroadcastIntervalSecs,
+        )
+    }
+
+    @Test
+    fun `meshBroadcastIntervalSecs coerces to 30 when below minimum`() {
+        val prefs = UserPrefs(meshBroadcastIntervalSecs = 5)
+        // Coercion happens in UserPrefsStore.update(); the data class itself
+        // doesn't coerce — we verify the coerce helper logic.
+        val coerced = prefs.meshBroadcastIntervalSecs.coerceIn(30, 60)
+        assertEquals(30, coerced)
+    }
+
+    @Test
+    fun `meshBroadcastIntervalSecs coerces to 60 when above maximum`() {
+        val prefs = UserPrefs(meshBroadcastIntervalSecs = 90)
+        val coerced = prefs.meshBroadcastIntervalSecs.coerceIn(30, 60)
+        assertEquals(60, coerced)
+    }
+
+    @Test
+    fun `meshBroadcastIntervalSecs accepts 45 (midpoint)`() {
+        val prefs = UserPrefs(meshBroadcastIntervalSecs = 45)
+        val coerced = prefs.meshBroadcastIntervalSecs.coerceIn(30, 60)
+        assertEquals(45, coerced)
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/MeshInboundClassifyTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/MeshInboundClassifyTest.kt
@@ -1,0 +1,60 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+
+/**
+ * Off-grid mesh plan Step 3 — pure [MeshCoTRouter] classifier tests.
+ *
+ * Verifies:
+ *  - b-t-f type → Chat
+ *  - a-f-G-U-C (PPLI) → Contact
+ *  - generic marker types → Contact
+ */
+class MeshInboundClassifyTest {
+
+    private fun event(type: String) = CoTEvent(
+        uid = "TEST-UID",
+        type = type,
+        lat = 0.0,
+        lon = 0.0,
+    )
+
+    @Test
+    fun `b-t-f classifies as Chat`() {
+        val result = MeshCoTRouter.classify(event("b-t-f"))
+        assertEquals(MeshCoTRouter.Destination.CHAT, result)
+    }
+
+    @Test
+    fun `ppli a-f-G-U-C classifies as Contact`() {
+        val result = MeshCoTRouter.classify(event("a-f-G-U-C"))
+        assertEquals(MeshCoTRouter.Destination.CONTACT, result)
+    }
+
+    @Test
+    fun `hostile contact classifies as Contact`() {
+        val result = MeshCoTRouter.classify(event("a-h-G"))
+        assertEquals(MeshCoTRouter.Destination.CONTACT, result)
+    }
+
+    @Test
+    fun `generic marker classifies as Contact`() {
+        val result = MeshCoTRouter.classify(event("a-f-G-U"))
+        assertEquals(MeshCoTRouter.Destination.CONTACT, result)
+    }
+
+    @Test
+    fun `b-t-f with suffix is still Chat`() {
+        // Future-proofing: exact match "b-t-f" only
+        val result = MeshCoTRouter.classify(event("b-t-f"))
+        assertEquals(MeshCoTRouter.Destination.CHAT, result)
+    }
+
+    @Test
+    fun `unrelated b type classifies as Contact`() {
+        val result = MeshCoTRouter.classify(event("b-r"))
+        assertEquals(MeshCoTRouter.Destination.CONTACT, result)
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/SelfPositionBroadcasterMeshTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/SelfPositionBroadcasterMeshTest.kt
@@ -1,0 +1,157 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.SelfFix
+import soy.engindearing.omnitak.mobile.data.UserPrefs
+
+/**
+ * Off-grid mesh PPLI plan Step 1 unit tests.
+ *
+ * Verifies the mesh send path in [SelfPositionBroadcaster]:
+ *  - skipped when no mesh connection (meshConnected = false)
+ *  - skipped when toggle disabled (meshBroadcastEnabled = false)
+ *  - fires correct CoT type + callsign + team when connected
+ *  - throttle suppresses second send within the window
+ *  - resumes after window elapses
+ *  - server PPLI (sendCoT) always fires regardless of mesh state
+ */
+class SelfPositionBroadcasterMeshTest {
+
+    private val testLocation = SelfFix(lat = 47.66, lon = -117.43, altitudeM = 600.0, speedKmh = 0.0, accuracyM = 5.0f, timeMs = 0L)
+    private val testPrefs = UserPrefs(
+        callsign = "ALPHA-1",
+        team = "Cyan",
+        selfUid = "ANDROID-test-uid",
+        selfLat = 47.66,
+        selfLon = -117.43,
+    )
+
+    /** Build a broadcaster under test with explicit control knobs. */
+    private fun makeBroadcaster(
+        scope: TestScope,
+        sendCoT: suspend (String) -> Boolean = { true },
+        meshConnected: () -> Boolean = { true },
+        meshBroadcastEnabled: () -> Boolean = { true },
+        meshThrottleMs: Long = 10_000L,
+        capturedMeshEvents: MutableList<CoTEvent> = mutableListOf(),
+    ): SelfPositionBroadcaster {
+        val fixFlow = MutableStateFlow<SelfFix?>(testLocation)
+        val prefsFlow = MutableStateFlow(testPrefs)
+        return SelfPositionBroadcaster(
+            scope = scope,
+            prefsFlow = prefsFlow,
+            updatePrefs = { _ -> },
+            sendCoT = sendCoT,
+            locationFix = fixFlow,
+            batteryProvider = { null },
+            intervalMs = 5_000L,
+            staleSeconds = 180L,
+            sendToMesh = { event ->
+                capturedMeshEvents.add(event)
+                true
+            },
+            meshConnected = meshConnected,
+            meshBroadcastEnabled = meshBroadcastEnabled,
+            meshThrottleMs = meshThrottleMs,
+        )
+    }
+
+    @Test
+    fun `mesh send skipped when disconnected`() = runTest {
+        val meshEvents = mutableListOf<CoTEvent>()
+        val b = makeBroadcaster(
+            scope = this,
+            meshConnected = { false },
+            capturedMeshEvents = meshEvents,
+        )
+        b.broadcastOnce(testPrefs)
+        assertEquals("no mesh send when disconnected", 0, meshEvents.size)
+    }
+
+    @Test
+    fun `mesh send skipped when toggle off`() = runTest {
+        val meshEvents = mutableListOf<CoTEvent>()
+        val b = makeBroadcaster(
+            scope = this,
+            meshConnected = { true },
+            meshBroadcastEnabled = { false },
+            capturedMeshEvents = meshEvents,
+        )
+        b.broadcastOnce(testPrefs)
+        assertEquals("no mesh send when toggle off", 0, meshEvents.size)
+    }
+
+    @Test
+    fun `mesh send fires with correct type callsign and team`() = runTest {
+        val meshEvents = mutableListOf<CoTEvent>()
+        val b = makeBroadcaster(
+            scope = this,
+            meshConnected = { true },
+            meshBroadcastEnabled = { true },
+            meshThrottleMs = 0L,
+            capturedMeshEvents = meshEvents,
+        )
+        b.broadcastOnce(testPrefs)
+        assertEquals("expected one mesh event", 1, meshEvents.size)
+        val ev = meshEvents[0]
+        assertEquals("a-f-G-U-C", ev.type)
+        assertEquals("ALPHA-1", ev.callsign)
+        assertEquals("Cyan", ev.teamName)
+        assertEquals("ANDROID-test-uid", ev.uid)
+    }
+
+    @Test
+    fun `throttle suppresses second send within window`() = runTest {
+        val meshEvents = mutableListOf<CoTEvent>()
+        val throttleMs = 10_000L
+        val b = makeBroadcaster(
+            scope = this,
+            meshConnected = { true },
+            meshBroadcastEnabled = { true },
+            meshThrottleMs = throttleMs,
+            capturedMeshEvents = meshEvents,
+        )
+        b.broadcastOnce(testPrefs)
+        assertEquals("first send fires", 1, meshEvents.size)
+        // Second call immediately — should be suppressed
+        b.broadcastOnce(testPrefs)
+        assertEquals("second within throttle suppressed", 1, meshEvents.size)
+    }
+
+    @Test
+    fun `mesh send resumes after throttle window`() = runTest {
+        val meshEvents = mutableListOf<CoTEvent>()
+        val b = makeBroadcaster(
+            scope = this,
+            meshConnected = { true },
+            meshBroadcastEnabled = { true },
+            meshThrottleMs = 0L, // zero throttle for simplicity
+            capturedMeshEvents = meshEvents,
+        )
+        b.broadcastOnce(testPrefs)
+        assertEquals("first send", 1, meshEvents.size)
+        b.broadcastOnce(testPrefs)
+        assertEquals("second send after zero-throttle window", 2, meshEvents.size)
+    }
+
+    @Test
+    fun `server sendCoT always fires regardless of mesh state`() = runTest {
+        val serverSends = mutableListOf<String>()
+        val b = makeBroadcaster(
+            scope = this,
+            sendCoT = { xml -> serverSends.add(xml); true },
+            meshConnected = { false },
+        )
+        b.broadcastOnce(testPrefs)
+        assertEquals("server send fires even with mesh disconnected", 1, serverSends.size)
+        assertTrue("XML is a CoT event", serverSends[0].contains("<event"))
+    }
+}


### PR DESCRIPTION
## Phase 1 — off-grid mesh TAK (OmniTAK↔OmniTAK)

When a Meshtastic radio is connected, OmniTAK now also routes self-PPLI (throttled ~30s) and GeoChat over portnum 72, not only to the TAK server. Inbound `b-t-f` is classified as chat (was mis-routed to the map). Team/`__group` crosses the mesh so team colors render off-grid. On-by-default "Broadcast over mesh" toggle added.

Wire format stays `TAKMessage{CoTEvent}` (Phase 1). Standard `TAKPacket` + unishox2 ecosystem interop is Phase 2.

**Verification:** build green + unit tests pass + wire-format round-trips. ⚠️ Real on-air LoRa delivery NOT yet verified (needs 2 radios or TAK_Meshtastic_Gateway).

Built via planner/checker + executor agent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)