### PR TITLE
chore(android): in-app title to OmniTAK (drop Mobile)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/AboutScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/AboutScreen.kt
@@ -23,7 +23,7 @@ fun AboutScreen() {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text("OmniTAK Mobile", style = MaterialTheme.typography.titleLarge, color = TacticalAccent)
+        Text("OmniTAK", style = MaterialTheme.typography.titleLarge, color = TacticalAccent)
         Spacer(Modifier.height(8.dp))
         Text("By Engindearing", style = MaterialTheme.typography.bodyLarge)
         Spacer(Modifier.height(16.dp))


### PR DESCRIPTION
## What
Drops the "Mobile" qualifier from the Android app's user-facing name to match the OmniTAK rebrand.

- `AboutScreen` title `"OmniTAK Mobile"` → `"OmniTAK"`.
- Launcher `app_name` was **already** `OmniTAK` (no change needed).

## Not changed (intentional)
- Package name `soy.engindearing.omnitak.mobile` — permanent identifier; changing it would orphan the Play listing/installs.

Trivial string-literal change; no build risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
