### PR TITLE
feat: zh-Hant (繁體中文) localization + live language picker (Android)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -34,6 +34,11 @@ class OmniTAKApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // Restore the operator's UI language (or match the device locale)
+        // before any Activity composes, so the first frame renders in the
+        // right language. Mirrors iOS's LocalizationManager init.
+        soy.engindearing.omnitak.mobile.i18n.Loc.init(this)
+
         // Load the canonical CoT-type → SIDC catalogue from
         // assets/cot_types.json. Silent failure keeps the hardcoded
         // floor active so the map still renders if the asset is

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/Loc.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/Loc.kt
@@ -1,0 +1,118 @@
+package soy.engindearing.omnitak.mobile.i18n
+
+import android.content.Context
+import android.content.res.Resources
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/**
+ * Runtime language switching without an Activity restart — the Android
+ * counterpart to the iOS `LocalizationManager`.
+ *
+ * Android's native per-locale resources (`values-zh-rTW/`) only take
+ * effect on Activity recreation. This manager instead keeps the active
+ * language in a Compose snapshot state and resolves keys against an
+ * in-memory catalogue ([LocStrings]), so flipping the picker in Settings
+ * re-renders every observing composable instantly — the same UX iOS gets
+ * from its `@Published` language switch.
+ *
+ * ## Usage
+ *     Text(Loc.t("settings.callsign"))
+ *
+ * Because [t] reads [current] (a snapshot state) during composition,
+ * changing the language via [setLanguage] recomposes every caller. Non
+ * composable callers (services, formatters) can call [t] too — they just
+ * won't auto-refresh on a live switch, which is fine for one-shot strings.
+ *
+ * English is the base catalogue every other language falls back to for
+ * keys it hasn't translated yet, matching the iOS fallback chain
+ * (active → English → key itself).
+ */
+object Loc {
+
+    /** Languages OmniTAK ships UI translations for. Mirrors the iOS
+     *  `LocalizationManager.Language` cases we have Android catalogues
+     *  for; adding a language is an enum case plus a [LocStrings] map. */
+    enum class Language(val code: String, val displayName: String, val flag: String) {
+        // displayName is the endonym — the language's own name, which is
+        // what users scanning a language list expect to see.
+        ENGLISH("en", "English", "🇬🇧"),
+        TRADITIONAL_CHINESE("zh-Hant", "繁體中文", "🇹🇼");
+
+        companion object {
+            fun fromCode(code: String?): Language? =
+                entries.firstOrNull { it.code == code }
+        }
+    }
+
+    private const val PREFS = "omnitak_locale"
+    private const val KEY_LANGUAGE = "app_language"
+
+    private var appContext: Context? = null
+
+    /** The active language. Reads inside composition are tracked by the
+     *  Compose snapshot system, so a change recomposes every view that
+     *  resolved a string through [t]. */
+    var current by mutableStateOf(Language.ENGLISH)
+        private set
+
+    /** Initialise once at process start (Application.onCreate), before any
+     *  UI composes. Restores the persisted choice, else best-effort matches
+     *  the device locale, else English. */
+    fun init(context: Context) {
+        val ctx = context.applicationContext
+        appContext = ctx
+        val stored = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getString(KEY_LANGUAGE, null)
+        current = Language.fromCode(stored) ?: systemDefault()
+    }
+
+    /** Switch the app's language. Persists the choice; the snapshot-state
+     *  write re-renders every observing composable immediately. */
+    fun setLanguage(language: Language) {
+        if (language == current) return
+        current = language
+        appContext?.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            ?.edit()
+            ?.putString(KEY_LANGUAGE, language.code)
+            ?.apply()
+    }
+
+    /** Resolve [key] against the active language, falling back to the
+     *  English base catalogue, then to the key itself (so a missing string
+     *  is visible in testing rather than rendering blank). */
+    fun t(key: String): String {
+        LocStrings.catalogue(current)[key]?.let { return it }
+        if (current != Language.ENGLISH) {
+            LocStrings.catalogue(Language.ENGLISH)[key]?.let { return it }
+        }
+        return key
+    }
+
+    /** Resolve a key carrying `String.format` placeholders (`%d`, `%s`). */
+    fun t(key: String, vararg args: Any?): String =
+        String.format(t(key), *args)
+
+    /** Best-effort match of the device's preferred locales to a language we
+     *  ship. A `zh-Hant` / `zh-TW` / `zh-HK` / `zh-MO` device resolves to
+     *  Traditional Chinese; a Simplified (`zh-Hans` / `zh-CN`) device falls
+     *  through to English since we don't ship Simplified. */
+    private fun systemDefault(): Language {
+        val locales = Resources.getSystem().configuration.locales
+        for (i in 0 until locales.size()) {
+            val locale = locales[i] ?: continue
+            val lang = locale.language.lowercase()
+            if (lang == "zh") {
+                val isTraditional = locale.script.equals("Hant", ignoreCase = true) ||
+                    locale.country.uppercase() in TRADITIONAL_REGIONS
+                if (isTraditional) return Language.TRADITIONAL_CHINESE
+                continue // Simplified Chinese — we don't ship it; keep scanning.
+            }
+            Language.fromCode(lang)?.let { return it }
+        }
+        return Language.ENGLISH
+    }
+
+    private val TRADITIONAL_REGIONS = setOf("TW", "HK", "MO")
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
@@ -1,0 +1,120 @@
+package soy.engindearing.omnitak.mobile.i18n
+
+import soy.engindearing.omnitak.mobile.i18n.Loc.Language
+
+/**
+ * In-memory string catalogues for [Loc]. Keys mirror the iOS catalogue's
+ * dotted-namespace convention (`settings.section.*`, `settings.*`) so the
+ * two platforms stay legible side by side.
+ *
+ * v1 scope: the Settings screen — the surface that hosts the language
+ * picker, and the Android counterpart to iOS's onboarding+Settings v1.
+ * Other screens render English until later passes extend coverage; any
+ * unkeyed string simply falls back through [Loc.t].
+ *
+ * Technical terms (TAK, ATAK, MGRS, UTM, OSM, FAA Remote ID, QR,
+ * WMTS/XYZ) are intentionally left in English in every language, the same
+ * call the iOS zh-Hant translation made.
+ */
+internal object LocStrings {
+
+    fun catalogue(language: Language): Map<String, String> = when (language) {
+        Language.ENGLISH -> EN
+        Language.TRADITIONAL_CHINESE -> ZH_HANT
+    }
+
+    private val EN: Map<String, String> = mapOf(
+        "settings.title" to "Settings",
+
+        // Section headers (rendered uppercased by SectionHeader)
+        "settings.section.identity" to "Identity",
+        "settings.section.interface" to "Interface",
+        "settings.section.units" to "Units",
+        "settings.section.coordinates" to "Coordinates",
+        "settings.section.mapTiles" to "Map tiles",
+        "settings.section.selfPosition" to "Self position",
+        "settings.section.droneDetection" to "Drone detection",
+        "settings.section.language" to "Language",
+
+        // Identity
+        "settings.callsign" to "Callsign",
+        "settings.team" to "Team",
+
+        // Interface
+        "settings.customizeToolbar" to "Customize Toolbar",
+        "settings.customizeToolbar.desc" to "Build your own bottom-bar shortcuts",
+
+        // Units
+        "settings.unit.metric" to "Metric",
+        "settings.unit.imperial" to "Imperial",
+
+        // Coordinates
+        "settings.coord.latlon" to "Lat/Lon",
+        "settings.coord.dms" to "DMS",
+        "settings.coord.mgrs" to "MGRS",
+        "settings.coord.utm" to "UTM",
+
+        // Map tiles
+        "settings.map.osm" to "OSM",
+        "settings.map.satellite" to "Satellite",
+        "settings.map.topo" to "Topo",
+        "settings.map.custom" to "Custom",
+        "settings.mapTiles.desc" to "OSM (street), Topo (OpenTopoMap), Satellite (Esri imagery), or a custom WMTS / XYZ tile URL. Picks apply immediately. Offline tile cache lands in a later release.",
+        "settings.tileUrl" to "Tile URL",
+        "settings.customTile.help" to "Must be an XYZ-style URL with {z}, {x}, {y} placeholders (ATAK-style {\$z}/{\$x}/{\$y} also works). WMTS endpoints from agency / private servers usually expose this. Falls back to OSM if invalid.",
+
+        // Self position
+        "settings.milStdSymbol" to "MIL-STD-2525 symbol",
+        "settings.milStdSymbol.desc" to "Render your own pip as a friendly-combat ground frame (a-f-G-U-C) instead of the legacy tactical disc. Affects only the map; PPLI broadcast is unchanged.",
+
+        // Drone detection
+        "settings.faaRemoteIdScanner" to "FAA Remote ID scanner",
+        "settings.faaRemoteId.desc" to "Listen for nearby drones (DJI Mavic, Skydio, Autel) broadcasting FAA Remote ID over Bluetooth. Detected drones appear on the map as unknown-air UAS contacts. Catches the Bluetooth-broadcast subset of Remote ID; WiFi-beacon broadcasts require a gy6 sensor. BLE scanning has a battery cost.",
+
+        // Language
+        "settings.appLanguage" to "App Language",
+    )
+
+    private val ZH_HANT: Map<String, String> = mapOf(
+        "settings.title" to "設定",
+
+        "settings.section.identity" to "身份",
+        "settings.section.interface" to "介面",
+        "settings.section.units" to "單位",
+        "settings.section.coordinates" to "座標",
+        "settings.section.mapTiles" to "地圖圖磚",
+        "settings.section.selfPosition" to "自身位置",
+        "settings.section.droneDetection" to "無人機偵測",
+        "settings.section.language" to "語言",
+
+        "settings.callsign" to "呼號",
+        "settings.team" to "團隊",
+
+        "settings.customizeToolbar" to "自訂工具列",
+        "settings.customizeToolbar.desc" to "打造您自己的底部工具列捷徑",
+
+        "settings.unit.metric" to "公制",
+        "settings.unit.imperial" to "英制",
+
+        "settings.coord.latlon" to "經緯度",
+        "settings.coord.dms" to "度分秒",
+        "settings.coord.mgrs" to "MGRS",
+        "settings.coord.utm" to "UTM",
+
+        "settings.map.osm" to "OSM",
+        "settings.map.satellite" to "衛星",
+        "settings.map.topo" to "地形",
+        "settings.map.custom" to "自訂",
+        "settings.mapTiles.desc" to "OSM（街道）、地形（OpenTopoMap）、衛星（Esri 影像），或自訂 WMTS / XYZ 圖磚網址。選擇即時套用。離線圖磚快取將於後續版本推出。",
+        "settings.tileUrl" to "圖磚網址",
+        "settings.customTile.help" to "必須是包含 {z}、{x}、{y} 預留位置的 XYZ 樣式網址（ATAK 樣式的 {\$z}/{\$x}/{\$y} 亦可）。機關／私人伺服器的 WMTS 端點通常會提供此格式。若無效則回退至 OSM。",
+
+        "settings.milStdSymbol" to "MIL-STD-2525 符號",
+        "settings.milStdSymbol.desc" to "將您自身的標記繪製為友軍地面戰鬥框架（a-f-G-U-C），取代舊版戰術圓點。僅影響地圖；PPLI 廣播維持不變。",
+
+        "settings.faaRemoteIdScanner" to "FAA Remote ID 掃描器",
+        "settings.faaRemoteId.desc" to "監聽附近無人機（DJI Mavic、Skydio、Autel）透過藍芽廣播的 FAA Remote ID。偵測到的無人機將以未知空域 UAS 目標顯示在地圖上。可接收藍芽廣播的 Remote ID 子集；WiFi 訊號廣播需搭配 gy6 感測器。藍芽掃描會消耗電池。",
+
+        "settings.appLanguage" to "應用程式語言",
+    )
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.OmniTAKApp
+import soy.engindearing.omnitak.mobile.i18n.Loc
 import soy.engindearing.omnitak.mobile.data.CoordFormat
 import soy.engindearing.omnitak.mobile.data.DistanceUnit
 import soy.engindearing.omnitak.mobile.data.MapProvider
@@ -79,7 +80,7 @@ fun SettingsScreen() {
         containerColor = TacticalBackground,
         topBar = {
             TopAppBar(
-                title = { Text("Settings", color = MaterialTheme.colorScheme.onBackground) },
+                title = { Text(Loc.t("settings.title"), color = MaterialTheme.colorScheme.onBackground) },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = TacticalBackground,
                     titleContentColor = MaterialTheme.colorScheme.onBackground,
@@ -95,7 +96,7 @@ fun SettingsScreen() {
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
-            SectionHeader("Identity")
+            SectionHeader(Loc.t("settings.section.identity"))
             // GAP-103 — local state insulates the field from DataStore round-trip
             // latency, otherwise every keystroke re-emits prefs.callsign and the
             // cursor jumps. The remember-key resyncs when prefs change externally.
@@ -106,7 +107,7 @@ fun SettingsScreen() {
                     callsignDraft = v
                     mutate { it.copy(callsign = v) }
                 },
-                label = { Text("Callsign") },
+                label = { Text(Loc.t("settings.callsign")) },
                 singleLine = true,
                 colors = settingsFieldColors(),
                 modifier = Modifier.fillMaxWidth(),
@@ -118,7 +119,7 @@ fun SettingsScreen() {
                 onSelect = { v -> mutate { it.copy(team = v) } },
             )
 
-            SectionHeader("Interface")
+            SectionHeader(Loc.t("settings.section.interface"))
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -129,9 +130,9 @@ fun SettingsScreen() {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text("Customize Toolbar", color = MaterialTheme.colorScheme.onBackground)
+                    Text(Loc.t("settings.customizeToolbar"), color = MaterialTheme.colorScheme.onBackground)
                     Text(
-                        "Build your own bottom-bar shortcuts",
+                        Loc.t("settings.customizeToolbar.desc"),
                         color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
                         style = MaterialTheme.typography.bodySmall,
                     )
@@ -139,41 +140,41 @@ fun SettingsScreen() {
                 Text("›", color = TacticalAccent, fontWeight = FontWeight.Bold)
             }
 
-            SectionHeader("Units")
+            SectionHeader(Loc.t("settings.section.units"))
             SegmentedRow(
                 options = listOf(
-                    DistanceUnit.METRIC to "Metric",
-                    DistanceUnit.IMPERIAL to "Imperial",
+                    DistanceUnit.METRIC to Loc.t("settings.unit.metric"),
+                    DistanceUnit.IMPERIAL to Loc.t("settings.unit.imperial"),
                 ),
                 selected = prefs.distanceUnit,
                 onSelect = { v -> mutate { it.copy(distanceUnit = v) } },
             )
 
-            SectionHeader("Coordinates")
+            SectionHeader(Loc.t("settings.section.coordinates"))
             SegmentedRow(
                 options = listOf(
-                    CoordFormat.LATLON_DECIMAL to "Lat/Lon",
-                    CoordFormat.LATLON_DMS to "DMS",
-                    CoordFormat.MGRS to "MGRS",
-                    CoordFormat.UTM to "UTM",
+                    CoordFormat.LATLON_DECIMAL to Loc.t("settings.coord.latlon"),
+                    CoordFormat.LATLON_DMS to Loc.t("settings.coord.dms"),
+                    CoordFormat.MGRS to Loc.t("settings.coord.mgrs"),
+                    CoordFormat.UTM to Loc.t("settings.coord.utm"),
                 ),
                 selected = prefs.coordFormat,
                 onSelect = { v -> mutate { it.copy(coordFormat = v) } },
             )
 
-            SectionHeader("Map tiles")
+            SectionHeader(Loc.t("settings.section.mapTiles"))
             SegmentedRow(
                 options = listOf(
-                    MapProvider.OSM_RASTER to "OSM",
-                    MapProvider.SATELLITE_HINT to "Satellite",
-                    MapProvider.TOPO_HINT to "Topo",
-                    MapProvider.WMTS_CUSTOM to "Custom",
+                    MapProvider.OSM_RASTER to Loc.t("settings.map.osm"),
+                    MapProvider.SATELLITE_HINT to Loc.t("settings.map.satellite"),
+                    MapProvider.TOPO_HINT to Loc.t("settings.map.topo"),
+                    MapProvider.WMTS_CUSTOM to Loc.t("settings.map.custom"),
                 ),
                 selected = prefs.mapProvider,
                 onSelect = { v -> mutate { it.copy(mapProvider = v) } },
             )
             Text(
-                "OSM (street), Topo (OpenTopoMap), Satellite (Esri imagery), or a custom WMTS / XYZ tile URL. Picks apply immediately. Offline tile cache lands in a later release.",
+                Loc.t("settings.mapTiles.desc"),
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
                 style = MaterialTheme.typography.bodySmall,
             )
@@ -189,32 +190,32 @@ fun SettingsScreen() {
                         urlDraft = v
                         mutate { it.copy(customTileUrl = v) }
                     },
-                    label = { Text("Tile URL") },
+                    label = { Text(Loc.t("settings.tileUrl")) },
                     placeholder = { Text("https://host/{z}/{x}/{y}.png") },
                     singleLine = true,
                     colors = settingsFieldColors(),
                     modifier = Modifier.fillMaxWidth(),
                 )
                 Text(
-                    "Must be an XYZ-style URL with {z}, {x}, {y} placeholders (ATAK-style {\$z}/{\$x}/{\$y} also works). WMTS endpoints from agency / private servers usually expose this. Falls back to OSM if invalid.",
+                    Loc.t("settings.customTile.help"),
                     color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
                     style = MaterialTheme.typography.bodySmall,
                 )
             }
 
-            SectionHeader("Self position")
+            SectionHeader(Loc.t("settings.section.selfPosition"))
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        "MIL-STD-2525 symbol",
+                        Loc.t("settings.milStdSymbol"),
                         color = MaterialTheme.colorScheme.onBackground,
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
-                        "Render your own pip as a friendly-combat ground frame (a-f-G-U-C) instead of the legacy tactical disc. Affects only the map; PPLI broadcast is unchanged.",
+                        Loc.t("settings.milStdSymbol.desc"),
                         color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
                         style = MaterialTheme.typography.bodySmall,
                     )
@@ -225,19 +226,19 @@ fun SettingsScreen() {
                 )
             }
 
-            SectionHeader("Drone detection")
+            SectionHeader(Loc.t("settings.section.droneDetection"))
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        "FAA Remote ID scanner",
+                        Loc.t("settings.faaRemoteIdScanner"),
                         color = MaterialTheme.colorScheme.onBackground,
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
-                        "Listen for nearby drones (DJI Mavic, Skydio, Autel) broadcasting FAA Remote ID over Bluetooth. Detected drones appear on the map as unknown-air UAS contacts. Catches the Bluetooth-broadcast subset of Remote ID; WiFi-beacon broadcasts require a gy6 sensor. BLE scanning has a battery cost.",
+                        Loc.t("settings.faaRemoteId.desc"),
                         color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
                         style = MaterialTheme.typography.bodySmall,
                     )
@@ -288,6 +289,16 @@ fun SettingsScreen() {
                     },
                 )
             }
