### PR TITLE
feat(plugin): Android Diagnostics example plugin (radial + CoT hooks), parity with iOS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,10 +129,13 @@ android {
 dependencies {
     // Plugin SDK + bundled plugins. The SDK carries the OmniTAKPlugin contract
     // and the registry; example-adsb is the ADS-B reference plugin extracted
-    // out of :app. Compile-time modules only — no dynamic/remote code, so the
-    // app stays Play-Store compliant.
+    // out of :app; example-diagnostics is a second reference plugin (radial +
+    // CoT hooks, OFF by default) for parity with iOS's DiagnosticsPlugin.
+    // Compile-time modules only — no dynamic/remote code, so the app stays
+    // Play-Store compliant.
     implementation(project(":plugins:plugin-sdk"))
     implementation(project(":plugins:example-adsb"))
+    implementation(project(":plugins:example-diagnostics"))
 
     val composeBom = platform("androidx.compose:compose-bom:2024.12.01")
     implementation(composeBom)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -212,6 +212,14 @@ class OmniTAKApp : Application() {
      *  its camera-center provider + camera-follow at the MapScreen seam. */
     val adsbPlugin: soy.engindearing.adsb.AdsbPlugin by lazy { soy.engindearing.adsb.AdsbPlugin() }
 
+    /** The bundled Diagnostics reference plugin — the second example plugin,
+     *  exercising the radial-action + CoT-handler hooks ADS-B doesn't use.
+     *  DISABLED by default (parity with iOS's DiagnosticsPlugin); see
+     *  [loadBundledPlugins] for the first-run enable-flag seeding. */
+    val diagnosticsPlugin: soy.engindearing.diagnostics.DiagnosticsPlugin by lazy {
+        soy.engindearing.diagnostics.DiagnosticsPlugin()
+    }
+
     val contactStore: ContactStore by lazy { ContactStore() }
     /** External gyb_detect sensor over BLE GATT (Phase 3 of the gy6 plan).
      *  Parsed drones merge into ContactStore via the shared RID- UID;
@@ -480,15 +488,33 @@ class OmniTAKApp : Application() {
      * are statically linked into the app, which keeps OmniTAK Play-Store
      * compliant.
      *
+     * Bundled plugins default ON (so first-time users see ADS-B) EXCEPT those in
+     * [DISABLED_BY_DEFAULT], whose `plugin_<id>_enabled` flag is seeded to false
+     * on first run. This mirrors iOS's `registeredDisabledByDefault` and keeps
+     * the registry/UI's `getBoolean(key, true)` reads honest: once the flag is
+     * stored, the registry won't activate it and the Plugins list shows it OFF.
+     *
      * Each plugin's hooks are tagged with its id (via the registry's
      * `onActivating` bracket → [pluginHost.withActivating]) so disabling a
      * plugin later removes exactly its hooks.
      */
     private fun loadBundledPlugins() {
         soy.engindearing.omnitak.plugin.PluginRegistry.register(adsbPlugin)
+        soy.engindearing.omnitak.plugin.PluginRegistry.register(diagnosticsPlugin)
+
+        // First-run: seed the default-OFF plugins' enable flags to false so the
+        // default-true reads everywhere else (registry + Plugins UI) yield OFF.
+        val prefs = pluginPrefs()
+        for (id in DISABLED_BY_DEFAULT) {
+            val key = soy.engindearing.omnitak.plugin.PluginRegistry.enabledKey(id)
+            if (!prefs.contains(key)) {
+                prefs.edit().putBoolean(key, false).apply()
+            }
+        }
+
         soy.engindearing.omnitak.plugin.PluginRegistry.activateEnabled(
             host = pluginHost.asPluginHost(),
-            prefs = pluginPrefs(),
+            prefs = prefs,
             onActivating = { id, activate -> pluginHost.withActivating(id) { activate() } },
         )
     }
@@ -505,6 +531,11 @@ class OmniTAKApp : Application() {
      *  immediately stops/resumes pushes to `cotSink`. */
     private companion object {
         const val FGS_DEBOUNCE_MS = 750L
+
+        /** Bundled plugins that ship OFF on first run (parity with iOS's
+         *  `registeredDisabledByDefault`). The Diagnostics probe is an SDK
+         *  reference plugin, never on for shipping users. */
+        val DISABLED_BY_DEFAULT = setOf("soy.engindearing.diagnostics")
     }
 
     val meshtasticCoTBridge: MeshtasticCoTBridge by lazy {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
@@ -242,6 +242,7 @@ fun AppNav() {
                 SettingsScreen(
                     onOpenAbout = { nav.navigate("about") },
                     onOpenPlugins = { pluginId -> nav.navigate("settings/plugin/$pluginId") },
+                    onOpenPluginsList = { nav.navigate("plugins") },
                 )
             }
             composable("about") { AboutScreen() }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -72,6 +73,7 @@ import soy.engindearing.omnitak.mobile.ui.components.ToolbarEditBus
 fun SettingsScreen(
     onOpenAbout: () -> Unit = {},
     onOpenPlugins: (pluginId: String) -> Unit = {},
+    onOpenPluginsList: () -> Unit = {},
 ) {
     val app = LocalContext.current.applicationContext as OmniTAKApp
     val prefs by app.userPrefsStore.prefs.collectAsState(initial = UserPrefs())
@@ -400,12 +402,45 @@ fun SettingsScreen(
                 onSelect = { lang -> Loc.setLanguage(lang) },
             )
 
-            // Plugins — each plugin registers a Settings row here via
-            // host.registerSettingsRow; tapping it opens the plugin's detail
-            // page (its settingsContent). Reads from the live host registration
-            // list so a plugin that activates/deactivates shows/hides its row.
+            // Plugins. The first row always browses the full Plugins list
+            // (every registered plugin + its enable toggle), so plugins that are
+            // OFF by default (e.g. Diagnostics) — and therefore register no
+            // settings row — are still discoverable. Below it, each ENABLED
+            // plugin's own settings row (registered via host.registerSettingsRow)
+            // deep-links to that plugin's detail page. Reads from the live host
+            // registration list so a plugin that activates/deactivates
+            // shows/hides its row.
+            SectionHeader("Plugins")
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable { onOpenPluginsList() }
+                    .padding(vertical = 10.dp, horizontal = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                androidx.compose.material3.Icon(
+                    Icons.Filled.Extension,
+                    contentDescription = null,
+                    tint = TacticalAccent,
+                    modifier = Modifier.size(22.dp),
+                )
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Manage plugins", color = MaterialTheme.colorScheme.onBackground)
+                    Text(
+                        "Bundled plugins and their on/off toggles",
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                androidx.compose.material3.Icon(
+                    Icons.Filled.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                )
+            }
             if (app.pluginHost.settingsRows.isNotEmpty()) {
-                SectionHeader("Plugins")
                 app.pluginHost.settingsRows.forEach { row ->
                     Row(
                         modifier = Modifier

--- a/plugins/example-diagnostics/README.md
+++ b/plugins/example-diagnostics/README.md
@@ -1,0 +1,55 @@
+# example-diagnostics — the Diagnostics reference plugin
+
+`:plugins:example-diagnostics` is the **second** bundled OmniTAK plugin and the
+Android counterpart of iOS's `DiagnosticsPlugin`. Where `:plugins:example-adsb`
+exercises the map-overlay + settings-row hooks, this one exercises the OTHER two
+host hooks so the entire SDK surface is demonstrated by real bundled plugins:
+
+- `registerRadialAction` — a "Diagnostics" map long-press action that logs and
+  records the tapped coordinate.
+- `registerCoTHandler` — observes every inbound CoT event, counts it, and
+  returns **false** (does NOT consume) so the core pipeline is untouched.
+
+It implements [`OmniTAKPlugin`](../plugin-sdk/src/main/kotlin/soy/engindearing/omnitak/plugin/OmniTAKPlugin.kt)
+and depends on **only** `:plugins:plugin-sdk` + Compose — never on `:app`, and
+(unlike ADS-B) not even on MapLibre, since it needs no map engine.
+
+## Off by default
+
+This plugin ships **DISABLED by default**, matching iOS's
+`registeredDisabledByDefault`. `OmniTAKApp.loadBundledPlugins()` seeds its
+`plugin_<id>_enabled` flag to `false` on first run (the id is in
+`OmniTAKApp.DISABLED_BY_DEFAULT`), so the Plugins list shows it as a second
+entry that is OFF. It never affects shipping users — it only proves the surface
+works and gives plugin authors a second, simpler template.
+
+## What's inside
+
+| File | Role |
+|------|------|
+| `DiagnosticsPlugin.kt` | The `OmniTAKPlugin`. `activate()` registers a radial action, a CoT handler, and a Settings row. |
+| `DiagnosticsState.kt` | Tiny observable state (StateFlows): inbound-CoT count + last radial coordinate. |
+| `DiagnosticsSettingsContent.kt` | Read-only live readouts, reached via Settings → Plugins → Diagnostics. |
+
+## The hooks it uses
+
+```kotlin
+host.registerRadialAction(PluginRadialAction("soy.engindearing.diagnostics.probe", Icons.Filled.BugReport, "Diagnostics")) { coordinate ->
+    // logs + records the long-press coordinate
+}
+host.registerCoTHandler { event ->
+    state.recordCoTEvent()
+    false   // observe only — never consume
+}
+host.registerSettingsRow("Diagnostics", Icons.Filled.BugReport)
+```
+
+## Tests
+
+`src/test/kotlin/soy/engindearing/diagnostics/DiagnosticsPluginTest.kt` exercises
+the radial + CoT hooks against the real plugin (parity with `:app`'s
+PluginHostSurfaceTest probe). Run with:
+
+```
+./gradlew :plugins:example-diagnostics:testDebugUnitTest
+```

--- a/plugins/example-diagnostics/build.gradle.kts
+++ b/plugins/example-diagnostics/build.gradle.kts
@@ -1,0 +1,47 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
+android {
+    namespace = "soy.engindearing.diagnostics"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions { jvmTarget = "17" }
+
+    buildFeatures { compose = true }
+
+    // JVM unit tests (DiagnosticsPlugin counter/coordinate) call android.util.Log.
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+}
+
+// No repositories {} block — see plugin-sdk/build.gradle.kts. Deps resolve
+// from the central google()/mavenCentral() in settings.gradle.kts.
+dependencies {
+    // The plugin contract. The Diagnostics plugin depends ONLY on the SDK +
+    // Compose — it exercises the registerRadialAction + registerCoTHandler hooks
+    // and needs no map engine, so (unlike example-adsb) there is no MapLibre dep.
+    implementation(project(":plugins:plugin-sdk"))
+
+    val composeBom = platform("androidx.compose:compose-bom:2024.12.01")
+    implementation(composeBom)
+    implementation("androidx.compose.runtime:runtime")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+    // Icons.Filled.BugReport for the radial/settings icon.
+    implementation("androidx.compose.material:material-icons-extended")
+
+    testImplementation("junit:junit:4.13.2")
+}

--- a/plugins/example-diagnostics/src/main/AndroidManifest.xml
+++ b/plugins/example-diagnostics/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/plugins/example-diagnostics/src/main/kotlin/soy/engindearing/diagnostics/DiagnosticsPlugin.kt
+++ b/plugins/example-diagnostics/src/main/kotlin/soy/engindearing/diagnostics/DiagnosticsPlugin.kt
@@ -1,0 +1,86 @@
+package soy.engindearing.diagnostics
+
+import android.util.Log
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.runtime.Composable
+import soy.engindearing.omnitak.plugin.OmniTAKPlugin
+import soy.engindearing.omnitak.plugin.PluginHost
+import soy.engindearing.omnitak.plugin.PluginRadialAction
+
+/**
+ * The Diagnostics reference plugin — the second bundled OmniTAK plugin and the
+ * Android counterpart of iOS's `DiagnosticsPlugin`.
+ *
+ * Where the ADS-B plugin exercises [PluginHost.registerMapOverlay] +
+ * [PluginHost.registerSettingsRow], this one exercises the OTHER two host hooks
+ * so the entire SDK surface is demonstrated by real bundled plugins (not only
+ * the `:app` PluginHostSurfaceTest probe):
+ *  - [PluginHost.registerRadialAction] — a "Diagnostics" long-press action that
+ *    logs / records the tapped coordinate.
+ *  - [PluginHost.registerCoTHandler]   — observes every inbound CoT event,
+ *    counts it, and returns **false** (does NOT consume), so the core pipeline
+ *    is untouched.
+ *
+ * It is **DISABLED by default** (see `OmniTAKApp.diagnosticsDisabledByDefault`,
+ * seeded as `plugin_<id>_enabled = false` on first run), matching iOS's
+ * `registeredDisabledByDefault`. It never affects shipping users — it only
+ * proves the surface works and gives plugin authors a second, simpler template.
+ *
+ * Like ADS-B, it depends on ONLY `:plugins:plugin-sdk` (+ Compose) — never on
+ * `:app` — so the dependency graph stays acyclic.
+ */
+class DiagnosticsPlugin : OmniTAKPlugin {
+
+    override val pluginId = "soy.engindearing.diagnostics"
+    override val displayName = "Diagnostics"
+    override val pluginVersion = "1.0.0"
+    override val pluginAuthor = "Engindearing"
+    override val pluginDescription =
+        "Internal SDK diagnostics — a radial probe that logs the tapped " +
+            "coordinate and an inbound-CoT event counter. Off by default; " +
+            "demonstrates the radial-action + CoT-handler host hooks."
+
+    /** Live, observable state surfaced in [settingsContent]. */
+    val state = DiagnosticsState()
+
+    override fun activate(host: PluginHost) {
+        // Hook 3: radial action. Adds a "Diagnostics" entry to the map
+        // long-press radial menu; selecting it logs + records the coordinate.
+        host.registerRadialAction(
+            PluginRadialAction(
+                id = "soy.engindearing.diagnostics.probe",
+                icon = Icons.Filled.BugReport,
+                label = "Diagnostics",
+            ),
+        ) { coordinate ->
+            Log.i(TAG, "radial action at ${coordinate.latitude}, ${coordinate.longitude}")
+            state.recordRadialCoordinate(coordinate)
+        }
+
+        // Hook 4: CoT handler. Counts every inbound event and returns false
+        // (does NOT consume) so the rest of the pipeline is untouched.
+        host.registerCoTHandler { event ->
+            state.recordCoTEvent()
+            Log.v(TAG, "observed CoT ${event.uid} (${event.type}) — count=${state.cotEventCount.value}")
+            false
+        }
+
+        // Hook 2: a Settings row so the live counters are reachable from
+        // Settings → Plugins → Diagnostics. (The plugin's own settingsContent()
+        // is also reachable directly from the Plugins list.)
+        host.registerSettingsRow(displayName, Icons.Filled.BugReport)
+    }
+
+    override fun deactivate() {
+        state.reset()
+    }
+
+    override fun settingsContent(): (@Composable () -> Unit) = {
+        DiagnosticsSettingsContent(state = state)
+    }
+
+    private companion object {
+        const val TAG = "DiagnosticsPlugin"
+    }
+}

--- a/plugins/example-diagnostics/src/main/kotlin/soy/engindearing/diagnostics/DiagnosticsSettingsContent.kt
+++ b/plugins/example-diagnostics/src/main/kotlin/soy/engindearing/diagnostics/DiagnosticsSettingsContent.kt
@@ -1,0 +1,88 @@
+package soy.engindearing.diagnostics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * The Diagnostics plugin's settings surface, reached from Settings → Plugins →
+ * Diagnostics. Read-only liveness readouts — there is no on/off control here
+ * (the plugin enable toggle on the Plugins list / detail screen IS the control);
+ * this just shows what the two registered hooks have observed:
+ *  - the running inbound-CoT event count
+ *  - the last "Diagnostics" radial long-press coordinate
+ *
+ * Both come from [DiagnosticsState] as StateFlows, so the readouts update live
+ * while the plugin is enabled (same reactive pattern as `AdsbSettingsContent`).
+ */
+@Composable
+fun DiagnosticsSettingsContent(state: DiagnosticsState) {
+    val cotCount by state.cotEventCount.collectAsState()
+    val lastCoord by state.lastRadialCoordinate.collectAsState()
+
+    Column(modifier = Modifier.fillMaxWidth().padding(4.dp)) {
+        Text(
+            "SDK diagnostics probe",
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Text(
+            "Counts inbound CoT events and records the last Diagnostics radial " +
+                "long-press. Does not modify any traffic.",
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(top = 2.dp),
+        )
+
+        Spacer(Modifier.height(12.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                "CoT events seen",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Text(
+                "$cotCount",
+                color = MaterialTheme.colorScheme.onBackground,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                "Last radial coordinate",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Text(
+                lastCoord?.let { "%.5f, %.5f".format(it.latitude, it.longitude) } ?: "—",
+                color = MaterialTheme.colorScheme.onBackground,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+
+        Text(
+            "Long-press the map and pick \"Diagnostics\" to capture a coordinate. " +
+                "Enabling this plugin does not affect shipping behavior — it only " +
+                "exercises the radial-action and CoT-handler SDK hooks.",
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(top = 12.dp),
+        )
+    }
+}

--- a/plugins/example-diagnostics/src/main/kotlin/soy/engindearing/diagnostics/DiagnosticsState.kt
+++ b/plugins/example-diagnostics/src/main/kotlin/soy/engindearing/diagnostics/DiagnosticsState.kt
@@ -1,0 +1,44 @@
+package soy.engindearing.diagnostics
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import soy.engindearing.omnitak.plugin.PluginLatLng
+
+/**
+ * The Diagnostics plugin's tiny observable state. Exposed as StateFlows so the
+ * plugin's [DiagnosticsSettingsContent] re-renders live (same reactive shape as
+ * the ADS-B plugin's `AdsbService`), without the plugin needing to hold any
+ * Compose state itself.
+ *
+ * It carries exactly the two liveness signals the two hooks produce:
+ *  - [cotEventCount] — incremented by the registered CoT handler.
+ *  - [lastRadialCoordinate] — set by the registered radial action's onSelect.
+ */
+class DiagnosticsState {
+
+    private val _cotEventCount = MutableStateFlow(0)
+    /** Number of inbound CoT events seen by the registered handler this session. */
+    val cotEventCount: StateFlow<Int> = _cotEventCount.asStateFlow()
+
+    private val _lastRadialCoordinate = MutableStateFlow<PluginLatLng?>(null)
+    /** Coordinate of the most recent "Diagnostics" radial long-press, or null. */
+    val lastRadialCoordinate: StateFlow<PluginLatLng?> = _lastRadialCoordinate.asStateFlow()
+
+    /** Called by the CoT handler for every inbound event (after core ingest). */
+    fun recordCoTEvent() {
+        _cotEventCount.value += 1
+    }
+
+    /** Called by the radial action's onSelect with the long-pressed coordinate. */
+    fun recordRadialCoordinate(coordinate: PluginLatLng) {
+        _lastRadialCoordinate.value = coordinate
+    }
+
+    /** Reset on deactivate so a re-enable starts from a clean slate (parity with
+     *  the iOS DiagnosticsPlugin, which zeroes its counter in deactivate). */
+    fun reset() {
+        _cotEventCount.value = 0
+        _lastRadialCoordinate.value = null
+    }
+}

--- a/plugins/example-diagnostics/src/test/kotlin/soy/engindearing/diagnostics/DiagnosticsPluginTest.kt
+++ b/plugins/example-diagnostics/src/test/kotlin/soy/engindearing/diagnostics/DiagnosticsPluginTest.kt
@@ -1,0 +1,106 @@
+package soy.engindearing.diagnostics
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.plugin.PluginCoTEvent
+import soy.engindearing.omnitak.plugin.PluginHost
+import soy.engindearing.omnitak.plugin.PluginLatLng
+import soy.engindearing.omnitak.plugin.PluginRadialAction
+
+/**
+ * Verifies the Diagnostics plugin wires the two host hooks ADS-B doesn't use
+ * (radial action + CoT handler) and that invoking the captured callbacks drives
+ * its observable [DiagnosticsState]. Mirrors `:app`'s PluginHostSurfaceTest, but
+ * against the REAL bundled plugin so the parity-with-iOS reference plugin is
+ * exercised, not only a test-only probe.
+ */
+class DiagnosticsPluginTest {
+
+    /** Captures registrations so the test can invoke them directly. */
+    private class FakePluginHost : PluginHost {
+        val overlays = mutableListOf<@Composable () -> Unit>()
+        val radials = mutableListOf<Pair<PluginRadialAction, (PluginLatLng) -> Unit>>()
+        val cotHandlers = mutableListOf<(PluginCoTEvent) -> Boolean>()
+        val settingsRows = mutableListOf<Pair<String, ImageVector>>()
+
+        override fun registerMapOverlay(overlay: @Composable () -> Unit) {
+            overlays += overlay
+        }
+        override fun registerRadialAction(action: PluginRadialAction, onSelect: (PluginLatLng) -> Unit) {
+            radials += action to onSelect
+        }
+        override fun registerCoTHandler(handler: (PluginCoTEvent) -> Boolean) {
+            cotHandlers += handler
+        }
+        override fun registerSettingsRow(label: String, icon: ImageVector) {
+            settingsRows += label to icon
+        }
+    }
+
+    @Test fun metadata_matches_ios_and_is_off_by_default_contract() {
+        val plugin = DiagnosticsPlugin()
+        assertEquals("soy.engindearing.diagnostics", plugin.pluginId)
+        assertEquals("Diagnostics", plugin.displayName)
+        assertEquals("1.0.0", plugin.pluginVersion)
+        assertEquals("Engindearing", plugin.pluginAuthor)
+    }
+
+    @Test fun activate_registers_radial_cot_and_settings_hooks() {
+        val host = FakePluginHost()
+        DiagnosticsPlugin().activate(host)
+
+        assertEquals("one radial action", 1, host.radials.size)
+        assertEquals("one CoT handler", 1, host.cotHandlers.size)
+        assertEquals("one settings row", 1, host.settingsRows.size)
+        assertEquals("soy.engindearing.diagnostics.probe", host.radials[0].first.id)
+        assertEquals("Diagnostics", host.radials[0].first.label)
+        // It does NOT touch the map-overlay hook (that's ADS-B's job).
+        assertTrue("no map overlay", host.overlays.isEmpty())
+    }
+
+    @Test fun radial_callback_records_last_coordinate() {
+        val host = FakePluginHost()
+        val plugin = DiagnosticsPlugin()
+        plugin.activate(host)
+
+        assertNull(plugin.state.lastRadialCoordinate.value)
+        host.radials[0].second(PluginLatLng(47.0, -117.0))
+
+        assertEquals(47.0, plugin.state.lastRadialCoordinate.value?.latitude)
+        assertEquals(-117.0, plugin.state.lastRadialCoordinate.value?.longitude)
+    }
+
+    @Test fun cot_handler_counts_and_does_not_consume() {
+        val host = FakePluginHost()
+        val plugin = DiagnosticsPlugin()
+        plugin.activate(host)
+
+        val consumed = host.cotHandlers[0](
+            PluginCoTEvent("uid-1", 47.0, -117.0, "ALPHA", "a-f-G-U-C", null)
+        )
+        host.cotHandlers[0](
+            PluginCoTEvent("uid-2", 47.1, -117.1, "BRAVO", "a-f-G-U-C", null)
+        )
+
+        assertEquals(2, plugin.state.cotEventCount.value)
+        assertFalse("diagnostics never consumes the event", consumed)
+    }
+
+    @Test fun deactivate_resets_state() {
+        val host = FakePluginHost()
+        val plugin = DiagnosticsPlugin()
+        plugin.activate(host)
+        host.cotHandlers[0](PluginCoTEvent("uid-1", 47.0, -117.0, null, null, null))
+        host.radials[0].second(PluginLatLng(47.0, -117.0))
+
+        plugin.deactivate()
+
+        assertEquals(0, plugin.state.cotEventCount.value)
+        assertNull(plugin.state.lastRadialCoordinate.value)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ include(":app")
 // one include() line here + one implementation(project(...)) in app/build.gradle.kts.
 include(":plugins:plugin-sdk")
 include(":plugins:example-adsb")
+include(":plugins:example-diagnostics")


### PR DESCRIPTION
## What

Brings Android to parity with iOS by adding a second bundled reference plugin, **`:plugins:example-diagnostics`**, the counterpart of iOS's `DiagnosticsPlugin`.

Where `:plugins:example-adsb` exercises the **map-overlay + settings-row** hooks, the Diagnostics plugin exercises the **other two** host hooks ADS-B doesn't use — previously only touched by `:app`'s `PluginHostSurfaceTest` probe, never a real bundled example:

- **`registerRadialAction`** — a "Diagnostics" long-press radial action that logs and records the tapped coordinate.
- **`registerCoTHandler`** — observes every inbound CoT event, counts it, and returns `false` (does **not** consume) so the core pipeline is untouched.

It implements `OmniTAKPlugin` (`pluginId "soy.engindearing.diagnostics"`, v1.0.0, author Engindearing) and ships **OFF by default**, matching iOS's `registeredDisabledByDefault`. Its `settingsContent()` shows live readouts (CoT events seen, last radial coordinate) via StateFlows — the same reactive pattern as `AdsbSettingsContent`.

## Default-OFF mechanism

The registry/UI default reads are `getBoolean(key, true)`. So `OmniTAKApp.loadBundledPlugins()` seeds the diagnostics `plugin_<id>_enabled` flag to `false` on first run (ids listed in `OmniTAKApp.DISABLED_BY_DEFAULT`). Result: Diagnostics ships OFF, ADS-B stays ON (its key is left unset → defaults ON).

## UI discoverability

A default-OFF plugin registers no settings row while disabled, so it would otherwise be invisible. This wires the previously-orphaned `PluginsListScreen` (route `"plugins"`, already in `AppNav` but reachable from nowhere) to a new **"Manage plugins"** row in Settings. That list reads `PluginRegistry.all()`, so both plugins appear with on/off toggles — Diagnostics shows as a **second entry, OFF by default**.

## Module shape

Mirrors `example-adsb`: new `:plugins:example-diagnostics` Gradle module added to `settings.gradle.kts` + `app/build.gradle.kts`. Depends on **only** `:plugins:plugin-sdk` + Compose (no MapLibre, no `:app`) — the dependency graph stays acyclic.

## Verification

- `./gradlew assembleDebug testDebugUnitTest` → **BUILD SUCCESSFUL** (new `DiagnosticsPluginTest` covers both hooks + the not-consume contract + deactivate reset).
- Installed on the running emulator:
  - First run seeds `plugin_soy.engindearing.diagnostics_enabled=false` (ADS-B key unset → ON).
  - Settings → Manage plugins shows **ADS-B (ON)** and **Diagnostics (OFF)** as a second entry.
  - Enabling Diagnostics does **not** crash and renders its `settingsContent` (CoT count + last radial coordinate); toggling back OFF is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)