### PR TITLE
fix(ui): compass clears the top status bar (#81)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -185,6 +185,14 @@ fun TacticalMap(
                     isCompassEnabled = true
                     isLogoEnabled = false
                     isAttributionEnabled = true
+                    // Issue #81 — push the compass below the ATAKStatusBar.
+                    // setCompassMargins(left, top, right, bottom) takes raw
+                    // pixels; 4 dp matches MapLibre's built-in side defaults
+                    // so only the top changes.
+                    val density = context.resources.displayMetrics.density
+                    val compassTopPx = (COMPASS_TOP_MARGIN_DP * density + 0.5f).toInt()
+                    val sideMarginPx = (4 * density + 0.5f).toInt()
+                    setCompassMargins(sideMarginPx, compassTopPx, sideMarginPx, sideMarginPx)
                 }
                 // Persist camera state on idle so bottom-nav switches
                 // (Map → Settings → Map etc.) don't reset the operator's
@@ -525,6 +533,26 @@ fun TacticalMap(
 
     AndroidView(factory = { mapView }, modifier = modifier)
 }
+
+/**
+ * Issue #81 — top margin for the MapLibre built-in compass so it clears
+ * the ATAKStatusBar that sits at the very top of the map surface.
+ *
+ * Derivation (all in dp):
+ *   ATAKStatusBar.padding(vertical = 8.dp): 8 top + 8 bottom  = 16 dp
+ *   ATAKStatusBar row content (13sp text / 14dp icon)          ≈ 20 dp
+ *   ATAKStatusBar total height                                  ≈ 36 dp
+ *   Typical Android system status bar                          ≈ 24 dp
+ *   Total top clearance                                        ≈ 60 dp
+ *   + 4 dp breathing room                                       = 64 dp
+ *
+ * This is a fixed dp constant because ATAKStatusBar has a fixed layout
+ * (no dynamic content that changes the bar height). The system status bar
+ * typically ranges 20–28 dp; 64 dp clears both extremes comfortably.
+ * setCompassMargins accepts raw pixels, so we convert at runtime via
+ * context.resources.displayMetrics.density.
+ */
+internal const val COMPASS_TOP_MARGIN_DP = 64
 
 /** Issue #75 — imperative holder for the self-marker's current dim state
  *  (stale restored fix vs live GPS). Shared between the activation path,


### PR DESCRIPTION
## Summary

- **Root cause:** `TacticalMap.kt:184-188` — `map.uiSettings.apply` set `isCompassEnabled = true` but never called `setCompassMargins()`, leaving MapLibre's default 4 dp top margin. The `ATAKStatusBar` occupies ~36 dp of app bar + ~24 dp system status bar = ~60 dp from the top edge, completely hiding the compass.
- **Fix:** Added `COMPASS_TOP_MARGIN_DP = 64` constant (at `TacticalMap.kt:555`) and called `setCompassMargins(4px, 64dp→px, 4px, 4px)` at map-ready time so the compass sits below the status bar, right-aligned.
- **Compass adaptive behavior preserved:** MapLibre's `setCompassFadeFacingNorth` default (compass only appears when bearing ≠ north) is untouched.
- **Cesium 3D engine:** No built-in bearing compass widget on the Android Cesium side — out of scope, tracked by the shared-bridge work.

## Changed files

| File | Lines | What |
|------|-------|------|
| `app/src/main/kotlin/…/ui/components/TacticalMap.kt` | 184–195 | `uiSettings.apply`: added `setCompassMargins()` call |
| `app/src/main/kotlin/…/ui/components/TacticalMap.kt` | 537–555 | Added `COMPASS_TOP_MARGIN_DP = 64` constant with derivation comment |

## Expected compass position

Compass widget appears **below the ATAKStatusBar** (~64 dp from the top of the screen), **right-aligned** with 4 dp right margin — matching the stock ATAK compass position. Disappears when bearing is north (unchanged adaptive behavior).

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL (all unit tests pass)
- [ ] On-device visual verification: rotate map → compass appears below status bar, not behind it. Rides with the next build.

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)