+
+            // Language — switches the UI language live, no restart. Bound
+            // straight to Loc; reading Loc.current here means a switch
+            // recomposes the whole screen instantly (iOS parity).
+            SectionHeader(Loc.t("settings.section.language"))
+            SegmentedRow(
+                options = Loc.Language.entries.map { it to "${it.flag}  ${it.displayName}" },
+                selected = Loc.current,
+                onSelect = { lang -> Loc.setLanguage(lang) },
+            )
 
             Spacer(Modifier.height(8.dp))
         }
@@ -396,7 +407,7 @@ private fun TeamColorDropdown(value: String, onSelect: (String) -> Unit) {
             value = current.first,
             onValueChange = {},
             readOnly = true,
-            label = { Text("Team") },
+            label = { Text(Loc.t("settings.team")) },
             leadingIcon = {
                 Box(
                     modifier = Modifier


### PR DESCRIPTION
Android parity for the iOS Traditional Chinese localization ([OmniTAK-iOS #50](https://github.com/engindearing-projects/OmniTAK-iOS/pull/50), originally contributed by @GavinChangTW).

## Why this is more than a translation file
iOS already had a `LocalizationManager` + key catalogue + localized onboarding/Settings, so adding zh-Hant there was a one-file drop. Android had **no i18n at all** — UI strings were hardcoded inline, no picker, no language infrastructure. This builds that foundation, mirroring the iOS architecture.

## What's here
- **`i18n/Loc.kt`** — the Android counterpart to iOS's `LocalizationManager`. Active language lives in Compose snapshot state, so flipping the picker recomposes every observing composable **instantly, no Activity restart** (same UX as iOS's `@Published` switch). English fallback chain (active → English → key), `SharedPreferences` persistence, and script-aware device-locale detection (`zh-Hant` / `zh-TW` / `zh-HK` / `zh-MO` → Traditional Chinese; Simplified falls through to English since we don't ship it).
- **`i18n/LocStrings.kt`** — `en` + `zh-Hant` catalogues using the iOS dotted-key convention (`settings.section.*`, `settings.*`), reusing the iOS zh-Hant translations where strings overlap. Technical terms (TAK, ATAK, MGRS, UTM, OSM, FAA Remote ID) kept in English — same call the iOS translation made.
- **`SettingsScreen.kt`** — every label resolved through `Loc.t()`, plus a live 🇬🇧/🇹🇼 language picker. CoT team-color names deliberately stay English (wire-format canonical — ATAK/OTS key teams by the English name).
- **`OmniTAKApp.kt`** — `Loc.init()` at startup, before first composition.

## Scope
v1 is the **Settings screen** — the surface that hosts the picker, and the Android counterpart to iOS's onboarding+Settings v1. Other screens fall back to English until later passes extend coverage. Adding a language later is just an enum case + a catalogue map.

## Verification
`:app:compileDebugKotlin` → **BUILD SUCCESSFUL**. (Visual render of the switch — and an iOS/Android side-by-side — to follow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)