### PR TITLE
feat(mesh): standard TAKPacket + unishox2 interop (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ OmniTAK-Android uses the following open-source components:
 - [AndroidX](https://developer.android.com/jetpack/androidx) — Apache 2.0
 - [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) — Apache 2.0
 - [Jetpack Compose](https://developer.android.com/jetpack/compose) — Apache 2.0
+- [Unishox2](https://github.com/siara-cc/Unishox2) (siara-cc) — Apache 2.0 — pure-Kotlin port for Meshtastic TAKPacket string compression
 
 ## Acknowledgments
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakEnums.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakEnums.kt
@@ -1,0 +1,90 @@
+package soy.engindearing.omnitak.mobile.data
+
+/**
+ * Enumerations mirroring the meshtastic atak.proto Team and MemberRole
+ * enums used in TAKPacket. Values match the proto's integer assignments
+ * exactly — the gateway and unishox2-py3 golden vectors were produced
+ * with these exact integer values so they must not be renumbered.
+ *
+ * CoT / ATAK use a space-separated display form ("Dark Blue", "Team Member")
+ * while the proto uses an underscore form ("Dark_Blue", "TeamMember").
+ * [Team.toCotName] / [Team.fromCotName] and [MemberRole.toCotName] /
+ * [MemberRole.fromCotName] bridge between the two forms.
+ */
+
+enum class Team(val value: Int, private val cotName: String) {
+    Unspecifed_Color(0, "Unspecified"),
+    White(1,       "White"),
+    Yellow(2,      "Yellow"),
+    Orange(3,      "Orange"),
+    Magenta(4,     "Magenta"),
+    Red(5,         "Red"),
+    Maroon(6,      "Maroon"),
+    Purple(7,      "Purple"),
+    Dark_Blue(8,   "Dark Blue"),
+    Blue(9,        "Blue"),
+    Cyan(10,       "Cyan"),
+    Teal(11,       "Teal"),
+    Green(12,      "Green"),
+    Dark_Green(13, "Dark Green"),
+    Brown(14,      "Brown");
+
+    /** The CoT display name used inside `<__group name="…"/>` attributes. */
+    fun toCotName(): String = cotName
+
+    companion object {
+        /** Lookup by integer value. Returns [Unspecifed_Color] on miss. */
+        fun fromValue(v: Int): Team = entries.firstOrNull { it.value == v } ?: Unspecifed_Color
+
+        /**
+         * Lookup by CoT display name (case-insensitive space form,
+         * e.g. "Dark Blue") OR proto enum name (underscore form,
+         * e.g. "Dark_Blue"). Returns [Unspecifed_Color] on miss.
+         */
+        fun fromCotName(name: String?): Team {
+            if (name == null) return Unspecifed_Color
+            val lower = name.lowercase()
+            return entries.firstOrNull {
+                it.cotName.lowercase() == lower ||
+                it.name.lowercase() == lower ||
+                it.name.lowercase() == lower.replace(' ', '_') ||
+                it.cotName.lowercase() == lower.replace('_', ' ')
+            } ?: Unspecifed_Color
+        }
+    }
+}
+
+enum class MemberRole(val value: Int, private val cotName: String) {
+    Unspecifed(0,       "Unspecified"),
+    TeamMember(1,       "Team Member"),
+    TeamLead(2,         "Team Lead"),
+    HQ(3,               "HQ"),
+    Sniper(4,           "Sniper"),
+    Medic(5,            "Medic"),
+    ForwardObserver(6,  "Forward Observer"),
+    RTO(7,              "RTO"),
+    K9(8,               "K9");
+
+    /** The CoT display name used inside `<__group role="…"/>` attributes. */
+    fun toCotName(): String = cotName
+
+    companion object {
+        /** Lookup by integer value. Returns [Unspecifed] on miss. */
+        fun fromValue(v: Int): MemberRole = entries.firstOrNull { it.value == v } ?: Unspecifed
+
+        /**
+         * Lookup by CoT role name ("Team Member") or proto name ("TeamMember").
+         * Case-insensitive, space ↔ no-space both accepted.
+         */
+        fun fromCotName(name: String?): MemberRole {
+            if (name == null) return Unspecifed
+            val lower = name.lowercase()
+            return entries.firstOrNull {
+                it.cotName.lowercase() == lower ||
+                it.name.lowercase() == lower ||
+                it.name.lowercase() == lower.replace(' ', '_').replace("_", "") ||
+                it.cotName.lowercase() == lower.replace("_", " ")
+            } ?: Unspecifed
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakPacketParser.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakPacketParser.kt
@@ -1,0 +1,538 @@
+package soy.engindearing.omnitak.mobile.data
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+
+/**
+ * Parses a Meshtastic portnum-72 TAKPacket (atak.proto) payload into a [CoTEvent].
+ *
+ * This is the Phase-2 inbound parser. The format detection heuristic looks for
+ * the strong TAKPacket signal (field 1 varint is_compressed + fields 2–6 being
+ * length-delimited sub-messages with the expected sub-fields). When detection
+ * fails the caller should fall back to [AtakPluginParser.parse] (Phase-1 TAKMessage).
+ *
+ * Schema handled (see [TakPacketSerializer] for the full schema comment):
+ *   PLI path    → CoT type="a-f-G-U-C", point from pli.lat_i/lon_i
+ *   GeoChat path → CoT type="b-t-f", remarks from chat.message
+ *
+ * Unishox2 decompression is applied when is_compressed=true using [Unishox2],
+ * the pure-Kotlin port that runs on plain JVM (unit tests).
+ */
+object TakPacketParser {
+
+    /**
+     * Try to parse [payload] as a TAKPacket. Returns a [CoTEvent] on success or
+     * null when the bytes don't look like a valid TAKPacket.
+     *
+     * Callers should then fall back to [AtakPluginParser.parse] on null.
+     */
+    fun parse(payload: ByteArray, fromNodeId: UInt = 0u): CoTEvent? {
+        if (payload.isEmpty()) return null
+        if (!looksLikeTakPacket(payload)) return null
+        return parseTakPacket(payload, fromNodeId)
+    }
+
+    // region Format detection -----------------------------------------------
+
+    /**
+     * Heuristic: a TAKPacket starts with either:
+     *   - 0x08 (field 1, varint) for is_compressed=true/false
+     *   - 0x12 (field 2, LEN) for contact when is_compressed is default-false (omitted)
+     *
+     * Additionally we require that none of the fields look like a
+     * TAKMessage/CoTEvent (which starts with field 1 LEN = type string "a-f-…"
+     * or field 2 LEN). The double-outer-wrapped TAKMessage starts with 0x12
+     * (field 2, LEN) but its inner bytes decode as CoTEvent strings. We
+     * distinguish them by checking the first field: if field=1,wire=0 (varint)
+     * the byte is 0x08 and the value is 0 or 1 → TAKPacket. If field=1,wire=2
+     * (LEN) the byte is 0x0A → TAKMessage.
+     */
+    private fun looksLikeTakPacket(bytes: ByteArray): Boolean {
+        if (bytes.isEmpty()) return false
+        val first = bytes[0].toInt() and 0xFF
+        // 0x08 = field 1, wire 0 (varint) → is_compressed bool
+        if (first == 0x08) return true
+        // 0x12 = field 2, wire 2 (LEN) → contact sub-message (is_compressed omitted = false)
+        // Distinguish from TAKMessage.cotEvent (also 0x12): check that the
+        // sub-message contents look like Contact{callsign, device_callsign},
+        // not like CoTEvent{type string}
+        if (first == 0x12) {
+            val sub = MeshtasticProtoParser.readLengthDelimited(bytes, 1) ?: return false
+            return looksLikeContact(sub.first)
+        }
+        return false
+    }
+
+    /** A Contact sub-message has field 1 (bytes/LEN) and/or field 2 (bytes/LEN).
+     *  Unlike CoTEvent field 1 which is a string type tag "a-f-G-…", Contact
+     *  field 1 is arbitrary bytes (possibly Unishox2 compressed, starting with
+     *  0x80 or other high bytes). We accept if field 1 is LEN and the content
+     *  doesn't start with 'a'/'b'. */
+    private fun looksLikeContact(bytes: ByteArray): Boolean {
+        if (bytes.isEmpty()) return false
+        val (tag, after) = MeshtasticProtoParser.readVarint(bytes, 0) ?: return false
+        val field = (tag shr 3).toInt()
+        val wire = (tag and 0x7UL).toInt()
+        if (field != 1 || wire != 2) return false
+        val sub = MeshtasticProtoParser.readLengthDelimited(bytes, after) ?: return false
+        // Accept anything — compressed or raw. The point is that this is a bytes
+        // field and not a CoTEvent type string that starts with "a-" / "b-".
+        return true
+    }
+
+    // endregion
+
+    // region Parser ---------------------------------------------------------
+
+    private data class ParsedContact(
+        var callsign: String = "",
+        var deviceCallsign: String = "",
+    )
+
+    private data class ParsedGroup(
+        var role: MemberRole = MemberRole.TeamMember,
+        var team: Team = Team.Cyan,
+    )
+
+    private data class ParsedStatus(
+        var battery: Int = 0,
+    )
+
+    private data class ParsedPli(
+        var latI: Int = 0,
+        var lonI: Int = 0,
+        var altitude: Int = 0,
+        var speed: Int = 0,
+        var course: Int = 0,
+    )
+
+    private data class ParsedChat(
+        var message: String = "",
+        var to: String = "All Chat Rooms",
+        var toCallsign: String = "",
+    )
+
+    private fun parseTakPacket(bytes: ByteArray, fromNodeId: UInt): CoTEvent? {
+        var isCompressed = false
+        var contact: ParsedContact? = null
+        var group: ParsedGroup? = null
+        var status: ParsedStatus? = null
+        var pli: ParsedPli? = null
+        var chat: ParsedChat? = null
+
+        var idx = 0
+        while (idx < bytes.size) {
+            val (tag, afterTag) = MeshtasticProtoParser.readVarint(bytes, idx) ?: return null
+            val field = (tag shr 3).toInt()
+            val wire = (tag and 0x7UL).toInt()
+            idx = afterTag
+            when (field) {
+                1 -> { // is_compressed (varint bool)
+                    if (wire != 0) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val (v, after) = MeshtasticProtoParser.readVarint(bytes, idx) ?: return null
+                    isCompressed = v != 0UL
+                    idx = after
+                }
+                2 -> { // contact (LEN)
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: return null
+                    contact = parseContact(sub.first, isCompressed)
+                    idx = sub.second
+                }
+                3 -> { // group (LEN)
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: return null
+                    group = parseGroup(sub.first)
+                    idx = sub.second
+                }
+                4 -> { // status (LEN)
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: return null
+                    status = parseStatus(sub.first)
+                    idx = sub.second
+                }
+                5 -> { // pli (LEN — oneof payload_variant)
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: return null
+                    pli = parsePli(sub.first)
+                    idx = sub.second
+                }
+                6 -> { // chat (LEN — oneof payload_variant)
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: return null
+                    chat = parseChat(sub.first, isCompressed)
+                    idx = sub.second
+                }
+                else -> idx = MeshtasticProtoParser.skipField(bytes, idx, wire)
+            }
+        }
+
+        val callsign = contact?.callsign?.takeIf { it.isNotEmpty() }
+            ?: "MESH-${"%08X".format(fromNodeId.toLong().toInt())}"
+        val uid = contact?.deviceCallsign?.takeIf { it.isNotEmpty() }
+            ?: "MESHTASTIC-${"%08X".format(fromNodeId.toLong().toInt())}"
+        val teamName = group?.team?.toCotName()
+        val teamRole = group?.role?.toCotName()
+        val now = isoNow()
+        val stale = isoStale()
+
+        return when {
+            pli != null -> buildPliCoT(pli, uid, callsign, teamName, teamRole, now, stale, group)
+            chat != null -> buildChatCoT(chat, uid, callsign, teamName, teamRole, now, stale)
+            else -> null
+        }
+    }
+
+    // region Sub-message parsers
+
+    private fun parseContact(bytes: ByteArray, isCompressed: Boolean): ParsedContact {
+        val c = ParsedContact()
+        var idx = 0
+        while (idx < bytes.size) {
+            val (tag, afterTag) = MeshtasticProtoParser.readVarint(bytes, idx) ?: break
+            val field = (tag shr 3).toInt()
+            val wire = (tag and 0x7UL).toInt()
+            idx = afterTag
+            when (field) {
+                1 -> { // callsign (bytes)
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: break
+                    c.callsign = decompressField(sub.first, isCompressed)
+                    idx = sub.second
+                }
+                2 -> { // device_callsign (bytes)
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: break
+                    c.deviceCallsign = decompressField(sub.first, isCompressed)
+                    idx = sub.second
+                }
+                else -> idx = MeshtasticProtoParser.skipField(bytes, idx, wire)
+            }
+        }
+        return c
+    }
+
+    private fun parseGroup(bytes: ByteArray): ParsedGroup {
+        val g = ParsedGroup()
+        var idx = 0
+        while (idx < bytes.size) {
+            val (tag, afterTag) = MeshtasticProtoParser.readVarint(bytes, idx) ?: break
+            val field = (tag shr 3).toInt()
+            val wire = (tag and 0x7UL).toInt()
+            idx = afterTag
+            when (field) {
+                1 -> { // role (varint)
+                    if (wire != 0) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val (v, after) = MeshtasticProtoParser.readVarint(bytes, idx) ?: break
+                    g.role = MemberRole.fromValue(v.toInt())
+                    idx = after
+                }
+                2 -> { // team (varint)
+                    if (wire != 0) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val (v, after) = MeshtasticProtoParser.readVarint(bytes, idx) ?: break
+                    g.team = Team.fromValue(v.toInt())
+                    idx = after
+                }
+                else -> idx = MeshtasticProtoParser.skipField(bytes, idx, wire)
+            }
+        }
+        return g
+    }
+
+    private fun parseStatus(bytes: ByteArray): ParsedStatus {
+        val s = ParsedStatus()
+        var idx = 0
+        while (idx < bytes.size) {
+            val (tag, afterTag) = MeshtasticProtoParser.readVarint(bytes, idx) ?: break
+            val field = (tag shr 3).toInt()
+            val wire = (tag and 0x7UL).toInt()
+            idx = afterTag
+            if (field == 1 && wire == 0) {
+                val (v, after) = MeshtasticProtoParser.readVarint(bytes, idx) ?: break
+                s.battery = v.toInt()
+                idx = after
+            } else {
+                idx = MeshtasticProtoParser.skipField(bytes, idx, wire)
+            }
+        }
+        return s
+    }
+
+    private fun parsePli(bytes: ByteArray): ParsedPli? {
+        val p = ParsedPli()
+        var sawLat = false
+        var sawLon = false
+        var idx = 0
+        while (idx < bytes.size) {
+            val (tag, afterTag) = MeshtasticProtoParser.readVarint(bytes, idx) ?: return null
+            val field = (tag shr 3).toInt()
+            val wire = (tag and 0x7UL).toInt()
+            idx = afterTag
+            when (field) {
+                1 -> { // latitude_i (sfixed32, wire=5)
+                    if (wire != 5) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val (raw, after) = MeshtasticProtoParser.readFixed32(bytes, idx) ?: return null
+                    p.latI = raw.toInt()
+                    sawLat = true
+                    idx = after
+                }
+                2 -> { // longitude_i (sfixed32, wire=5)
+                    if (wire != 5) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val (raw, after) = MeshtasticProtoParser.readFixed32(bytes, idx) ?: return null
+                    p.lonI = raw.toInt()
+                    sawLon = true
+                    idx = after
+                }
+                3 -> { // altitude (varint)
+                    if (wire != 0) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val (v, after) = MeshtasticProtoParser.readVarint(bytes, idx) ?: return null
+                    p.altitude = v.toInt()
+                    idx = after
+                }
+                4 -> { // speed (varint)
+                    if (wire != 0) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val (v, after) = MeshtasticProtoParser.readVarint(bytes, idx) ?: return null
+                    p.speed = v.toInt()
+                    idx = after
+                }
+                5 -> { // course (varint)
+                    if (wire != 0) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val (v, after) = MeshtasticProtoParser.readVarint(bytes, idx) ?: return null
+                    p.course = v.toInt()
+                    idx = after
+                }
+                else -> idx = MeshtasticProtoParser.skipField(bytes, idx, wire)
+            }
+        }
+        if (!sawLat || !sawLon) return null
+        return p
+    }
+
+    private fun parseChat(bytes: ByteArray, isCompressed: Boolean): ParsedChat? {
+        val c = ParsedChat()
+        var sawMessage = false
+        var idx = 0
+        while (idx < bytes.size) {
+            val (tag, afterTag) = MeshtasticProtoParser.readVarint(bytes, idx) ?: return null
+            val field = (tag shr 3).toInt()
+            val wire = (tag and 0x7UL).toInt()
+            idx = afterTag
+            when (field) {
+                1 -> { // message (bytes)
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: return null
+                    c.message = decompressField(sub.first, isCompressed)
+                    sawMessage = true
+                    idx = sub.second
+                }
+                2 -> { // to (bytes) — gateway sends this raw even when is_compressed=true
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: return null
+                    // Tolerate either raw or compressed (gateway uses raw; some clients may compress)
+                    c.to = decompressFieldTolerant(sub.first)
+                    idx = sub.second
+                }
+                3 -> { // to_callsign (bytes)
+                    if (wire != 2) { idx = MeshtasticProtoParser.skipField(bytes, idx, wire); continue }
+                    val sub = MeshtasticProtoParser.readLengthDelimited(bytes, idx) ?: return null
+                    c.toCallsign = decompressFieldTolerant(sub.first)
+                    idx = sub.second
+                }
+                else -> idx = MeshtasticProtoParser.skipField(bytes, idx, wire)
+            }
+        }
+        if (!sawMessage) return null
+        return c
+    }
+
+    // endregion
+
+    // region CoT event builders
+
+    private fun buildPliCoT(
+        pli: ParsedPli,
+        uid: String,
+        callsign: String,
+        teamName: String?,
+        teamRole: String?,
+        now: String,
+        stale: String,
+        group: ParsedGroup?,
+    ): CoTEvent {
+        val lat = pli.latI / 1e7
+        val lon = pli.lonI / 1e7
+        val hae = pli.altitude.toDouble()
+        val detailXml = buildPliDetailXml(callsign, teamName, teamRole, group, pli)
+        val rawXml = buildCoTXml(
+            uid = uid, type = "a-f-G-U-C", how = "m-g",
+            lat = lat, lon = lon, hae = hae, ce = 9_999_999.0, le = 9_999_999.0,
+            timeIso = now, staleIso = stale, detailXml = detailXml,
+        )
+        return CoTEvent(
+            uid = uid,
+            type = "a-f-G-U-C",
+            lat = lat,
+            lon = lon,
+            hae = hae,
+            ce = 9_999_999.0,
+            le = 9_999_999.0,
+            timeIso = now,
+            staleIso = stale,
+            callsign = callsign,
+            remarks = "",
+            teamName = teamName,
+            teamRole = teamRole,
+            rawXml = rawXml,
+        )
+    }
+
+    private fun buildChatCoT(
+        chat: ParsedChat,
+        uid: String,
+        callsign: String,
+        teamName: String?,
+        teamRole: String?,
+        now: String,
+        stale: String,
+    ): CoTEvent {
+        val msgUid = "GeoChat.$uid.${chat.to}.${UUID.randomUUID()}"
+        val detailXml = buildChatDetailXml(callsign, uid, chat, teamName, teamRole, now)
+        val rawXml = buildCoTXml(
+            uid = msgUid, type = "b-t-f", how = "h-g-i-g-o",
+            lat = 0.0, lon = 0.0, hae = 9_999_999.0, ce = 9_999_999.0, le = 9_999_999.0,
+            timeIso = now, staleIso = stale, detailXml = detailXml,
+        )
+        return CoTEvent(
+            uid = msgUid,
+            type = "b-t-f",
+            lat = 0.0,
+            lon = 0.0,
+            timeIso = now,
+            staleIso = stale,
+            callsign = callsign,
+            remarks = chat.message,
+            teamName = teamName,
+            teamRole = teamRole,
+            rawXml = rawXml,
+        )
+    }
+
+    // endregion
+
+    // region XML helpers
+
+    private fun buildPliDetailXml(
+        callsign: String,
+        teamName: String?,
+        teamRole: String?,
+        group: ParsedGroup?,
+        pli: ParsedPli,
+    ): String = buildString {
+        append("<detail>")
+        append("<contact callsign=\"${esc(callsign)}\"/>")
+        if (teamName != null) {
+            val role = teamRole?.let { " role=\"${esc(it)}\"" } ?: ""
+            append("<__group name=\"${esc(teamName)}\"$role/>")
+        }
+        if (pli.speed != 0 || pli.course != 0) {
+            append("<track speed=\"${pli.speed}\" course=\"${pli.course}\"/>")
+        }
+        append("</detail>")
+    }
+
+    private fun buildChatDetailXml(
+        callsign: String,
+        fromUid: String,
+        chat: ParsedChat,
+        teamName: String?,
+        teamRole: String?,
+        now: String,
+    ): String = buildString {
+        val chatroom = if (chat.to.isNotEmpty()) chat.to else "All Chat Rooms"
+        append("<detail>")
+        append("<__chat chatroom=\"${esc(chatroom)}\" groupOwner=\"false\"")
+        append(" id=\"${esc(chatroom)}\" parent=\"RootContactGroup\"")
+        append(" senderCallsign=\"${esc(callsign)}\">")
+        append("<chatgrp id=\"${esc(chatroom)}\" uid0=\"${esc(fromUid)}\" uid1=\"${esc(chatroom)}\"/>")
+        append("</__chat>")
+        append("<link relation=\"p-p\" type=\"a-f-G-U-C\" uid=\"${esc(fromUid)}\"/>")
+        if (teamName != null) {
+            val role = teamRole?.let { " role=\"${esc(it)}\"" } ?: ""
+            append("<__group name=\"${esc(teamName)}\"$role/>")
+        }
+        append("<remarks source=\"BAO.F.ATAK.${esc(fromUid)}\" time=\"$now\" to=\"${esc(chatroom)}\">")
+        append(esc(chat.message))
+        append("</remarks>")
+        append("</detail>")
+    }
+
+    private fun buildCoTXml(
+        uid: String, type: String, how: String,
+        lat: Double, lon: Double, hae: Double, ce: Double, le: Double,
+        timeIso: String, staleIso: String,
+        detailXml: String,
+    ): String = buildString {
+        append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+        append("<event version=\"2.0\" uid=\"${esc(uid)}\" type=\"${esc(type)}\"")
+        append(" time=\"$timeIso\" start=\"$timeIso\" stale=\"$staleIso\"")
+        append(" how=\"${esc(how)}\">")
+        append("<point lat=\"$lat\" lon=\"$lon\" hae=\"$hae\" ce=\"$ce\" le=\"$le\"/>")
+        append(detailXml)
+        append("</event>")
+    }
+
+    private fun esc(s: String) = s
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+
+    // endregion
+
+    // region Decompression helpers
+
+    /** Decompress a bytes field when is_compressed=true, otherwise decode as UTF-8. */
+    private fun decompressField(bytes: ByteArray, isCompressed: Boolean): String {
+        if (bytes.isEmpty()) return ""
+        return if (isCompressed) {
+            runCatching { Unishox2.decompress(bytes) }.getOrElse {
+                // Tolerate: if decompress fails, try raw UTF-8
+                runCatching { String(bytes, Charsets.UTF_8) }.getOrDefault("")
+            }
+        } else {
+            String(bytes, Charsets.UTF_8)
+        }
+    }
+
+    /**
+     * Tolerant decompression: try Unishox2 first (some senders compress `to`),
+     * fall back to raw UTF-8.
+     */
+    private fun decompressFieldTolerant(bytes: ByteArray): String {
+        if (bytes.isEmpty()) return ""
+        // If the first byte is a printable ASCII or common string start, treat as raw
+        val first = bytes[0].toInt() and 0xFF
+        if (first in 0x20..0x7E || first == 0x0A || first == 0x0D) {
+            return runCatching { String(bytes, Charsets.UTF_8) }.getOrDefault("")
+        }
+        // Otherwise try Unishox2
+        return runCatching { Unishox2.decompress(bytes) }
+            .getOrElse { runCatching { String(bytes, Charsets.UTF_8) }.getOrDefault("") }
+    }
+
+    // endregion
+
+    // region Timestamp helpers
+
+    private val isoFmt get() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+
+    private fun isoNow(): String = isoFmt.format(Date())
+    private fun isoStale(): String = isoFmt.format(Date(System.currentTimeMillis() + 300_000L))
+
+    // endregion
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakPacketSerializer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/TakPacketSerializer.kt
@@ -1,0 +1,236 @@
+package soy.engindearing.omnitak.mobile.data
+
+import java.io.ByteArrayOutputStream
+import kotlin.math.roundToLong
+
+/**
+ * Serializes a [CoTEvent] into a Meshtastic portnum-72 TAKPacket (atak.proto).
+ *
+ * This is the Phase-2 replacement for [AtakPluginSerializer.serialize] on the TX
+ * path. The TAKPacket format is the standard used by:
+ *   - Stock Meshtastic ATAK Plugin app
+ *   - Meshtastic phone-app with TAK role
+ *   - TAK_Meshtastic_Gateway
+ *
+ * COMPATIBILITY TARGET: Meshtastic firmware PRIOR to PR #10105 (merged 2026-05-26),
+ * which used unishox2 (default preset) for portnum-72 TAKPacket strings. #10105 dropped
+ * unishox2 for a V2 format. We target the pre-#10105 installed base — the ATAK-plugin /
+ * gateway / phone-app population deployed today. A future Phase 3 can add the V2 format.
+ *
+ * Schema (hand-rolled, no protobuf-javalite — consistent with project conventions):
+ *   TAKPacket {
+ *     is_compressed=1:varint, contact=2:LEN, group=3:LEN, status=4:LEN,
+ *     pli=5:LEN, chat=6:LEN
+ *   }
+ *   Contact { callsign=1:LEN bytes, device_callsign=2:LEN bytes }
+ *   Group   { role=1:varint, team=2:varint }
+ *   Status  { battery=1:varint }
+ *   PLI     { latitude_i=1:I32 sfixed32, longitude_i=2:I32 sfixed32,
+ *             altitude=3:varint, speed=4:varint, course=5:varint }
+ *   GeoChat { message=1:LEN, to=2:LEN, to_callsign=3:LEN }
+ *
+ * PLI packets: is_compressed=false — callsign/device_callsign as raw UTF-8.
+ * Chat packets: is_compressed=true — callsign/device_callsign/message compressed
+ *               via [Unishox2]; chat.to is always raw (matches gateway behaviour).
+ *
+ * Wire helpers reuse the same pattern as [AtakPluginSerializer].
+ */
+object TakPacketSerializer {
+
+    /**
+     * Build a TAKPacket payload for a PLI (position) event.
+     *
+     * @param event     The CoT event (must have valid lat/lon).
+     * @param callsign  The human-readable callsign (contact.callsign).
+     * @param deviceId  The unique device ID (contact.device_callsign / UID).
+     * @param battery   Battery level 0-100.
+     */
+    fun serializePli(
+        event: CoTEvent,
+        callsign: String = event.callsign ?: event.uid,
+        deviceId: String = event.uid,
+        battery: Int = 0,
+        speed: Int = 0,
+        course: Int = 0,
+    ): ByteArray {
+        val out = ByteArrayOutputStream()
+
+        // is_compressed=false → proto3 default, omit field 1 entirely so the
+        // wire matches the stock Meshtastic ATAK Plugin / gateway output.
+
+        // 2: contact
+        val contactBytes = buildContact(callsign, deviceId, compressed = false)
+        appendLenField(out, field = 2, bytes = contactBytes)
+
+        // 3: group
+        val team = Team.fromCotName(event.teamName)
+        val role = MemberRole.fromCotName(event.teamRole).let {
+            // Default to TeamMember if unspecified, matching gateway default
+            if (it == MemberRole.Unspecifed) MemberRole.TeamMember else it
+        }
+        val groupBytes = buildGroup(role, team)
+        appendLenField(out, field = 3, bytes = groupBytes)
+
+        // 4: status
+        val statusBytes = buildStatus(battery)
+        appendLenField(out, field = 4, bytes = statusBytes)
+
+        // 5: pli (oneof payload_variant)
+        val latI = (event.lat * 1e7).roundToLong().toInt()
+        val lonI = (event.lon * 1e7).roundToLong().toInt()
+        val altitude = event.hae.toInt()
+        val pliBytes = buildPli(latI, lonI, altitude, speed = speed, course = course)
+        appendLenField(out, field = 5, bytes = pliBytes)
+
+        return out.toByteArray()
+    }
+
+    /**
+     * Build a TAKPacket payload for a GeoChat (b-t-f) event.
+     *
+     * @param event     The CoT event.
+     * @param callsign  Sender callsign (will be Unishox2-compressed).
+     * @param deviceId  Sender device ID / UID (will be Unishox2-compressed).
+     * @param message   The chat message text (will be Unishox2-compressed).
+     * @param to        The chat destination (raw — "All Chat Rooms" or UID).
+     * @param battery   Battery level 0-100.
+     */
+    fun serializeChat(
+        event: CoTEvent,
+        callsign: String = event.callsign ?: event.uid,
+        deviceId: String = event.uid,
+        message: String = event.remarks,
+        to: String = "All Chat Rooms",
+        battery: Int = 0,
+    ): ByteArray {
+        val out = ByteArrayOutputStream()
+
+        // 1: is_compressed = true (1)
+        appendVarintField(out, field = 1, value = 1UL)
+
+        // 2: contact (compressed)
+        val contactBytes = buildContact(callsign, deviceId, compressed = true)
+        appendLenField(out, field = 2, bytes = contactBytes)
+
+        // 3: group
+        val team = Team.fromCotName(event.teamName)
+        val role = MemberRole.fromCotName(event.teamRole).let {
+            if (it == MemberRole.Unspecifed) MemberRole.TeamMember else it
+        }
+        val groupBytes = buildGroup(role, team)
+        appendLenField(out, field = 3, bytes = groupBytes)
+
+        // 4: status
+        val statusBytes = buildStatus(battery)
+        appendLenField(out, field = 4, bytes = statusBytes)
+
+        // 6: chat (oneof payload_variant) — message compressed, to raw
+        val chatBytes = buildChat(message, to, compressed = true)
+        appendLenField(out, field = 6, bytes = chatBytes)
+
+        return out.toByteArray()
+    }
+
+    // region Sub-message builders -------------------------------------------
+
+    private fun buildContact(callsign: String, deviceCallsign: String, compressed: Boolean): ByteArray {
+        val out = ByteArrayOutputStream()
+        val csBytes = if (compressed) Unishox2.compress(callsign) else callsign.toByteArray(Charsets.UTF_8)
+        val dcBytes = if (compressed) Unishox2.compress(deviceCallsign) else deviceCallsign.toByteArray(Charsets.UTF_8)
+        // 1: callsign (bytes)
+        appendTag(out, field = 1, wire = 2)
+        appendVarint(out, csBytes.size.toULong())
+        out.write(csBytes)
+        // 2: device_callsign (bytes)
+        appendTag(out, field = 2, wire = 2)
+        appendVarint(out, dcBytes.size.toULong())
+        out.write(dcBytes)
+        return out.toByteArray()
+    }
+
+    private fun buildGroup(role: MemberRole, team: Team): ByteArray {
+        val out = ByteArrayOutputStream()
+        // 1: role (varint)
+        appendVarintField(out, field = 1, value = role.value.toULong())
+        // 2: team (varint)
+        appendVarintField(out, field = 2, value = team.value.toULong())
+        return out.toByteArray()
+    }
+
+    private fun buildStatus(battery: Int): ByteArray {
+        val out = ByteArrayOutputStream()
+        // 1: battery (varint)
+        appendVarintField(out, field = 1, value = battery.toULong())
+        return out.toByteArray()
+    }
+
+    private fun buildPli(latI: Int, lonI: Int, altitude: Int, speed: Int, course: Int): ByteArray {
+        val out = ByteArrayOutputStream()
+        // 1: latitude_i  (sfixed32 / wire type 5)
+        appendTag(out, field = 1, wire = 5)
+        appendSFixed32(out, latI)
+        // 2: longitude_i (sfixed32 / wire type 5)
+        appendTag(out, field = 2, wire = 5)
+        appendSFixed32(out, lonI)
+        // 3: altitude (varint)
+        if (altitude != 0) appendVarintField(out, field = 3, value = altitude.toULong())
+        // 4: speed (varint)
+        if (speed != 0) appendVarintField(out, field = 4, value = speed.toULong())
+        // 5: course (varint)
+        if (course != 0) appendVarintField(out, field = 5, value = course.toULong())
+        return out.toByteArray()
+    }
+
+    private fun buildChat(message: String, to: String, compressed: Boolean): ByteArray {
+        val out = ByteArrayOutputStream()
+        val msgBytes = if (compressed) Unishox2.compress(message) else message.toByteArray(Charsets.UTF_8)
+        val toBytes = to.toByteArray(Charsets.UTF_8) // to is always raw
+        // 1: message (bytes)
+        appendTag(out, field = 1, wire = 2)
+        appendVarint(out, msgBytes.size.toULong())
+        out.write(msgBytes)
+        // 2: to (bytes)
+        appendTag(out, field = 2, wire = 2)
+        appendVarint(out, toBytes.size.toULong())
+        out.write(toBytes)
+        return out.toByteArray()
+    }
+
+    // endregion
+
+    // region Wire helpers (mirroring AtakPluginSerializer) ------------------
+
+    internal fun appendTag(out: ByteArrayOutputStream, field: Int, wire: Int) {
+        appendVarint(out, ((field shl 3) or (wire and 0x7)).toULong())
+    }
+
+    internal fun appendVarint(out: ByteArrayOutputStream, value: ULong) {
+        var v = value
+        while (v >= 0x80uL) {
+            out.write(((v and 0x7FuL).toInt()) or 0x80)
+            v = v shr 7
+        }
+        out.write(v.toInt() and 0x7F)
+    }
+
+    internal fun appendVarintField(out: ByteArrayOutputStream, field: Int, value: ULong) {
+        appendTag(out, field = field, wire = 0)
+        appendVarint(out, value)
+    }
+
+    private fun appendLenField(out: ByteArrayOutputStream, field: Int, bytes: ByteArray) {
+        appendTag(out, field = field, wire = 2)
+        appendVarint(out, bytes.size.toULong())
+        out.write(bytes)
+    }
+
+    /** sfixed32: 4-byte little-endian signed 32-bit integer. */
+    private fun appendSFixed32(out: ByteArrayOutputStream, value: Int) {
+        out.write(value and 0xFF)
+        out.write((value ushr 8) and 0xFF)
+        out.write((value ushr 16) and 0xFF)
+        out.write((value ushr 24) and 0xFF)
+    }
+
+    // endregion
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/Unishox2.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/Unishox2.kt
@@ -1,0 +1,1226 @@
+package soy.engindearing.omnitak.mobile.data
+
+/*
+ * Unishox2.kt — Pure-Kotlin port of the Unishox2 compression algorithm.
+ *
+ * Ported from the reference C implementation:
+ *   https://github.com/siara-cc/Unishox2/blob/master/unishox2.c
+ *   (commit: master branch, retrieved 2026-05-28)
+ *
+ * Original author: Arundale Ramanathan / Siara Logics (cc)
+ * License: Apache License 2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE: This file is a derivative work of Unishox2 (C implementation)
+ * by Arundale Ramanathan / Siara Logics (cc), ported to Kotlin for use
+ * in OmniTAK Android. The algorithm, tables, and logic are faithful to
+ * the original USX_PSET_DFLT (default preset) codec.
+ *
+ * Only compress() and decompress() are exposed. Both use the default
+ * preset (USX_PSET_DFLT) — which is what unishox2-py3 1.0.0 uses — so
+ * output is byte-identical to the Python library.
+ */
+
+/**
+ * Unishox2 compressor / decompressor using the DEFAULT preset
+ * (USX_PSET_DFLT). Produces output byte-identical to unishox2-py3 1.0.0.
+ *
+ * This is a pure-JVM implementation (no JNI) so it can run in unit tests
+ * without an Android environment.
+ */
+object Unishox2 {
+
+    // region Constants -------------------------------------------------------
+
+    // UNISHOX_MAGIC_BITS = 0xFF, UNISHOX_MAGIC_BIT_LEN = 1 → first bit = 1
+    private const val MAGIC_BITS: Int = 0xFF
+    private const val MAGIC_BIT_LEN: Int = 1
+
+    // Horizontal states
+    private const val USX_ALPHA = 0
+    private const val USX_SYM   = 1
+    private const val USX_NUM   = 2
+    private const val USX_DICT  = 3
+    private const val USX_DELTA = 4
+
+    // Switch / terminator codes
+    private const val SW_CODE     = 0
+    private const val SW_CODE_LEN = 2
+
+    private const val UNI_STATE_SPL_CODE     = 0xF8
+    private const val UNI_STATE_SPL_CODE_LEN = 5
+    private const val UNI_STATE_SW_CODE      = 0x80
+    private const val UNI_STATE_SW_CODE_LEN  = 2
+
+    private const val NICE_LEN = 5
+
+    // Varint-like codes stored as (code<<3 | len) → upper 5 bits = code, lower 3 = bitlen
+    private const val RPT_CODE      = (2 shl 5) + 26
+    private const val TERM_CODE     = (2 shl 5) + 27
+    private const val LF_CODE       = (1 shl 5) + 7
+    private const val CRLF_CODE     = (1 shl 5) + 8
+    private const val CR_CODE       = (1 shl 5) + 22
+    private const val TAB_CODE      = (1 shl 5) + 14
+    private const val NUM_SPC_CODE  = (2 shl 5) + 17
+
+    // Default preset tables
+    private val USX_HCODES = intArrayOf(0x00, 0x40, 0x80, 0xC0, 0xE0)
+    private val USX_HCODE_LENS = intArrayOf(2, 2, 2, 3, 3)
+
+    private val USX_FREQ_SEQ = arrayOf("\": \"", "\": ", "</", "=\"", "\":\"", "://")
+
+    private val USX_TEMPLATES = arrayOf<String?>(
+        "tfff-of-tfTtf:rf:rf.fffZ",
+        "tfff-of-tf",
+        "(fff) fff-ffff",
+        "tf:rf:rf",
+        null,
+    )
+
+    /** Character sets: [USX_ALPHA][USX_SYM][USX_NUM] × 28 positions.
+     *  Position 0 in each row is a "special" placeholder (0x00 in C). */
+    private val USX_SETS = arrayOf(
+        intArrayOf(
+            0, ' '.code, 'e'.code, 't'.code, 'a'.code, 'o'.code, 'i'.code, 'n'.code,
+            's'.code, 'r'.code, 'l'.code, 'c'.code, 'd'.code, 'h'.code, 'u'.code, 'p'.code,
+            'm'.code, 'b'.code, 'g'.code, 'w'.code, 'f'.code, 'y'.code, 'v'.code, 'k'.code,
+            'q'.code, 'j'.code, 'x'.code, 'z'.code,
+        ),
+        intArrayOf(
+            '"'.code, '{'.code, '}'.code, '_'.code, '<'.code, '>'.code, ':'.code, '\n'.code,
+            0, '['.code, ']'.code, '\\'.code, ';'.code, '\''.code, '\t'.code, '@'.code,
+            '*'.code, '&'.code, '?'.code, '!'.code, '^'.code, '|'.code, '\r'.code, '~'.code,
+            '`'.code, 0, 0, 0,
+        ),
+        intArrayOf(
+            0, ','.code, '.'.code, '0'.code, '1'.code, '9'.code, '2'.code, '5'.code,
+            '-'.code, '/'.code, '3'.code, '4'.code, '6'.code, '7'.code, '8'.code,
+            '('.code, ')'.code, ' '.code, '='.code, '+'.code, '$'.code, '%'.code,
+            '#'.code, 0, 0, 0, 0, 0,
+        ),
+    )
+
+    /** Vertical codes (MSB-aligned in the byte). */
+    private val USX_VCODES = intArrayOf(
+        0x00, 0x40, 0x60, 0x80, 0x90, 0xA0, 0xB0,
+        0xC0, 0xD0, 0xD8, 0xE0, 0xE4, 0xE8, 0xEC,
+        0xEE, 0xF0, 0xF2, 0xF4, 0xF6, 0xF7, 0xF8,
+        0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
+    )
+
+    /** Length of each vertical code (in bits). */
+    private val USX_VCODE_LENS = intArrayOf(
+        2, 3, 3, 4, 4, 4, 4,
+        4, 5, 5, 6, 6, 6, 7,
+        7, 7, 7, 7, 8, 8, 8,
+        8, 8, 8, 8, 8, 8, 8,
+    )
+
+    /** Freq-sequence codes: upper 3 bits = set (USX_SYM/USX_NUM), lower 5 = vcode pos. */
+    private val USX_FREQ_CODES = intArrayOf(
+        (1 shl 5) + 25, (1 shl 5) + 26, (1 shl 5) + 27,
+        (2 shl 5) + 23, (2 shl 5) + 24, (2 shl 5) + 25,
+    )
+
+    private const val USX_OFFSET_94 = 33
+
+    /** usx_code_94[c - 33]: upper 3 bits = set, lower 5 = vpos. */
+    private val USX_CODE_94 = IntArray(94)
+
+    // Count encoding tables
+    private val COUNT_BIT_LENS = intArrayOf(2, 4, 7, 11, 16)
+    private val COUNT_ADDER    = intArrayOf(4, 20, 148, 2196, 67732)
+    // count_codes[] in C: {0x01,0x82,0xC3,0xE4,0xF4} — upper 5 bits code, lower 3 bits length
+    private val COUNT_CODES    = intArrayOf(0x01, 0x82, 0xC3, 0xE4, 0xF4)
+
+    // Unicode delta encoding tables
+    private val UNI_BIT_LEN = intArrayOf(6, 12, 14, 16, 21)
+    private val UNI_ADDER   = intArrayOf(0, 64, 4160, 20544, 86080)
+
+    // Decoder vertical lookup helpers
+    private val USX_VSECTIONS     = intArrayOf(0x7F, 0xBF, 0xDF, 0xEF, 0xFF)
+    private val USX_VSECTION_POS  = intArrayOf(0, 4, 8, 12, 20)
+    private val USX_VSECTION_MASK = intArrayOf(0x7F, 0x3F, 0x1F, 0x0F, 0x0F)
+    private val USX_VSECTION_SHIFT= intArrayOf(5, 4, 3, 1, 0)
+
+    private val USX_VCODE_LOOKUP = intArrayOf(
+        (1 shl 5) + 0,  (1 shl 5) + 0,  (2 shl 5) + 1,  (2 shl 5) + 2,
+        (3 shl 5) + 3,  (3 shl 5) + 4,  (3 shl 5) + 5,  (3 shl 5) + 6,
+        (3 shl 5) + 7,  (3 shl 5) + 7,  (4 shl 5) + 8,  (4 shl 5) + 9,
+        (5 shl 5) + 10, (5 shl 5) + 10, (5 shl 5) + 11, (5 shl 5) + 11,
+        (5 shl 5) + 12, (5 shl 5) + 12, (6 shl 5) + 13, (6 shl 5) + 14,
+        (6 shl 5) + 15, (6 shl 5) + 15, (6 shl 5) + 16, (6 shl 5) + 16,
+        (6 shl 5) + 17, (6 shl 5) + 17, (7 shl 5) + 18, (7 shl 5) + 19,
+        (7 shl 5) + 20, (7 shl 5) + 21, (7 shl 5) + 22, (7 shl 5) + 23,
+        (7 shl 5) + 24, (7 shl 5) + 25, (7 shl 5) + 26, (7 shl 5) + 27,
+    )
+
+    private val USX_MASK = intArrayOf(0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0xFE, 0xFF)
+
+    // Nibble types
+    private const val USX_NIB_NUM       = 0
+    private const val USX_NIB_HEX_LOWER = 1
+    private const val USX_NIB_HEX_UPPER = 2
+    private const val USX_NIB_NOT       = 3
+
+    // Init flag
+    private var isInited = false
+
+    // endregion
+
+    // region Initialisation -------------------------------------------------
+
+    private fun initCoder() {
+        if (isInited) return
+        USX_CODE_94.fill(0)
+        for (i in 0 until 3) {
+            for (j in 0 until 28) {
+                val c = USX_SETS[i][j]
+                if (c > 32) {
+                    USX_CODE_94[c - USX_OFFSET_94] = (i shl 5) + j
+                    if (c in 'a'.code..'z'.code)
+                        USX_CODE_94[c - USX_OFFSET_94 - ('a'.code - 'A'.code)] = (i shl 5) + j
+                }
+            }
+        }
+        isInited = true
+    }
+
+    // endregion
+
+    // region Public API -----------------------------------------------------
+
+    /**
+     * Compress [text] using the Unishox2 default preset.
+     * Output is byte-identical to Python `unishox2.compress(text)`.
+     */
+    fun compress(text: String): ByteArray {
+        initCoder()
+        val inBytes = text.toByteArray(Charsets.UTF_8)
+        val len = inBytes.size
+        // Allocate generous output buffer (same as Python: 4× input size minimum)
+        val maxOut = maxOf(len * 4 + 16, 32)
+        val out = ByteArray(maxOut)
+        val ol = compressInternal(inBytes, len, out, maxOut)
+        return out.copyOf(ol)
+    }
+
+    /**
+     * Decompress [data] using the Unishox2 default preset.
+     * Output is byte-identical to Python `unishox2.decompress(data, len)`.
+     */
+    fun decompress(data: ByteArray): String {
+        initCoder()
+        val len = data.size
+        val maxOut = maxOf(len * 10, 64)
+        val out = ByteArray(maxOut)
+        val ol = decompressInternal(data, len, out, maxOut)
+        return String(out, 0, ol, Charsets.UTF_8)
+    }
+
+    // endregion
+
+    // region Compress -------------------------------------------------------
+
+    private fun appendBits(out: ByteArray, olen: Int, ol: Int, code: Int, clen: Int): Int {
+        var curOl = ol
+        var curCode = code
+        var curClen = clen
+        while (curClen > 0) {
+            val curBit = curOl % 8
+            var blen = curClen
+            var aByte = curCode and USX_MASK[blen - 1]
+            aByte = aByte ushr curBit
+            if (blen + curBit > 8) blen = 8 - curBit
+            val oidx = curOl / 8
+            if (oidx < 0 || olen <= oidx) return -1
+            if (curBit == 0) out[oidx] = aByte.toByte()
+            else out[oidx] = (out[oidx].toInt() or aByte).toByte()
+            curCode = curCode shl blen
+            curOl += blen
+            curClen -= blen
+        }
+        return curOl
+    }
+
+    private fun appendSwitchCode(out: ByteArray, olen: Int, ol: Int, state: Int): Int {
+        return if (state == USX_DELTA) {
+            val ol2 = appendBits(out, olen, ol, UNI_STATE_SPL_CODE, UNI_STATE_SPL_CODE_LEN)
+            if (ol2 < 0) return ol2
+            appendBits(out, olen, ol2, UNI_STATE_SW_CODE, UNI_STATE_SW_CODE_LEN)
+        } else {
+            appendBits(out, olen, ol, SW_CODE, SW_CODE_LEN)
+        }
+    }
+
+    private fun appendCode(
+        out: ByteArray, olen: Int, ol: Int, code: Int,
+        stateRef: IntArray, // [0] = mutable state
+    ): Int {
+        val hcode = code ushr 5
+        val vcode = code and 0x1F
+        if (USX_HCODE_LENS[hcode] == 0 && hcode != USX_ALPHA) return ol
+        var curOl = ol
+        when (hcode) {
+            USX_ALPHA -> {
+                if (stateRef[0] != USX_ALPHA) {
+                    curOl = appendSwitchCode(out, olen, curOl, stateRef[0])
+                    if (curOl < 0) return curOl
+                    curOl = appendBits(out, olen, curOl, USX_HCODES[USX_ALPHA], USX_HCODE_LENS[USX_ALPHA])
+                    if (curOl < 0) return curOl
+                    stateRef[0] = USX_ALPHA
+                }
+            }
+            USX_SYM -> {
+                curOl = appendSwitchCode(out, olen, curOl, stateRef[0])
+                if (curOl < 0) return curOl
+                curOl = appendBits(out, olen, curOl, USX_HCODES[USX_SYM], USX_HCODE_LENS[USX_SYM])
+                if (curOl < 0) return curOl
+            }
+            USX_NUM -> {
+                if (stateRef[0] != USX_NUM) {
+                    curOl = appendSwitchCode(out, olen, curOl, stateRef[0])
+                    if (curOl < 0) return curOl
+                    curOl = appendBits(out, olen, curOl, USX_HCODES[USX_NUM], USX_HCODE_LENS[USX_NUM])
+                    if (curOl < 0) return curOl
+                    val c = USX_SETS[hcode][vcode]
+                    if (c in '0'.code..'9'.code) stateRef[0] = USX_NUM
+                }
+            }
+        }
+        return appendBits(out, olen, curOl, USX_VCODES[vcode], USX_VCODE_LENS[vcode])
+    }
+
+    private fun encodeCount(out: ByteArray, olen: Int, ol: Int, count: Int): Int {
+        var curOl = ol
+        for (i in 0 until 5) {
+            if (count < COUNT_ADDER[i]) {
+                curOl = appendBits(out, olen, curOl, COUNT_CODES[i] and 0xF8, COUNT_CODES[i] and 0x07)
+                if (curOl < 0) return curOl
+                val adj = count - (if (i > 0) COUNT_ADDER[i - 1] else 0)
+                val count16 = (adj shl (16 - COUNT_BIT_LENS[i])) and 0xFFFF
+                if (COUNT_BIT_LENS[i] > 8) {
+                    curOl = appendBits(out, olen, curOl, count16 ushr 8, 8)
+                    if (curOl < 0) return curOl
+                    curOl = appendBits(out, olen, curOl, count16 and 0xFF, COUNT_BIT_LENS[i] - 8)
+                } else {
+                    curOl = appendBits(out, olen, curOl, count16 ushr 8, COUNT_BIT_LENS[i])
+                }
+                return curOl
+            }
+        }
+        return curOl
+    }
+
+    private fun encodeUnicode(out: ByteArray, olen: Int, ol: Int, code: Int, prevCode: Int): Int {
+        val codes = intArrayOf(0x01, 0x82, 0xC3, 0xE4, 0xF5, 0xFD)
+        var diff = code - prevCode
+        if (diff < 0) diff = -diff
+        var till = 0
+        for (i in 0 until 5) {
+            till += (1 shl UNI_BIT_LEN[i])
+            if (diff < till) {
+                var curOl = appendBits(out, olen, ol, codes[i] and 0xF8, codes[i] and 0x07)
+                if (curOl < 0) return curOl
+                curOl = appendBits(out, olen, curOl, if (prevCode > code) 0x80 else 0, 1)
+                if (curOl < 0) return curOl
+                val value = diff - UNI_ADDER[i]
+                when {
+                    UNI_BIT_LEN[i] > 16 -> {
+                        val v = (value shl (24 - UNI_BIT_LEN[i])) and 0xFFFFFF
+                        curOl = appendBits(out, olen, curOl, v ushr 16, 8)
+                        if (curOl < 0) return curOl
+                        curOl = appendBits(out, olen, curOl, (v ushr 8) and 0xFF, 8)
+                        if (curOl < 0) return curOl
+                        curOl = appendBits(out, olen, curOl, v and 0xFF, UNI_BIT_LEN[i] - 16)
+                    }
+                    UNI_BIT_LEN[i] > 8 -> {
+                        val v = (value shl (16 - UNI_BIT_LEN[i])) and 0xFFFF
+                        curOl = appendBits(out, olen, curOl, v ushr 8, 8)
+                        if (curOl < 0) return curOl
+                        curOl = appendBits(out, olen, curOl, v and 0xFF, UNI_BIT_LEN[i] - 8)
+                    }
+                    else -> {
+                        val v = (value shl (8 - UNI_BIT_LEN[i])) and 0xFF
+                        curOl = appendBits(out, olen, curOl, v, UNI_BIT_LEN[i])
+                    }
+                }
+                return curOl
+            }
+        }
+        return ol
+    }
+
+    private fun readUTF8(inBytes: ByteArray, len: Int, l: Int): Pair<Int, Int> {
+        // Returns (codepoint, utf8len) or (0, 0) if not valid multi-byte UTF-8
+        if (l < len - 1 && (inBytes[l].toInt() and 0xE0) == 0xC0 && (inBytes[l + 1].toInt() and 0xC0) == 0x80) {
+            val ret = ((inBytes[l].toInt() and 0x1F) shl 6) + (inBytes[l + 1].toInt() and 0x3F)
+            if (ret >= 0x80) return ret to 2
+        }
+        if (l < len - 2 &&
+            (inBytes[l].toInt() and 0xF0) == 0xE0 &&
+            (inBytes[l + 1].toInt() and 0xC0) == 0x80 &&
+            (inBytes[l + 2].toInt() and 0xC0) == 0x80
+        ) {
+            val ret = ((inBytes[l].toInt() and 0x0F) shl 12) +
+                ((inBytes[l + 1].toInt() and 0x3F) shl 6) +
+                (inBytes[l + 2].toInt() and 0x3F)
+            if (ret >= 0x0800) return ret to 3
+        }
+        if (l < len - 3 &&
+            (inBytes[l].toInt() and 0xF8) == 0xF0 &&
+            (inBytes[l + 1].toInt() and 0xC0) == 0x80 &&
+            (inBytes[l + 2].toInt() and 0xC0) == 0x80 &&
+            (inBytes[l + 3].toInt() and 0xC0) == 0x80
+        ) {
+            val ret = ((inBytes[l].toInt() and 0x07) shl 18) +
+                ((inBytes[l + 1].toInt() and 0x3F) shl 12) +
+                ((inBytes[l + 2].toInt() and 0x3F) shl 6) +
+                (inBytes[l + 3].toInt() and 0x3F)
+            if (ret >= 0x10000) return ret to 4
+        }
+        return 0 to 0
+    }
+
+    private fun matchOccurrence(
+        inBytes: ByteArray, len: Int, l: Int,
+        out: ByteArray, olen: Int, olRef: IntArray,
+        stateRef: IntArray,
+    ): Int {
+        var longestDist = 0
+        var longestLen = 0
+        var j = l - NICE_LEN
+        while (j >= 0) {
+            var k = l
+            while (k < len && j + k - l < l) {
+                if (inBytes[k] != inBytes[j + k - l]) break
+                k++
+            }
+            // Skip partial UTF-8 trailing continuation bytes
+            while (k > l && (inBytes[k - 1].toInt() and 0xC0) == 0x80) k--
+            if ((k - l) > (NICE_LEN - 1)) {
+                val matchLen = k - l - NICE_LEN
+                val matchDist = l - j - NICE_LEN + 1
+                if (matchLen > longestLen) {
+                    longestLen = matchLen
+                    longestDist = matchDist
+                }
+            }
+            j--
+        }
+        if (longestLen > 0) {
+            var curOl = appendSwitchCode(out, olen, olRef[0], stateRef[0])
+            if (curOl < 0) return curOl
+            curOl = appendBits(out, olen, curOl, USX_HCODES[USX_DICT], USX_HCODE_LENS[USX_DICT])
+            if (curOl < 0) return curOl
+            curOl = encodeCount(out, olen, curOl, longestLen)
+            if (curOl < 0) return curOl
+            curOl = encodeCount(out, olen, curOl, longestDist)
+            if (curOl < 0) return curOl
+            olRef[0] = curOl
+            return l + longestLen + NICE_LEN - 1
+        }
+        return -(l)
+    }
+
+    private fun getNibbleType(c: Int): Int = when {
+        c in '0'.code..'9'.code -> USX_NIB_NUM
+        c in 'a'.code..'f'.code -> USX_NIB_HEX_LOWER
+        c in 'A'.code..'F'.code -> USX_NIB_HEX_UPPER
+        else -> USX_NIB_NOT
+    }
+
+    private fun getBaseCode(c: Int): Int = when {
+        c in '0'.code..'9'.code -> (c - '0'.code) shl 4
+        c in 'A'.code..'F'.code -> (c - 'A'.code + 10) shl 4
+        c in 'a'.code..'f'.code -> (c - 'a'.code + 10) shl 4
+        else -> 0
+    }
+
+    private fun appendNibbleEscape(out: ByteArray, olen: Int, ol: Int, state: Int): Int {
+        var curOl = appendSwitchCode(out, olen, ol, state)
+        if (curOl < 0) return curOl
+        curOl = appendBits(out, olen, curOl, USX_HCODES[USX_NUM], USX_HCODE_LENS[USX_NUM])
+        if (curOl < 0) return curOl
+        return appendBits(out, olen, curOl, 0, 2)
+    }
+
+    private fun appendFinalBits(
+        out: ByteArray, olen: Int, ol: Int,
+        state: Int, isAllUpper: Boolean,
+    ): Int {
+        var curOl = ol
+        if (USX_HCODE_LENS[USX_ALPHA] != 0) {
+            if (state != USX_NUM) {
+                curOl = appendSwitchCode(out, olen, curOl, state)
+                if (curOl < 0) return curOl
+                curOl = appendBits(out, olen, curOl, USX_HCODES[USX_NUM], USX_HCODE_LENS[USX_NUM])
+                if (curOl < 0) return curOl
+            }
+            curOl = appendBits(out, olen, curOl, USX_VCODES[TERM_CODE and 0x1F], USX_VCODE_LENS[TERM_CODE and 0x1F])
+            if (curOl < 0) return curOl
+        }
+        // Fill last byte with the last bit pattern
+        val lastBit = if (curOl == 0) 0
+        else if ((out[(curOl - 1) / 8].toInt() shl ((curOl - 1) and 7)) and 0x80 != 0) 0xFF else 0
+        return appendBits(out, olen, curOl, lastBit, (8 - curOl % 8) and 7)
+    }
+
+    private fun compressInternal(inBytes: ByteArray, len: Int, out: ByteArray, olen: Int): Int {
+        var ol = 0
+        var l = 0
+        var prevUni = 0
+        val stateRef = intArrayOf(USX_ALPHA)
+        var isAllUpper = false
+
+        // Magic bit
+        ol = appendBits(out, olen, ol, MAGIC_BITS, MAGIC_BIT_LEN)
+        if (ol < 0) return 0
+
+        while (l < len) {
+            // Dict match
+            if (USX_HCODE_LENS[USX_DICT] != 0 && l < len - NICE_LEN + 1) {
+                val olRef = intArrayOf(ol)
+                val ret = matchOccurrence(inBytes, len, l, out, olen, olRef, stateRef)
+                if (ret > 0) {
+                    ol = olRef[0]
+                    l = ret + 1
+                    continue
+                } else if (ret < 0 && olRef[0] < 0) {
+                    return olen + 1
+                }
+                // ret == -l means no match, continue normally
+            }
+
+            var cIn = inBytes[l].toInt() and 0xFF
+
+            // Repeat run detection
+            if (l > 0 && len > 4 && l < len - 4 && USX_HCODE_LENS[USX_NUM] != 0) {
+                if (cIn == (inBytes[l - 1].toInt() and 0xFF) &&
+                    cIn == (inBytes[l + 1].toInt() and 0xFF) &&
+                    cIn == (inBytes[l + 2].toInt() and 0xFF) &&
+                    cIn == (inBytes[l + 3].toInt() and 0xFF)
+                ) {
+                    var rptCount = l + 4
+                    while (rptCount < len && (inBytes[rptCount].toInt() and 0xFF) == cIn) rptCount++
+                    rptCount -= l
+                    ol = appendCode(out, olen, ol, RPT_CODE, stateRef)
+                    if (ol < 0) return 0
+                    ol = encodeCount(out, olen, ol, rptCount - 4)
+                    if (ol < 0) return 0
+                    l += rptCount
+                    continue
+                }
+            }
+
+            // UUID detection
+            if (l <= len - 36 && USX_HCODE_LENS[USX_NUM] != 0) {
+                val b = inBytes
+                if (b[l + 8].toInt().toChar() == '-' && b[l + 13].toInt().toChar() == '-' &&
+                    b[l + 18].toInt().toChar() == '-' && b[l + 23].toInt().toChar() == '-'
+                ) {
+                    var hexType = USX_NIB_NUM
+                    var uidPos = l
+                    while (uidPos < l + 36) {
+                        val cu = b[uidPos].toInt() and 0xFF
+                        if (cu == '-'.code && (uidPos - l == 8 || uidPos - l == 13 || uidPos - l == 18 || uidPos - l == 23)) {
+                            uidPos++; continue
+                        }
+                        val nibType = getNibbleType(cu)
+                        if (nibType == USX_NIB_NOT) break
+                        if (nibType != USX_NIB_NUM) {
+                            if (hexType != USX_NIB_NUM && hexType != nibType) break
+                            hexType = nibType
+                        }
+                        uidPos++
+                    }
+                    if (uidPos == l + 36) {
+                        ol = appendNibbleEscape(out, olen, ol, stateRef[0])
+                        if (ol < 0) return 0
+                        ol = appendBits(out, olen, ol, if (hexType == USX_NIB_HEX_LOWER) 0xC0 else 0xF0,
+                            if (hexType == USX_NIB_HEX_LOWER) 3 else 5)
+                        if (ol < 0) return 0
+                        for (up in l until l + 36) {
+                            val cu = b[up].toInt() and 0xFF
+                            if (cu != '-'.code) {
+                                ol = appendBits(out, olen, ol, getBaseCode(cu), 4)
+                                if (ol < 0) return 0
+                            }
+                        }
+                        l += 36
+                        continue
+                    }
+                }
+            }
+
+            // Hex run detection
+            if (l < len - 5 && USX_HCODE_LENS[USX_NUM] != 0) {
+                var hexType = USX_NIB_NUM
+                var hexLen = 0
+                while (l + hexLen < len) {
+                    val nibType = getNibbleType(inBytes[l + hexLen].toInt() and 0xFF)
+                    if (nibType == USX_NIB_NOT) break
+                    if (nibType != USX_NIB_NUM) {
+                        if (hexType != USX_NIB_NUM && hexType != nibType) break
+                        hexType = nibType
+                    }
+                    hexLen++
+                }
+                if (hexLen > 10 && hexType == USX_NIB_NUM) hexType = USX_NIB_HEX_LOWER
+                if ((hexType == USX_NIB_HEX_LOWER || hexType == USX_NIB_HEX_UPPER) && hexLen > 3) {
+                    ol = appendNibbleEscape(out, olen, ol, stateRef[0])
+                    if (ol < 0) return 0
+                    ol = appendBits(out, olen, ol, if (hexType == USX_NIB_HEX_LOWER) 0x80 else 0xE0,
+                        if (hexType == USX_NIB_HEX_LOWER) 2 else 4)
+                    if (ol < 0) return 0
+                    ol = encodeCount(out, olen, ol, hexLen)
+                    if (ol < 0) return 0
+                    var hl = hexLen
+                    var li = l
+                    do {
+                        ol = appendBits(out, olen, ol, getBaseCode(inBytes[li].toInt() and 0xFF), 4)
+                        if (ol < 0) return 0
+                        li++
+                    } while (--hl > 0)
+                    l = li
+                    continue
+                }
+            }
+
+            // Template detection
+            var matchedTemplate = false
+            for (ti in USX_TEMPLATES.indices) {
+                val tmpl = USX_TEMPLATES[ti] ?: continue
+                val rem = tmpl.length
+                var j = 0
+                while (j < rem && l + j < len) {
+                    val ct = tmpl[j]
+                    val ci = inBytes[l + j].toInt() and 0xFF
+                    val ciChar = ci.toChar()
+                    if (ct == 'f' || ct == 'F') {
+                        val nibType = getNibbleType(ci)
+                        if (nibType != (if (ct == 'f') USX_NIB_HEX_LOWER else USX_NIB_HEX_UPPER) && nibType != USX_NIB_NUM) break
+                    } else if (ct == 'r' || ct == 't' || ct == 'o') {
+                        val maxDigit = when (ct) { 'r' -> '7'; 't' -> '3'; else -> '1' }
+                        if (ciChar < '0' || ciChar > maxDigit) break
+                    } else if (ct != ciChar) break
+                    j++
+                }
+                if (j.toFloat() / rem > 0.66f) {
+                    val curRem = rem - j
+                    ol = appendNibbleEscape(out, olen, ol, stateRef[0])
+                    if (ol < 0) return 0
+                    ol = appendBits(out, olen, ol, 0, 1)
+                    if (ol < 0) return 0
+                    ol = appendBits(out, olen, ol, COUNT_CODES[ti] and 0xF8, COUNT_CODES[ti] and 0x07)
+                    if (ol < 0) return 0
+                    ol = encodeCount(out, olen, ol, curRem)
+                    if (ol < 0) return 0
+                    for (k in 0 until j) {
+                        val ct = tmpl[k]
+                        if (ct == 'f' || ct == 'F') {
+                            ol = appendBits(out, olen, ol, getBaseCode(inBytes[l + k].toInt() and 0xFF), 4)
+                            if (ol < 0) return 0
+                        } else if (ct == 'r' || ct == 't' || ct == 'o') {
+                            val nbits = when (ct) { 'r' -> 3; 't' -> 2; else -> 1 }
+                            ol = appendBits(out, olen, ol, ((inBytes[l + k].toInt() and 0xFF) - '0'.code) shl (8 - nbits), nbits)
+                            if (ol < 0) return 0
+                        }
+                    }
+                    l += j
+                    matchedTemplate = true
+                    break
+                }
+            }
+            if (matchedTemplate) continue
+
+            // Frequent sequence detection
+            var matchedFreq = false
+            for (fi in 0 until 6) {
+                val seq = USX_FREQ_SEQ[fi]
+                val seqLen = seq.length
+                if (len - seqLen >= 0 && l <= len - seqLen) {
+                    val setIdx = USX_FREQ_CODES[fi] ushr 5
+                    if (USX_HCODE_LENS[setIdx] != 0) {
+                        var match = true
+                        for (si in 0 until seqLen) {
+                            if ((inBytes[l + si].toInt() and 0xFF) != seq[si].code) { match = false; break }
+                        }
+                        if (match) {
+                            ol = appendCode(out, olen, ol, USX_FREQ_CODES[fi], stateRef)
+                            if (ol < 0) return 0
+                            l += seqLen
+                            matchedFreq = true
+                            break
+                        }
+                    }
+                }
+            }
+            if (matchedFreq) continue
+
+            cIn = inBytes[l].toInt() and 0xFF
+            var isUpper = cIn in 'A'.code..'Z'.code
+
+            if (!isUpper) {
+                if (isAllUpper) {
+                    isAllUpper = false
+                    ol = appendSwitchCode(out, olen, ol, stateRef[0])
+                    if (ol < 0) return 0
+                    ol = appendBits(out, olen, ol, USX_HCODES[USX_ALPHA], USX_HCODE_LENS[USX_ALPHA])
+                    if (ol < 0) return 0
+                    stateRef[0] = USX_ALPHA
+                }
+            }
+
+            if (isUpper && !isAllUpper) {
+                if (stateRef[0] == USX_NUM) {
+                    ol = appendSwitchCode(out, olen, ol, stateRef[0])
+                    if (ol < 0) return 0
+                    ol = appendBits(out, olen, ol, USX_HCODES[USX_ALPHA], USX_HCODE_LENS[USX_ALPHA])
+                    if (ol < 0) return 0
+                    stateRef[0] = USX_ALPHA
+                }
+                ol = appendSwitchCode(out, olen, ol, stateRef[0])
+                if (ol < 0) return 0
+                ol = appendBits(out, olen, ol, USX_HCODES[USX_ALPHA], USX_HCODE_LENS[USX_ALPHA])
+                if (ol < 0) return 0
+                if (stateRef[0] == USX_DELTA) {
+                    stateRef[0] = USX_ALPHA
+                    ol = appendSwitchCode(out, olen, ol, stateRef[0])
+                    if (ol < 0) return 0
+                    ol = appendBits(out, olen, ol, USX_HCODES[USX_ALPHA], USX_HCODE_LENS[USX_ALPHA])
+                    if (ol < 0) return 0
+                }
+            }
+
+            val cNext = if (l + 1 < len) inBytes[l + 1].toInt() and 0xFF else 0
+
+            if (cIn in 32..126) {
+                if (isUpper && !isAllUpper) {
+                    var ll = l + 4
+                    while (ll >= l && ll < len) {
+                        if ((inBytes[ll].toInt() and 0xFF) < 'A'.code || (inBytes[ll].toInt() and 0xFF) > 'Z'.code) break
+                        ll--
+                    }
+                    if (ll == l - 1) {
+                        ol = appendSwitchCode(out, olen, ol, stateRef[0])
+                        if (ol < 0) return 0
+                        ol = appendBits(out, olen, ol, USX_HCODES[USX_ALPHA], USX_HCODE_LENS[USX_ALPHA])
+                        if (ol < 0) return 0
+                        stateRef[0] = USX_ALPHA
+                        isAllUpper = true
+                    }
+                }
+                if (stateRef[0] == USX_DELTA && (cIn == ' '.code || cIn == '.'.code || cIn == ','.code)) {
+                    val splCode = when (cIn.toChar()) {
+                        ',' -> 0xC0; '.' -> 0xE0; ' ' -> 0; else -> -1
+                    }
+                    val splCodeLen = when (cIn.toChar()) {
+                        ',' -> 3; '.' -> 4; ' ' -> 1; else -> 4
+                    }
+                    if (splCode >= 0) {
+                        ol = appendBits(out, olen, ol, UNI_STATE_SPL_CODE, UNI_STATE_SPL_CODE_LEN)
+                        if (ol < 0) return 0
+                        ol = appendBits(out, olen, ol, splCode, splCodeLen)
+                        if (ol < 0) return 0
+                        l++
+                        continue
+                    }
+                }
+                var cInAdj = cIn - 32
+                if (isAllUpper && isUpper) cInAdj += 32
+                if (cInAdj == 0) {
+                    if (stateRef[0] == USX_NUM) {
+                        ol = appendBits(out, olen, ol, USX_VCODES[NUM_SPC_CODE and 0x1F], USX_VCODE_LENS[NUM_SPC_CODE and 0x1F])
+                    } else {
+                        ol = appendBits(out, olen, ol, USX_VCODES[1], USX_VCODE_LENS[1])
+                    }
+                    if (ol < 0) return 0
+                } else {
+                    val code94 = USX_CODE_94[cInAdj - 1]
+                    ol = appendCode(out, olen, ol, code94, stateRef)
+                    if (ol < 0) return 0
+                }
+            } else if (cIn == 13 && cNext == 10) {
+                ol = appendCode(out, olen, ol, CRLF_CODE, stateRef)
+                if (ol < 0) return 0
+                l++
+            } else if (cIn == 10) {
+                if (stateRef[0] == USX_DELTA) {
+                    ol = appendBits(out, olen, ol, UNI_STATE_SPL_CODE, UNI_STATE_SPL_CODE_LEN)
+                    if (ol < 0) return 0
+                    ol = appendBits(out, olen, ol, 0xF0, 4)
+                    if (ol < 0) return 0
+                } else {
+                    ol = appendCode(out, olen, ol, LF_CODE, stateRef)
+                    if (ol < 0) return 0
+                }
+            } else if (cIn == 13) {
+                ol = appendCode(out, olen, ol, CR_CODE, stateRef)
+                if (ol < 0) return 0
+            } else if (cIn == '\t'.code) {
+                ol = appendCode(out, olen, ol, TAB_CODE, stateRef)
+                if (ol < 0) return 0
+            } else {
+                val (uni, utf8len) = readUTF8(inBytes, len, l)
+                if (uni != 0) {
+                    var curL = l + utf8len
+                    if (stateRef[0] != USX_DELTA) {
+                        val (uni2, _) = readUTF8(inBytes, len, curL)
+                        if (uni2 != 0) {
+                            if (stateRef[0] != USX_ALPHA) {
+                                ol = appendSwitchCode(out, olen, ol, stateRef[0])
+                                if (ol < 0) return 0
+                                ol = appendBits(out, olen, ol, USX_HCODES[USX_ALPHA], USX_HCODE_LENS[USX_ALPHA])
+                                if (ol < 0) return 0
+                            }
+                            ol = appendSwitchCode(out, olen, ol, stateRef[0])
+                            if (ol < 0) return 0
+                            ol = appendBits(out, olen, ol, USX_HCODES[USX_ALPHA], USX_HCODE_LENS[USX_ALPHA])
+                            if (ol < 0) return 0
+                            ol = appendBits(out, olen, ol, USX_VCODES[1], USX_VCODE_LENS[1])
+                            if (ol < 0) return 0
+                            stateRef[0] = USX_DELTA
+                        } else {
+                            ol = appendSwitchCode(out, olen, ol, stateRef[0])
+                            if (ol < 0) return 0
+                            ol = appendBits(out, olen, ol, USX_HCODES[USX_DELTA], USX_HCODE_LENS[USX_DELTA])
+                            if (ol < 0) return 0
+                        }
+                    }
+                    ol = encodeUnicode(out, olen, ol, uni, prevUni)
+                    if (ol < 0) return 0
+                    prevUni = uni
+                    l = curL
+                    continue
+                } else {
+                    // Binary escape
+                    var binCount = 1
+                    var bi = l + 1
+                    while (bi < len) {
+                        val (u, _) = readUTF8(inBytes, len, bi)
+                        if (u != 0) break
+                        val cBi = inBytes[bi].toInt() and 0xFF
+                        if (bi < len - 4 &&
+                            cBi == (inBytes[bi - 1].toInt() and 0xFF) &&
+                            cBi == (inBytes[bi + 1].toInt() and 0xFF) &&
+                            cBi == (inBytes[bi + 2].toInt() and 0xFF) &&
+                            cBi == (inBytes[bi + 3].toInt() and 0xFF)
+                        ) break
+                        binCount++
+                        bi++
+                    }
+                    ol = appendNibbleEscape(out, olen, ol, stateRef[0])
+                    if (ol < 0) return 0
+                    ol = appendBits(out, olen, ol, 0xF8, 5)
+                    if (ol < 0) return 0
+                    ol = encodeCount(out, olen, ol, binCount)
+                    if (ol < 0) return 0
+                    var bc = binCount
+                    var li = l
+                    do {
+                        ol = appendBits(out, olen, ol, inBytes[li].toInt() and 0xFF, 8)
+                        if (ol < 0) return 0
+                        li++
+                    } while (--bc > 0)
+                    l = li
+                    continue
+                }
+            }
+            l++
+        }
+
+        // Terminator + fill last byte
+        val finalOl = (ol + 7) / 8
+        appendFinalBits(out, finalOl, ol, stateRef[0], isAllUpper)
+        return finalOl
+    }
+
+    // endregion
+
+    // region Decompress -----------------------------------------------------
+
+    private fun readBit(inBytes: ByteArray, bitNo: Int): Int =
+        inBytes[bitNo shr 3].toInt() and (0x80 ushr (bitNo % 8))
+
+    private fun read8bitCode(inBytes: ByteArray, lenBits: Int, bitNo: Int): Int {
+        val bitPos = bitNo and 0x07
+        val charPos = bitNo shr 3
+        val lenBytes = lenBits shr 3
+        var code = (inBytes[charPos].toInt() and 0xFF) shl bitPos
+        val nextPos = charPos + 1
+        if (nextPos < lenBytes)
+            code = code or ((inBytes[nextPos].toInt() and 0xFF) ushr (8 - bitPos))
+        else
+            code = code or (0xFF ushr (8 - bitPos))
+        return code and 0xFF
+    }
+
+    private fun readVCodeIdx(inBytes: ByteArray, lenBits: Int, bitNoRef: IntArray): Int {
+        if (bitNoRef[0] >= lenBits) return 99
+        val code = read8bitCode(inBytes, lenBits, bitNoRef[0])
+        for (i in 0 until 5) {
+            if (code <= USX_VSECTIONS[i]) {
+                val vcode = USX_VCODE_LOOKUP[USX_VSECTION_POS[i] + ((code and USX_VSECTION_MASK[i]) ushr USX_VSECTION_SHIFT[i])]
+                bitNoRef[0] += (vcode ushr 5) + 1
+                if (bitNoRef[0] > lenBits) return 99
+                return vcode and 0x1F
+            }
+        }
+        return 99
+    }
+
+    private val LEN_MASKS = intArrayOf(0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0xFE, 0xFF)
+
+    private fun readHCodeIdx(inBytes: ByteArray, lenBits: Int, bitNoRef: IntArray): Int {
+        if (USX_HCODE_LENS[USX_ALPHA] == 0) return USX_ALPHA
+        if (bitNoRef[0] >= lenBits) return 99
+        val code = read8bitCode(inBytes, lenBits, bitNoRef[0])
+        for (codePos in 0 until 5) {
+            val clen = USX_HCODE_LENS[codePos]
+            if (clen != 0 && (code and LEN_MASKS[clen - 1]) == USX_HCODES[codePos]) {
+                bitNoRef[0] += clen
+                return codePos
+            }
+        }
+        return 99
+    }
+
+    private fun getStepCodeIdx(inBytes: ByteArray, lenBits: Int, bitNoRef: IntArray, limit: Int): Int {
+        var idx = 0
+        while (bitNoRef[0] < lenBits && readBit(inBytes, bitNoRef[0]) != 0) {
+            idx++
+            bitNoRef[0]++
+            if (idx == limit) return idx
+        }
+        if (bitNoRef[0] >= lenBits) return 99
+        bitNoRef[0]++
+        return idx
+    }
+
+    private fun getNumFromBits(inBytes: ByteArray, lenBits: Int, bitNo: Int, count: Int): Int {
+        var ret = 0
+        var bn = bitNo
+        var c = count
+        while (c-- > 0 && bn < lenBits) {
+            ret += if (readBit(inBytes, bn) != 0) 1 shl c else 0
+            bn++
+        }
+        return if (c < 0) ret else -1
+    }
+
+    private fun readCount(inBytes: ByteArray, bitNoRef: IntArray, lenBits: Int): Int {
+        val idx = getStepCodeIdx(inBytes, lenBits, bitNoRef, 4)
+        if (idx == 99) return -1
+        if (bitNoRef[0] + COUNT_BIT_LENS[idx] - 1 >= lenBits) return -1
+        val count = getNumFromBits(inBytes, lenBits, bitNoRef[0], COUNT_BIT_LENS[idx]) +
+            if (idx > 0) COUNT_ADDER[idx - 1] else 0
+        bitNoRef[0] += COUNT_BIT_LENS[idx]
+        return count
+    }
+
+    private fun readUnicode(inBytes: ByteArray, bitNoRef: IntArray, lenBits: Int): Int {
+        var idx = getStepCodeIdx(inBytes, lenBits, bitNoRef, 5)
+        if (idx == 99) return 0x7FFFFF00 + 99
+        if (idx == 5) {
+            idx = getStepCodeIdx(inBytes, lenBits, bitNoRef, 4)
+            return 0x7FFFFF00 + idx
+        }
+        if (idx >= 0) {
+            val sign = if (bitNoRef[0] < lenBits) readBit(inBytes, bitNoRef[0]) else 0
+            bitNoRef[0]++
+            if (bitNoRef[0] + UNI_BIT_LEN[idx] - 1 >= lenBits) return 0x7FFFFF00 + 99
+            val count = getNumFromBits(inBytes, lenBits, bitNoRef[0], UNI_BIT_LEN[idx]) + UNI_ADDER[idx]
+            bitNoRef[0] += UNI_BIT_LEN[idx]
+            return if (sign != 0) -count else count
+        }
+        return 0
+    }
+
+    private fun writeUTF8(out: ByteArray, olen: Int, ol: Int, uni: Int): Int {
+        var curOl = ol
+        if (uni < (1 shl 11)) {
+            if (curOl >= olen) return olen + 1
+            out[curOl++] = (0xC0 + (uni ushr 6)).toByte()
+            if (curOl >= olen) return olen + 1
+            out[curOl++] = (0x80 + (uni and 0x3F)).toByte()
+        } else if (uni < (1 shl 16)) {
+            if (curOl >= olen) return olen + 1
+            out[curOl++] = (0xE0 + (uni ushr 12)).toByte()
+            if (curOl >= olen) return olen + 1
+            out[curOl++] = (0x80 + ((uni ushr 6) and 0x3F)).toByte()
+            if (curOl >= olen) return olen + 1
+            out[curOl++] = (0x80 + (uni and 0x3F)).toByte()
+        } else {
+            if (curOl >= olen) return olen + 1
+            out[curOl++] = (0xF0 + (uni ushr 18)).toByte()
+            if (curOl >= olen) return olen + 1
+            out[curOl++] = (0x80 + ((uni ushr 12) and 0x3F)).toByte()
+            if (curOl >= olen) return olen + 1
+            out[curOl++] = (0x80 + ((uni ushr 6) and 0x3F)).toByte()
+            if (curOl >= olen) return olen + 1
+            out[curOl++] = (0x80 + (uni and 0x3F)).toByte()
+        }
+        return curOl
+    }
+
+    private fun decodeRepeat(
+        inBytes: ByteArray, lenBits: Int,
+        out: ByteArray, olen: Int, ol: Int,
+        bitNoRef: IntArray,
+    ): Int {
+        val dictLen = (readCount(inBytes, bitNoRef, lenBits) + NICE_LEN)
+        if (dictLen < NICE_LEN) return -1
+        val dist = readCount(inBytes, bitNoRef, lenBits) + NICE_LEN - 1
+        if (dist < NICE_LEN - 1) return -1
+        val left = olen - ol
+        if (left <= 0) return olen + 1
+        if (ol - dist < 0) return -1
+        val copyLen = minOf(left, dictLen)
+        System.arraycopy(out, ol - dist, out, ol, copyLen)
+        if (left < dictLen) return olen + 1
+        return ol + dictLen
+    }
+
+    private fun getHexChar(nibble: Int, hexType: Int): Char =
+        if (nibble in 0..9) '0' + nibble
+        else if (hexType < USX_NIB_HEX_UPPER) 'a' + nibble - 10
+        else 'A' + nibble - 10
+
+    private fun decompressInternal(inBytes: ByteArray, len: Int, out: ByteArray, olen: Int): Int {
+        var ol = 0
+        val bitNoRef = intArrayOf(MAGIC_BIT_LEN) // skip magic bit
+        var dstate = USX_ALPHA
+        var h = USX_ALPHA
+        var isAllUpper = false
+        var prevUni = 0
+        val lenBits = len shl 3
+
+        while (bitNoRef[0] < lenBits) {
+            val origBitNo = bitNoRef[0]
+            if (dstate == USX_DELTA || h == USX_DELTA) {
+                if (dstate != USX_DELTA) h = dstate
+                val delta = readUnicode(inBytes, bitNoRef, lenBits)
+                if ((delta ushr 8) == 0x7FFFFF) {
+                    val splCodeIdx = delta and 0xFF
+                    if (splCodeIdx == 99) break
+                    when (splCodeIdx) {
+                        0 -> {
+                            if (ol >= olen) return olen + 1
+                            out[ol++] = ' '.code.toByte()
+                            continue
+                        }
+                        1 -> {
+                            h = readHCodeIdx(inBytes, lenBits, bitNoRef)
+                            if (h == 99) { bitNoRef[0] = lenBits; continue }
+                            if (h == USX_DELTA || h == USX_ALPHA) { dstate = h; continue }
+                            if (h == USX_DICT) {
+                                val rptRet = decodeRepeat(inBytes, lenBits, out, olen, ol, bitNoRef)
+                                if (rptRet < 0) return ol
+                                if (rptRet > olen) return olen + 1
+                                ol = rptRet
+                                h = dstate
+                                continue
+                            }
+                        }
+                        2 -> { if (ol >= olen) return olen + 1; out[ol++] = ','.code.toByte(); continue }
+                        3 -> { if (ol >= olen) return olen + 1; out[ol++] = '.'.code.toByte(); continue }
+                        4 -> { if (ol >= olen) return olen + 1; out[ol++] = 10.toByte(); continue }
+                    }
+                } else {
+                    prevUni += delta
+                    val newOl = writeUTF8(out, olen, ol, prevUni)
+                    if (newOl > olen) return olen + 1
+                    ol = newOl
+                }
+                if (dstate == USX_DELTA && h == USX_DELTA) continue
+            } else {
+                h = dstate
+            }
+
+            var isUpper = isAllUpper
+            var v = readVCodeIdx(inBytes, lenBits, bitNoRef)
+            if (v == 99 || h == 99) { bitNoRef[0] = origBitNo; break }
+
+            if (v == 0 && h != USX_SYM) {
+                if (bitNoRef[0] >= lenBits) break
+                if (h != USX_NUM || dstate != USX_DELTA) {
+                    h = readHCodeIdx(inBytes, lenBits, bitNoRef)
+                    if (h == 99 || bitNoRef[0] >= lenBits) { bitNoRef[0] = origBitNo; break }
+                }
+                when (h) {
+                    USX_ALPHA -> {
+                        if (dstate == USX_ALPHA) {
+                            if (USX_HCODE_LENS[USX_ALPHA] == 0 && 0 == (read8bitCode(inBytes, lenBits, bitNoRef[0] - SW_CODE_LEN) and (0xFF shl (8 - (if (isAllUpper) 4 else 6))))) {
+                                break // Terminator for preset 1
+                            }
+                            if (isAllUpper) {
+                                isUpper = false; isAllUpper = false; continue
+                            }
+                            v = readVCodeIdx(inBytes, lenBits, bitNoRef)
+                            if (v == 99) { bitNoRef[0] = origBitNo; break }
+                            if (v == 0) {
+                                h = readHCodeIdx(inBytes, lenBits, bitNoRef)
+                                if (h == 99) { bitNoRef[0] = origBitNo; break }
+                                if (h == USX_ALPHA) { isAllUpper = true; continue }
+                            }
+                            isUpper = true
+                        } else {
+                            dstate = USX_ALPHA; continue
+                        }
+                    }
+                    USX_DICT -> {
+                        val rptRet = decodeRepeat(inBytes, lenBits, out, olen, ol, bitNoRef)
+                        if (rptRet < 0) break
+                        if (rptRet > olen) return olen + 1
+                        ol = rptRet
+                        continue
+                    }
+                    USX_DELTA -> { continue }
+                    else -> {
+                        if (h != USX_NUM || dstate != USX_DELTA)
+                            v = readVCodeIdx(inBytes, lenBits, bitNoRef)
+                        if (v == 99) { bitNoRef[0] = origBitNo; break }
+                        if (h == USX_NUM && v == 0) {
+                            // Nibble/template/binary escape
+                            val idx = getStepCodeIdx(inBytes, lenBits, bitNoRef, 5)
+                            if (idx == 99) break
+                            if (idx == 0) {
+                                // Template
+                                val ti = getStepCodeIdx(inBytes, lenBits, bitNoRef, 4)
+                                if (ti >= 5) break
+                                val rem0 = readCount(inBytes, bitNoRef, lenBits)
+                                if (rem0 < 0) break
+                                val tmpl = USX_TEMPLATES[ti] ?: break
+                                val tlen = tmpl.length
+                                if (rem0 > tlen) break
+                                val rem = tlen - rem0
+                                var eof = false
+                                for (j2 in 0 until rem) {
+                                    val ct = tmpl[j2]
+                                    if (ct == 'f' || ct == 'r' || ct == 't' || ct == 'o' || ct == 'F') {
+                                        val nbits = when (ct) { 'f', 'F' -> 4; 'r' -> 3; 't' -> 2; else -> 1 }
+                                        val rawChar = getNumFromBits(inBytes, lenBits, bitNoRef[0], nbits)
+                                        if (rawChar < 0) { eof = true; break }
+                                        if (ol >= olen) return olen + 1
+                                        out[ol++] = getHexChar(rawChar, if (ct == 'f') USX_NIB_HEX_LOWER else USX_NIB_HEX_UPPER).code.toByte()
+                                        bitNoRef[0] += nbits
+                                    } else {
+                                        if (ol >= olen) return olen + 1
+                                        out[ol++] = ct.code.toByte()
+                                    }
+                                }
+                                if (eof) break
+                            } else if (idx == 5) {
+                                // Binary escape
+                                var binCount = readCount(inBytes, bitNoRef, lenBits)
+                                if (binCount < 0) break
+                                if (binCount == 0) break
+                                do {
+                                    val rawChar = getNumFromBits(inBytes, lenBits, bitNoRef[0], 8)
+                                    if (rawChar < 0) break
+                                    if (ol >= olen) return olen + 1
+                                    out[ol++] = rawChar.toByte()
+                                    bitNoRef[0] += 8
+                                } while (--binCount > 0)
+                                if (binCount > 0) break
+                            } else {
+                                // Hex run
+                                var nibbleCount = 0
+                                if (idx == 2 || idx == 4) nibbleCount = 32
+                                else {
+                                    nibbleCount = readCount(inBytes, bitNoRef, lenBits)
+                                    if (nibbleCount < 0) break
+                                    if (nibbleCount == 0) break
+                                }
+                                val hexType = if (idx < 3) USX_NIB_HEX_LOWER else USX_NIB_HEX_UPPER
+                                do {
+                                    val nibble = getNumFromBits(inBytes, lenBits, bitNoRef[0], 4)
+                                    if (nibble < 0) break
+                                    if (ol >= olen) return olen + 1
+                                    out[ol++] = getHexChar(nibble, hexType).code.toByte()
+                                    if ((idx == 2 || idx == 4) && (nibbleCount == 25 || nibbleCount == 21 || nibbleCount == 17 || nibbleCount == 13)) {
+                                        if (ol >= olen) return olen + 1
+                                        out[ol++] = '-'.code.toByte()
+                                    }
+                                    bitNoRef[0] += 4
+                                } while (--nibbleCount > 0)
+                                if (nibbleCount > 0) break
+                            }
+                            if (dstate == USX_DELTA) h = USX_DELTA
+                            continue
+                        }
+                    }
+                }
+            }
+
+            if (isUpper && v == 1) { h = USX_DELTA; dstate = USX_DELTA; continue }
+
+            var c = 0
+            if (h < 3 && v < 28) c = USX_SETS[h][v]
+            if (c in 'a'.code..'z'.code) {
+                dstate = USX_ALPHA
+                if (isUpper) c -= 32
+            } else {
+                if (c in '0'.code..'9'.code) {
+                    dstate = USX_NUM
+                } else if (c == 0) {
+                    if (v == 8) {
+                        if (ol >= olen) return olen + 1
+                        out[ol++] = '\r'.code.toByte()
+                        if (ol >= olen) return olen + 1
+                        out[ol++] = '\n'.code.toByte()
+                    } else if (h == USX_NUM && v == 26) {
+                        var count = readCount(inBytes, bitNoRef, lenBits)
+                        if (count < 0) break
+                        count += 4
+                        if (ol <= 0) return 0
+                        val rptC = out[ol - 1]
+                        while (count-- > 0) {
+                            if (ol >= olen) return olen + 1
+                            out[ol++] = rptC
+                        }
+                    } else if (h == USX_SYM && v > 24) {
+                        val vi = v - 25
+                        val freqSeq = USX_FREQ_SEQ[vi]
+                        val left = olen - ol
+                        if (left <= 0) return olen + 1
+                        val copyLen = minOf(left, freqSeq.length)
+                        for (fi in 0 until copyLen) out[ol++] = freqSeq[fi].code.toByte()
+                        if (left < freqSeq.length) return olen + 1
+                    } else if (h == USX_NUM && v > 22 && v < 26) {
+                        val vi = v - (23 - 3)
+                        val freqSeq = USX_FREQ_SEQ[vi]
+                        val left = olen - ol
+                        if (left <= 0) return olen + 1
+                        val copyLen = minOf(left, freqSeq.length)
+                        for (fi in 0 until copyLen) out[ol++] = freqSeq[fi].code.toByte()
+                        if (left < freqSeq.length) return olen + 1
+                    } else {
+                        break // terminator
+                    }
+                    if (dstate == USX_DELTA) h = USX_DELTA
+                    continue
+                }
+            }
+            if (dstate == USX_DELTA) h = USX_DELTA
+            if (ol >= olen) return olen + 1
+            out[ol++] = c.toByte()
+        }
+
+        return ol
+    }
+
+    // endregion
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
@@ -31,6 +31,8 @@ import java.util.Locale
 import java.util.TimeZone
 import soy.engindearing.omnitak.mobile.data.AtakPluginSerializer
 import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.TakPacketParser
+import soy.engindearing.omnitak.mobile.data.TakPacketSerializer
 import soy.engindearing.omnitak.mobile.data.FromRadioFrame
 import soy.engindearing.omnitak.mobile.data.MeshConnectionType
 import soy.engindearing.omnitak.mobile.data.MeshNode
@@ -304,18 +306,22 @@ class MeshtasticManager(private val context: Context? = null) {
                 }
             }
             PORTNUM_ATAK_PLUGIN, PORTNUM_ATAK_FORWARDER -> {
-                val event = AtakPluginParser.parse(packet.payload)
+                // Phase 2: try TAKPacket (atak.proto) first for interop with stock
+                // Meshtastic ATAK Plugin / gateway. Fall back to Phase-1 TAKMessage
+                // parser for OmniTAK-to-OmniTAK links and older clients.
+                val event = TakPacketParser.parse(packet.payload, packet.from)
+                    ?: AtakPluginParser.parse(packet.payload)
                 if (event != null) {
                     runCatching { cotSink?.invoke(event) }
                         .onFailure { Log.w(TAG, "cotSink failed for ATAK plugin event: ${it.message}") }
                     Log.i(
                         TAG,
-                        "RX ATAK plugin from ${packet.from.toString(16)} -> CoT ${event.uid} ($PORTNUM_ATAK_PLUGIN bytes=${packet.payload.size})",
+                        "RX ATAK plugin from ${packet.from.toString(16)} -> CoT ${event.uid} (bytes=${packet.payload.size})",
                     )
                 } else {
                     Log.w(
                         TAG,
-                        "RX ATAK plugin from ${packet.from.toString(16)} unparseable, ${packet.payload.size}B",
+                        "RX ATAK plugin from ${packet.from.toString(16)} unparseable (tried TAKPacket+TAKMessage), ${packet.payload.size}B",
                     )
                 }
             }
@@ -530,7 +536,14 @@ class MeshtasticManager(private val context: Context? = null) {
      * [MeshtasticBleClient.sendToRadio] (chunked at the negotiated MTU).
      */
     suspend fun sendCoTOverMesh(event: CoTEvent, channelIndex: UInt = 0u): Boolean {
-        val payload = AtakPluginSerializer.serialize(event)
+        // Phase 2: Emit standard TAKPacket (atak.proto) for interop with stock
+        // Meshtastic ATAK Plugin, Meshtastic phone-app TAK role, and the
+        // TAK_Meshtastic_Gateway. The MeshPacket wrapper still uses
+        // AtakPluginSerializer.buildToRadio (portnum 72 framing).
+        val payload = when {
+            event.type == "b-t-f" -> TakPacketSerializer.serializeChat(event)
+            else -> TakPacketSerializer.serializePli(event)
+        }
         val toRadio = AtakPluginSerializer.buildToRadio(
             payloadBytes = payload,
             channelIndex = channelIndex,

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/TakPacketPhase2Test.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/TakPacketPhase2Test.kt
@@ -1,0 +1,299 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Phase-2 golden-vector tests for Unishox2, TakPacketSerializer, TakPacketParser,
+ * TakEnums, and format-detection.
+ *
+ * All golden vectors are embedded from /tmp/mesh_golden_vectors.json (produced by
+ * unishox2-py3 1.0.0 + the reference gateway proto).
+ *
+ * Unishox2 byte-exactness is the pass/fail gate — the tests assert compressed hex
+ * byte-for-byte against the Python reference output.
+ */
+class TakPacketPhase2Test {
+
+    // -------------------------------------------------------------------------
+    // (a) Unishox2 compress/decompress golden vectors
+    // -------------------------------------------------------------------------
+
+    private data class UnishoxVector(val text: String, val hexExpected: String)
+
+    private val UNISHOX_VECTORS = listOf(
+        UnishoxVector("ALPHA1",              "804f1e3b4814ff"),
+        UnishoxVector("ANDROID-1234abcd",    "804e75babe80b4452091a55e69"),
+        UnishoxVector("Moving to OBJ Bravo", "879afabcf65148283d07ea0f5b9faa"),
+        UnishoxVector("",                    "97"),
+        UnishoxVector("Overwatch-7",         "857d3dfbcc73d8b45dbf"),
+        UnishoxVector("RTO actual, sitrep?", "86c20294f31de7824b571b7e07d8"),
+    )
+
+    @Test fun unishox2_compress_matches_golden_vectors() {
+        for (v in UNISHOX_VECTORS) {
+            val compressed = Unishox2.compress(v.text)
+            val actualHex = compressed.toHex()
+            assertEquals(
+                "compress(\"${v.text}\") should equal golden vector",
+                v.hexExpected,
+                actualHex,
+            )
+        }
+    }
+
+    @Test fun unishox2_decompress_round_trips_golden_vectors() {
+        for (v in UNISHOX_VECTORS) {
+            val compressed = v.hexExpected.fromHex()
+            val decompressed = Unishox2.decompress(compressed)
+            assertEquals(
+                "decompress(compress(\"${v.text}\")) should round-trip",
+                v.text,
+                decompressed,
+            )
+        }
+    }
+
+    @Test fun unishox2_compress_then_decompress_round_trips() {
+        for (v in UNISHOX_VECTORS) {
+            val compressed = Unishox2.compress(v.text)
+            val decompressed = Unishox2.decompress(compressed)
+            assertEquals(
+                "compress→decompress should be identity for \"${v.text}\"",
+                v.text,
+                decompressed,
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // (b) TakPacketParser.parse(PLI wire_hex) → CoTEvent lat≈47.6062 lon≈-122.3321
+    //     callsign ALPHA1 team Cyan
+    // -------------------------------------------------------------------------
+
+    // Golden PLI wire_hex from mesh_golden_vectors.json:
+    //   fields: callsign=ALPHA1, device_callsign=ANDROID-1234abcd, team=Cyan(10),
+    //           role=TeamMember(1), battery=85, lat=47.6062, lon=-122.3321,
+    //           altitude=56, speed=3, course=270, is_compressed=false
+    private val PLI_WIRE_HEX = "121a0a06414c504841311210414e44524f49442d31323334616263641a040801100a220208552a110d3021601c15589a15b718382003288e02"
+
+    @Test fun parse_pli_golden_vector() {
+        val bytes = PLI_WIRE_HEX.fromHex()
+        val event = TakPacketParser.parse(bytes)
+        assertNotNull("PLI golden vector should parse", event)
+        event!!
+
+        assertEquals("a-f-G-U-C", event.type)
+        assertEquals("ALPHA1", event.callsign)
+        assertEquals(47.6062, event.lat, 1e-4)
+        assertEquals(-122.3321, event.lon, 1e-4)
+        assertEquals("Cyan", event.teamName)
+        // uid = device_callsign
+        assertTrue("uid should be device callsign", event.uid.contains("ANDROID-1234abcd"))
+    }
+
+    // -------------------------------------------------------------------------
+    // (c) parse(GeoChat wire_hex) → b-t-f message "Moving to OBJ Bravo" team Red
+    // -------------------------------------------------------------------------
+
+    // Golden GeoChat wire_hex from mesh_golden_vectors.json:
+    //   fields: callsign=ALPHA1(compressed), device_callsign=ANDROID-1234abcd(compressed),
+    //           team=Red(5), role=TeamLead(2), battery=72,
+    //           message=Moving to OBJ Bravo(compressed), to=All Chat Rooms(raw),
+    //           is_compressed=true
+    private val GEOCHAT_WIRE_HEX = "080112180a07804f1e3b4814ff120d804e75babe80b4452091a55e691a04080210052202084832210a0f879afabcf65148283d07ea0f5b9faa120e416c6c204368617420526f6f6d73"
+
+    @Test fun parse_geochat_golden_vector() {
+        val bytes = GEOCHAT_WIRE_HEX.fromHex()
+        val event = TakPacketParser.parse(bytes)
+        assertNotNull("GeoChat golden vector should parse", event)
+        event!!
+
+        assertEquals("b-t-f", event.type)
+        assertEquals("Moving to OBJ Bravo", event.remarks)
+        assertEquals("Red", event.teamName)
+        assertEquals("ALPHA1", event.callsign)
+    }
+
+    // -------------------------------------------------------------------------
+    // (d) TakPacketSerializer encode uncompressed PLI byte-matches golden PLI wire_hex
+    // -------------------------------------------------------------------------
+
+    @Test fun serialize_pli_matches_golden_wire_hex() {
+        // Build the exact same CoTEvent the golden vector represents.
+        val event = CoTEvent(
+            uid = "ANDROID-1234abcd",
+            type = "a-f-G-U-C",
+            lat = 47.6062,
+            lon = -122.3321,
+            hae = 56.0,
+            callsign = "ALPHA1",
+            teamName = "Cyan",
+            teamRole = "Team Member",
+        )
+        val actual = TakPacketSerializer.serializePli(
+            event = event,
+            callsign = "ALPHA1",
+            deviceId = "ANDROID-1234abcd",
+            battery = 85,
+            speed = 3,
+            course = 270,
+        )
+        val expected = PLI_WIRE_HEX.fromHex()
+
+        // Compare byte by byte; print diff on failure
+        if (!actual.contentEquals(expected)) {
+            val actualHex = actual.toHex()
+            assertEquals(
+                "PLI serializer output should match golden wire_hex\nexpected: $PLI_WIRE_HEX\nactual  : $actualHex",
+                PLI_WIRE_HEX,
+                actualHex,
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // (e) TakEnums name↔int both ways + normalization
+    // -------------------------------------------------------------------------
+
+    @Test fun team_enum_int_to_name_round_trip() {
+        val cases = mapOf(
+            0  to "Unspecifed_Color",
+            1  to "White",
+            5  to "Red",
+            8  to "Dark_Blue",
+            9  to "Blue",
+            10 to "Cyan",
+            13 to "Dark_Green",
+            14 to "Brown",
+        )
+        for ((v, name) in cases) {
+            val team = Team.fromValue(v)
+            assertEquals("Team.fromValue($v).name", name, team.name)
+            assertEquals("Team.fromValue($v).value", v, team.value)
+        }
+    }
+
+    @Test fun team_cot_name_round_trip() {
+        // Space form (CoT display)
+        assertEquals(Team.Dark_Blue, Team.fromCotName("Dark Blue"))
+        assertEquals(Team.Dark_Green, Team.fromCotName("Dark Green"))
+        assertEquals(Team.Cyan, Team.fromCotName("Cyan"))
+        assertEquals(Team.Red, Team.fromCotName("Red"))
+        // Underscore form (proto enum name)
+        assertEquals(Team.Dark_Blue, Team.fromCotName("Dark_Blue"))
+        assertEquals(Team.Dark_Green, Team.fromCotName("Dark_Green"))
+        // Case-insensitive
+        assertEquals(Team.Cyan, Team.fromCotName("cyan"))
+        assertEquals(Team.Red, Team.fromCotName("RED"))
+    }
+
+    @Test fun team_cot_name_output() {
+        assertEquals("Dark Blue", Team.Dark_Blue.toCotName())
+        assertEquals("Dark Green", Team.Dark_Green.toCotName())
+        assertEquals("Cyan", Team.Cyan.toCotName())
+    }
+
+    @Test fun member_role_enum_int_to_name_round_trip() {
+        val cases = mapOf(
+            0 to "Unspecifed",
+            1 to "TeamMember",
+            2 to "TeamLead",
+            6 to "ForwardObserver",
+            8 to "K9",
+        )
+        for ((v, name) in cases) {
+            val role = MemberRole.fromValue(v)
+            assertEquals("MemberRole.fromValue($v).name", name, role.name)
+            assertEquals("MemberRole.fromValue($v).value", v, role.value)
+        }
+    }
+
+    @Test fun member_role_cot_name_round_trip() {
+        assertEquals(MemberRole.TeamMember, MemberRole.fromCotName("Team Member"))
+        assertEquals(MemberRole.TeamLead, MemberRole.fromCotName("Team Lead"))
+        assertEquals(MemberRole.ForwardObserver, MemberRole.fromCotName("Forward Observer"))
+        assertEquals(MemberRole.K9, MemberRole.fromCotName("K9"))
+    }
+
+    @Test fun member_role_cot_name_output() {
+        assertEquals("Team Member", MemberRole.TeamMember.toCotName())
+        assertEquals("Team Lead", MemberRole.TeamLead.toCotName())
+        assertEquals("Forward Observer", MemberRole.ForwardObserver.toCotName())
+    }
+
+    // -------------------------------------------------------------------------
+    // (f) Format detection: Phase-1 TAKMessage payload still decodes via fallback
+    // -------------------------------------------------------------------------
+
+    @Test fun phase1_takemessage_parses_via_fallback() {
+        // Build a Phase-1 TAKMessage payload using AtakPluginSerializer (the
+        // Phase-1 serializer). TakPacketParser.parse should return null,
+        // letting the caller fall back to AtakPluginParser.parse.
+        val event = CoTEvent(
+            uid = "MESH-FALLBACK-01",
+            type = "a-f-G-U-C",
+            lat = 47.6,
+            lon = -122.3,
+            callsign = "FALLBACK",
+        )
+        val phase1Payload = AtakPluginSerializer.serialize(event)
+
+        // TakPacketParser must return null for a TAKMessage payload
+        val takResult = TakPacketParser.parse(phase1Payload)
+        assertNull(
+            "TakPacketParser should return null for Phase-1 TAKMessage payload (should fall back)",
+            takResult,
+        )
+
+        // AtakPluginParser must still parse it
+        val fallbackResult = AtakPluginParser.parse(phase1Payload)
+        assertNotNull("AtakPluginParser should decode Phase-1 TAKMessage payload", fallbackResult)
+        fallbackResult!!
+        assertEquals("MESH-FALLBACK-01", fallbackResult.uid)
+        assertEquals("a-f-G-U-C", fallbackResult.type)
+        assertEquals(47.6, fallbackResult.lat, 1e-6)
+    }
+
+    // -------------------------------------------------------------------------
+    // Additional: sfixed32 negative longitude round-trip
+    // -------------------------------------------------------------------------
+
+    @Test fun sfixed32_negative_longitude_round_trips() {
+        // -122.3321 → latitude_i = -1223321000
+        val lonI = (-122.3321 * 1e7).toLong().toInt()
+        assertEquals(-1223321000, lonI)
+
+        // Write as sfixed32 LE
+        val out = java.io.ByteArrayOutputStream()
+        out.write(lonI and 0xFF)
+        out.write((lonI ushr 8) and 0xFF)
+        out.write((lonI ushr 16) and 0xFF)
+        out.write((lonI ushr 24) and 0xFF)
+        val bytes = out.toByteArray()
+
+        // Read back via MeshtasticProtoParser.readFixed32 + reinterpret as signed
+        val (raw, _) = MeshtasticProtoParser.readFixed32(bytes, 0)!!
+        val recovered = raw.toInt()
+        assertEquals(-1223321000, recovered)
+        val recoveredLon = recovered / 1e7
+        assertEquals(-122.3321, recoveredLon, 1e-4)
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+
+    private fun String.fromHex(): ByteArray {
+        check(length % 2 == 0) { "Hex string must have even length" }
+        return ByteArray(length / 2) { i ->
+            substring(i * 2, i * 2 + 2).toInt(16).toByte()
+        }
+    }
+}


### PR DESCRIPTION
## Phase 2 — standard Meshtastic TAKPacket + unishox2 (ecosystem interop)

Stacked on the Phase 1 branch `feat/mesh-offgrid-ppli-chat`.

Transmit/receive the standard compact `TAKPacket` (atak.proto) on portnum 72 with unishox2 compression, so OmniTAK interoperates over the mesh with **non-OmniTAK gear**: the stock Meshtastic ATAK Plugin, the Meshtastic phone-app TAK role, and TAK_Meshtastic_Gateway. PLI for `a-*` positions, GeoChat for `b-t-f`; team/role mapped to the `Team`/`MemberRole` enums. Inbound tries TAKPacket first and falls back to the Phase-1 `TAKMessage` decoder.

**Verification:** byte-exact against golden vectors generated from the real `unishox2-py3` + gateway proto (6 unishox2 string vectors, a 57-byte PLI packet, a 73-byte compressed GeoChat packet). Build green; round-trip + decode + encode all pass.

⚠️ Targets **pre-firmware-PR-#10105** unishox2 (default preset) — the installed base deployed today. #10105 (2026-05-26) dropped unishox2 for a V2 format; that is a future Phase 3.
⚠️ Real on-air LoRa interop with a physical stock-plugin device / running gateway is the final manual gate, not covered by unit tests.

Built via planner → executor → checker agent review (checker caught + fixed inbound `chat.to` decode + outbound role derivation on iOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)