### PR TITLE
fix(cesium): inherit 2D viewport on engine switch (#78)

### DIFF
--- a/app/src/main/assets/cesium_scene.html
+++ b/app/src/main/assets/cesium_scene.html
@@ -125,6 +125,18 @@
       v.camera.lookAt(target,new Cesium.HeadingPitchRange(heading,pitch,range));
       v.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);_postCameraChanged(v);
     },
+    // #78 (Android) / #62 (iOS) — engine-switch viewport handoff. Native
+    // calls this once on bridge-ready with the 2D engine's last camera;
+    // cancels the (0,0) bootstrap flight and jumps straight to the
+    // inherited view, top-down like the 2D map. `height` is precomputed
+    // natively from the web-mercator zoom (CesiumCameraMath is the exact
+    // inverse of _zoomFromHeight above). Optional pitch (deg, default -90)
+    // keeps the method reusable for pose restores. No call = legacy intro.
+    setCamera(arg){const e=_parse(arg);if(!e||typeof e.lat!=='number'||typeof e.lon!=='number'||typeof e.height!=='number')return;const v=_state.viewer;if(!v)return;
+      v.camera.cancelFlight();
+      v.camera.setView({destination:Cesium.Cartesian3.fromDegrees(e.lon,e.lat,e.height),orientation:{heading:Cesium.Math.toRadians(e.heading||0),pitch:Cesium.Math.toRadians(typeof e.pitch==='number'?e.pitch:-90),roll:0}});
+      _hideLoading();_postCameraChanged(v);
+    },
     ping(){return _state.ready?'pong':'loading'},
     upsertDrawing(arg){const d=_parse(arg);if(!d||!d.uid||!d.kind||!Array.isArray(d.coords)||d.coords.length===0)return;const v=_state.viewer;if(!v)return;
       const color=_drawColor(d.color,0.85),fillC=_drawColor(d.color,0.25),width=typeof d.width==='number'?d.width:3;

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MapCameraStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MapCameraStore.kt
@@ -30,6 +30,12 @@ class MapCameraStore(private val userPrefsStore: UserPrefsStore) {
         private set
     var lastZoom: Double? = null
         private set
+    // Bearing (degrees clockwise from north) is session-memory ONLY — it
+    // is not persisted with the lat/lon/zoom triple because the 2D map
+    // intentionally cold-starts north-up. It exists so the 2D↔3D engine
+    // switch can hand the rotation across within a session (#78).
+    var lastBearing: Double? = null
+        private set
 
     private val scope = CoroutineScope(Dispatchers.IO)
     private var debounceJob: Job? = null
@@ -54,10 +60,11 @@ class MapCameraStore(private val userPrefsStore: UserPrefsStore) {
      * immediately and debounce-persists to DataStore after 500 ms so
      * rapid pan/zoom gestures coalesce into a single write.
      */
-    fun update(lat: Double, lon: Double, zoom: Double) {
+    fun update(lat: Double, lon: Double, zoom: Double, bearing: Double = 0.0) {
         lastTargetLat = lat
         lastTargetLon = lon
         lastZoom      = zoom
+        lastBearing   = bearing
 
         debounceJob?.cancel()
         debounceJob = scope.launch {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumCameraMath.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumCameraMath.kt
@@ -1,0 +1,98 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import kotlin.math.cos
+import kotlin.math.log2
+import kotlin.math.max
+import kotlin.math.pow
+
+/**
+ * Web-mercator zoom ↔ Cesium camera height conversion (issue #78).
+ *
+ * The Cesium globe and the MapLibre 2D engine describe "how far out the
+ * operator is looking" differently — MapLibre as a web-mercator zoom
+ * level, Cesium as camera altitude in meters. The scene bridge already
+ * converts 3D → 2D: `_zoomFromHeight` in `cesium_scene.html` maps the
+ * camera height to a zoom on every `camerachanged` event, which is how
+ * the 3D → 2D engine switch inherits the viewport (via MapCameraStore).
+ *
+ * [heightForZoom] is the exact algebraic inverse of that JS function, so
+ * a camera seeded for the 2D → 3D handoff reports back the same zoom it
+ * was seeded from — repeated engine toggles must not zoom-creep. Keep
+ * the two implementations in lockstep.
+ *
+ * The JS forward mapping (height → zoom):
+ *
+ *     mpp  = max(h * 256 / 1000, 1)            // height → meters-per-pixel
+ *     zoom = clamp(log2(40075017 * max(cos(lat), 0.01) / mpp), 0, 22)
+ *
+ * Inverting for height gives the standard web-mercator shape
+ * `height = C * cos(lat) / 2^zoom` with C = 40_075_017 * 1000 / 256
+ * ≈ 156_543_035 m (equatorial circumference × the bridge's 1000/256
+ * height-per-meters-per-pixel scale). Sanity: zoom 15 at the equator
+ * ≈ 4.8 km altitude.
+ */
+object CesiumCameraMath {
+
+    /** Equatorial circumference used by the JS `_zoomFromHeight`. */
+    private const val EARTH_CIRCUMFERENCE_M = 40_075_017.0
+
+    /** The JS bridge maps height → meters-per-pixel as `mpp = h * 256 / 1000`. */
+    private const val HEIGHT_PER_MPP = 1000.0 / 256.0
+
+    /** Zoom clamp range — mirrors the JS `Math.max(0, Math.min(22, z))`. */
+    private const val MIN_ZOOM = 0.0
+    private const val MAX_ZOOM = 22.0
+
+    /** `cos(lat)` floor — mirrors the JS `Math.max(Math.cos(latRad), 0.01)`. */
+    private const val MIN_COS_LAT = 0.01
+
+    /**
+     * Bootstrap world-flight altitude from `cesium_scene.html` — also the
+     * ceiling for seeded cameras, so a whole-world 2D zoom (< ~3) never
+     * places the camera farther out than the legacy intro view.
+     */
+    const val WORLD_VIEW_HEIGHT_M = 20_000_000.0
+
+    /** Floor so degenerate inputs can never seed a subterranean camera. */
+    private const val MIN_HEIGHT_M = 10.0
+
+    /**
+     * Cesium camera altitude (meters above the ellipsoid) that frames the
+     * same ground extent as web-mercator [zoom] at latitude [latDeg].
+     */
+    fun heightForZoom(zoom: Double, latDeg: Double): Double {
+        val z = zoom.coerceIn(MIN_ZOOM, MAX_ZOOM)
+        val c = max(cos(Math.toRadians(latDeg)), MIN_COS_LAT)
+        val mpp = EARTH_CIRCUMFERENCE_M * c / 2.0.pow(z)
+        return (mpp * HEIGHT_PER_MPP).coerceIn(MIN_HEIGHT_M, WORLD_VIEW_HEIGHT_M)
+    }
+
+    /**
+     * Web-mercator zoom for a Cesium camera at [heightMeters] above
+     * latitude [latDeg] — the exact Kotlin mirror of the JS
+     * `_zoomFromHeight`, kept here so the inverse pair can be unit
+     * tested on the JVM.
+     */
+    fun zoomForHeight(heightMeters: Double, latDeg: Double): Double {
+        val c = max(cos(Math.toRadians(latDeg)), MIN_COS_LAT)
+        val mpp = max(heightMeters / HEIGHT_PER_MPP, 1.0)
+        return log2(EARTH_CIRCUMFERENCE_M * c / mpp).coerceIn(MIN_ZOOM, MAX_ZOOM)
+    }
+}
+
+/**
+ * Viewport captured from the 2D engine at engine-switch time, used to
+ * seed the Cesium camera on bridge-ready (issue #78). [bearing] is
+ * degrees clockwise from north — MapLibre's bearing and Cesium's
+ * heading share that convention.
+ */
+data class CesiumCameraSeed(
+    val lat: Double,
+    val lon: Double,
+    val zoom: Double,
+    val bearing: Double,
+) {
+    /** All fields must be finite — these are interpolated into JS source. */
+    val isValid: Boolean
+        get() = lat.isFinite() && lon.isFinite() && zoom.isFinite() && bearing.isFinite()
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
@@ -42,8 +42,16 @@ fun CesiumMapView(
     selfCallsign: String,
     onLongPress: (LatLng, Offset) -> Unit,
     onContactTap: (CoTEvent) -> Unit,
-    onCameraChanged: (LatLng, Double) -> Unit,
+    // Camera events from the scene: target, web-mercator zoom, heading
+    // (degrees clockwise from north — MapLibre's bearing convention).
+    // Heading rides along so the 3D→2D switch keeps the rotation (#78).
+    onCameraChanged: (LatLng, Double, Double) -> Unit,
     modifier: Modifier = Modifier,
+    // #78 — 2D→3D engine-switch handoff. When non-null (the operator was
+    // looking somewhere on the 2D engine), the globe opens at this
+    // viewport instead of the scene's legacy (0,0) world intro flight.
+    // Captured once per activation by MapScreen; seeded on bridge-ready.
+    initialCamera: CesiumCameraSeed? = null,
     // Tick counters from the on-screen map controls. Incrementing one fires
     // the matching camera command on the globe. Mirror the TacticalMap
     // (2D) wiring so the +/- zoom and "center on me" buttons work on 3D too.
@@ -79,6 +87,23 @@ fun CesiumMapView(
         wv.evaluateJavascript("window.OmniBridge.setEntities($json);", null)
     }
 
+    // #78 — seed the globe camera from the 2D engine's viewport on
+    // bridge-ready. Zoom → height via CesiumCameraMath (the exact inverse
+    // of the scene's _zoomFromHeight, so toggling engines never
+    // zoom-creeps). Fields are validated finite before being
+    // interpolated into JS source.
+    fun seedInheritedCamera() {
+        val wv = webViewRef.value ?: return
+        val seed = initialCamera
+        if (seed == null || !seed.isValid) return
+        val height = CesiumCameraMath.heightForZoom(seed.zoom, seed.lat)
+        wv.evaluateJavascript(
+            "window.OmniBridge.setCamera(" +
+                "{lat:${seed.lat},lon:${seed.lon},height:$height,heading:${seed.bearing}});",
+            null,
+        )
+    }
+
     AndroidView(
         modifier = modifier,
         factory = { ctx ->
@@ -95,6 +120,10 @@ fun CesiumMapView(
                         fun onReady() {
                             mainHandler.post {
                                 ready.value = true
+                                // Inherit the 2D viewport before the first
+                                // entity push so the scene opens where the
+                                // operator was looking (#78).
+                                seedInheritedCamera()
                                 pushEntities()
                             }
                         }
@@ -121,7 +150,11 @@ fun CesiumMapView(
                                         onLongPressState.value(LatLng(lat, lon), Offset(sx, sy))
                                     }
                                     "camerachanged" -> {
-                                        onCameraState.value(LatLng(lat, lon), o.optDouble("zoom", 11.0))
+                                        onCameraState.value(
+                                            LatLng(lat, lon),
+                                            o.optDouble("zoom", 11.0),
+                                            o.optDouble("heading", 0.0),
+                                        )
                                     }
                                 }
                             }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -47,6 +47,11 @@ import soy.engindearing.omnitak.mobile.data.TakTeamColor
 fun TacticalMap(
     initialCenter: LatLng = LatLng(0.0, 0.0),  // neutral world default — callers should pass a real center
     initialZoom: Double = 2.0,
+    /** Initial camera rotation (degrees clockwise from north). #78 — the
+     *  3D→2D engine switch hands the globe's heading back through this so
+     *  the rotation survives the swap; cold start keeps the north-up
+     *  default. */
+    initialBearing: Double = 0.0,
     styleJson: String = TACTICAL_STYLE_DARK_MATTER,
     onMapLongPress: ((LatLng, Offset) -> Unit)? = null,
     onContactTap: ((CoTEvent) -> Unit)? = null,
@@ -81,7 +86,9 @@ fun TacticalMap(
      *  fall back to cyan (0xFF00FFFF) to match CivTAK's default for
      *  unaffiliated friendlies. Sourced from [soy.engindearing.omnitak.mobile.data.UserPrefs.team]. */
     selfTeamColor: String = "Cyan",
-    onCameraIdle: ((LatLng, Double) -> Unit)? = null,
+    /** Camera idle: target, zoom, bearing (degrees clockwise from north).
+     *  Bearing feeds the #78 engine-switch viewport handoff. */
+    onCameraIdle: ((LatLng, Double, Double) -> Unit)? = null,
     /** Fired once the MapLibre map is ready. Issue #16 — lasso uses
      *  this to grab the [MapLibreMap] reference for screen↔geo
      *  projection during freehand selection. */
@@ -126,6 +133,7 @@ fun TacticalMap(
                 map.cameraPosition = CameraPosition.Builder()
                     .target(initialCenter)
                     .zoom(initialZoom)
+                    .bearing(initialBearing)
                     .build()
                 map.setStyle(Style.Builder().fromJson(styleJson)) { style ->
                     ContactLayer.update(map, context, currentContacts)
@@ -164,7 +172,7 @@ fun TacticalMap(
                 map.addOnCameraIdleListener {
                     val pos = map.cameraPosition
                     val target = pos.target ?: return@addOnCameraIdleListener
-                    currentCameraIdle?.invoke(target, pos.zoom)
+                    currentCameraIdle?.invoke(target, pos.zoom, pos.bearing)
                 }
                 map.addOnMapLongClickListener { latLng ->
                     val screen = map.projection.toScreenLocation(latLng)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -373,9 +373,9 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             }
         )
     }
-    val handleCameraChanged: (LatLng, Double) -> Unit = { target, zoom ->
+    val handleCameraChanged: (LatLng, Double, Double) -> Unit = { target, zoom, bearing ->
         cameraTarget = target
-        app.mapCameraStore.update(target.latitude, target.longitude, zoom)
+        app.mapCameraStore.update(target.latitude, target.longitude, zoom, bearing)
     }
     // Keep the ADSB query box following the viewport — significant pans
     // move the box, the next 15s poll picks it up. Routed through the plugin;
@@ -402,6 +402,34 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             .background(MaterialTheme.colorScheme.background),
     ) {
         if (userPrefs.cesiumGlobeEnabled) {
+        // #78 — 2D→3D viewport handoff, captured once per globe activation
+        // (the `remember` is forgotten when the 3D branch leaves
+        // composition, so every switch re-reads the latest camera).
+        // Priority mirrors TacticalMap's cold-start chain below:
+        //   1. Last camera (live this session, or persisted) — the operator
+        //      was looking somewhere; the globe must open there.
+        //   2. Self-fix at zoom 12 — cold start straight into 3D with no
+        //      meaningful camera yet (parity with the 2D GPS start).
+        //   3. null — nothing to inherit; the scene keeps its legacy (0,0)
+        //      world intro flight.
+        val cesiumSeed = remember {
+            val store = app.mapCameraStore
+            val storeLat = store.lastTargetLat
+            val storeLon = store.lastTargetLon
+            val storeZoom = store.lastZoom
+            val fix = selfFix
+            when {
+                storeLat != null && storeLon != null && storeZoom != null ->
+                    soy.engindearing.omnitak.mobile.ui.components.CesiumCameraSeed(
+                        storeLat, storeLon, storeZoom, store.lastBearing ?: 0.0,
+                    )
+                fix != null ->
+                    soy.engindearing.omnitak.mobile.ui.components.CesiumCameraSeed(
+                        fix.lat, fix.lon, 12.0, 0.0,
+                    )
+                else -> null
+            }
+        }
         // 3D Globe — photoreal Cesium WebView engine. Contacts (incl. dropped
         // pins) + self render as entities; long-press surfaces the same radial
         // menu the 2D/terrain engines use, tapping a contact opens its sheet.
@@ -414,6 +442,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             onLongPress = handleMapLongPress,
             onContactTap = handleContactTap,
             onCameraChanged = handleCameraChanged,
+            initialCamera = cesiumSeed,
             // Same control ticks the 2D map uses — make +/- and "center on
             // me" drive the globe (VC 77: buttons did nothing on 3D).
             zoomInTrigger = zoomInTick,
@@ -453,6 +482,10 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             },
             initialZoom = app.mapCameraStore.lastZoom
                 ?: if (selfFix != null) 12.0 else FALLBACK_GLOBAL_ZOOM,
+            // #78 — 3D→2D handoff: restore the rotation the globe (or the
+            // prior 2D view this session) had. Session-memory only, so
+            // cold start stays north-up exactly as before.
+            initialBearing = app.mapCameraStore.lastBearing ?: 0.0,
             onCameraIdle = handleCameraChanged,
             onMapReady = { map -> mapboxMap = map },
             // GAP-101 / GAP-107 — react to the basemap selection from Settings.

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumCameraMathTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumCameraMathTest.kt
@@ -1,0 +1,95 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies the zoom ↔ Cesium-camera-height conversion used by the
+ * 2D ↔ 3D engine-switch viewport handoff (issue #78).
+ *
+ * [CesiumCameraMath.zoomForHeight] must stay an exact Kotlin mirror of
+ * `_zoomFromHeight` in `cesium_scene.html` (the 3D → 2D direction), and
+ * [CesiumCameraMath.heightForZoom] must be its algebraic inverse so
+ * repeated engine toggles don't zoom-creep.
+ */
+class CesiumCameraMathTest {
+
+    /** height = C·cos(lat)/2^zoom with C = 40_075_017·1000/256. */
+    @Test fun heightForZoom_zoom15_equator_is_about_4_8km() {
+        val h = CesiumCameraMath.heightForZoom(15.0, 0.0)
+        // 40_075_017_000 / 256 / 2^15 = 4777.19…
+        assertEquals(4777.19, h, 0.5)
+    }
+
+    @Test fun heightForZoom_scales_with_cos_latitude() {
+        val equator = CesiumCameraMath.heightForZoom(15.0, 0.0)
+        val at60 = CesiumCameraMath.heightForZoom(15.0, 60.0)
+        // cos(60°) = 0.5 — same zoom frames half the ground width, so
+        // the camera sits at half the altitude.
+        assertEquals(equator * 0.5, at60, 0.5)
+    }
+
+    /** The seeded camera must report back the zoom it was seeded from. */
+    @Test fun roundTrip_zoom_to_height_to_zoom_is_stable() {
+        for (zoom in listOf(3.0, 5.5, 10.0, 12.25, 15.0, 18.0, 22.0)) {
+            for (lat in listOf(0.0, 47.65, -33.86, 60.0, -60.0)) {
+                val h = CesiumCameraMath.heightForZoom(zoom, lat)
+                val back = CesiumCameraMath.zoomForHeight(h, lat)
+                assertEquals("zoom=$zoom lat=$lat", zoom, back, 1e-6)
+            }
+        }
+    }
+
+    /** Mirror of the JS `_zoomFromHeight`: the 20,000 km bootstrap world
+     *  view maps to a whole-world web-mercator zoom (~3). */
+    @Test fun zoomForHeight_worldViewHeight_is_whole_world_zoom() {
+        val z = CesiumCameraMath.zoomForHeight(CesiumCameraMath.WORLD_VIEW_HEIGHT_M, 0.0)
+        // log2(40075017 / (20_000_000·256/1000)) = 2.9685…
+        assertEquals(2.9685, z, 0.001)
+    }
+
+    /** A whole-world 2D zoom must not seed the camera farther out than
+     *  the legacy (0,0) intro flight. */
+    @Test fun heightForZoom_clamps_to_world_view_ceiling() {
+        assertEquals(
+            CesiumCameraMath.WORLD_VIEW_HEIGHT_M,
+            CesiumCameraMath.heightForZoom(0.0, 0.0),
+            0.0,
+        )
+    }
+
+    @Test fun heightForZoom_clamps_out_of_range_zoom() {
+        assertEquals(
+            CesiumCameraMath.heightForZoom(22.0, 0.0),
+            CesiumCameraMath.heightForZoom(30.0, 0.0),
+            1e-9,
+        )
+    }
+
+    /** cos(lat) floor (0.01) keeps polar cameras finite and mirrored. */
+    @Test fun polar_latitude_uses_cos_floor_and_still_round_trips() {
+        val h = CesiumCameraMath.heightForZoom(10.0, 89.9)
+        assertTrue(h.isFinite() && h > 0)
+        assertEquals(10.0, CesiumCameraMath.zoomForHeight(h, 89.9), 1e-6)
+    }
+
+    @Test fun zoomForHeight_clamps_into_0_22() {
+        assertEquals(22.0, CesiumCameraMath.zoomForHeight(0.5, 0.0), 0.0)
+        assertEquals(0.0, CesiumCameraMath.zoomForHeight(1.0e12, 0.0), 0.0)
+    }
+
+    // --- CesiumCameraSeed validity (values are interpolated into JS) ---
+
+    @Test fun seed_with_finite_fields_is_valid() {
+        assertTrue(CesiumCameraSeed(47.65, -117.42, 12.0, 35.0).isValid)
+    }
+
+    @Test fun seed_with_nan_or_infinite_field_is_invalid() {
+        assertFalse(CesiumCameraSeed(Double.NaN, -117.42, 12.0, 0.0).isValid)
+        assertFalse(CesiumCameraSeed(47.65, Double.NEGATIVE_INFINITY, 12.0, 0.0).isValid)
+        assertFalse(CesiumCameraSeed(47.65, -117.42, Double.NaN, 0.0).isValid)
+        assertFalse(CesiumCameraSeed(47.65, -117.42, 12.0, Double.POSITIVE_INFINITY).isValid)
+    }
+}


### PR DESCRIPTION
Fixes #78 — opening the 3D Globe reset the camera to lat/lng (0,0) fully zoomed out (the `cesium_scene.html` bootstrap flight) instead of preserving the operator's 2D viewport. Reported by u/mozios on the r/ATAK tester thread.

## Handoff design

**2D → 3D (the bug):** nothing ever seeded the Cesium camera — the scene's init unconditionally flew to `(0,0, 20,000 km)`. Now:

- `MapScreen` captures a `CesiumCameraSeed` (center lat/lon, zoom, bearing) from `MapCameraStore` once per globe activation (a `remember` in the 3D branch, so each switch re-reads the latest camera). The store is engine-agnostic and already kept current by camera-idle events.
- `CesiumMapView` seeds the scene on **bridge-ready** via a new minimal `OmniBridge.setCamera({lat, lon, height, heading[, pitch]})` method: it cancels the bootstrap flight and does an instant `setView`, top-down (pitch −90) like the 2D map. No call → the legacy world intro, byte-compatible with today.

**3D → 2D:** center+zoom already inherited on Android (Cesium `camerachanged` → `_zoomFromHeight` → `MapCameraStore` → `TacticalMap` initial camera). This PR adds **bearing** to that path: Cesium heading rides the `camerachanged` payload into the store and back out through a new `TacticalMap.initialBearing`. Bearing is session-memory only — cold start stays north-up, exactly as before.

**Cold start straight into 3D (no meaningful 2D camera):** priority mirrors the 2D cold-start chain — last camera → GPS fix at zoom 12 → legacy (0,0) world intro. Viewport inherit only wins when the operator was actually looking somewhere.

## Zoom ↔ height conversion

The scene already converts 3D→2D (`_zoomFromHeight` in `cesium_scene.html`), so the new Kotlin `CesiumCameraMath.heightForZoom` is derived as its **exact algebraic inverse** rather than a fresh formula:

```
height = C · cos(lat) / 2^zoom,   C = 40_075_017 · 1000 / 256 ≈ 156_543_035 m
```

Sanity: zoom 15 at the equator ≈ 4.8 km altitude. Exact-inverse pairing means a seeded camera reports back the zoom it was seeded from — repeated 2D↔3D toggles cannot zoom-creep. Heights clamp to the 20,000 km bootstrap ceiling so whole-world zooms never seed farther out than the legacy intro.

## JS bridge contract (iOS lockstep)

One additive method on `window.OmniBridge` (`setCamera`), commented in the HTML with the #78/#62 cross-reference. Nothing existing changed, and the un-seeded path is untouched — the iOS copy of the scene keeps working as-is until **engindearing-projects/OmniTAK-iOS#62 ports the same contract** (iOS already re-flies a persisted Cesium pose on ready; it should additionally seed from the 2D MapKit camera using this method, with its own zoom→height conversion mirroring `_zoomFromHeight`).

## Verification

- `./gradlew assembleDebug` — green
- `./gradlew testDebugUnitTest` — green (all existing + 10 new)
- New pure-JVM `CesiumCameraMathTest`: zoom-15 sanity case, cos(lat) scaling, round-trip stability across zooms/latitudes, world-view height ↔ whole-world zoom, clamp behavior, polar cos-floor, and `CesiumCameraSeed` finite-field validation (values are interpolated into JS source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)