### PR TITLE
fix(drawing): survive style reloads — re-anchor drawing layers (#80)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -185,6 +185,14 @@ fun TacticalMap(
                     isCompassEnabled = true
                     isLogoEnabled = false
                     isAttributionEnabled = true
+                    // Issue #81 — push the compass below the ATAKStatusBar.
+                    // setCompassMargins(left, top, right, bottom) takes raw
+                    // pixels; 4 dp matches MapLibre's built-in side defaults
+                    // so only the top changes.
+                    val density = context.resources.displayMetrics.density
+                    val compassTopPx = (COMPASS_TOP_MARGIN_DP * density + 0.5f).toInt()
+                    val sideMarginPx = (4 * density + 0.5f).toInt()
+                    setCompassMargins(sideMarginPx, compassTopPx, sideMarginPx, sideMarginPx)
                 }
                 // Persist camera state on idle so bottom-nav switches
                 // (Map → Settings → Map etc.) don't reset the operator's
@@ -525,6 +533,26 @@ fun TacticalMap(
 
     AndroidView(factory = { mapView }, modifier = modifier)
 }
+
+/**
+ * Issue #81 — top margin for the MapLibre built-in compass so it clears
+ * the ATAKStatusBar that sits at the very top of the map surface.
+ *
+ * Derivation (all in dp):
+ *   ATAKStatusBar.padding(vertical = 8.dp): 8 top + 8 bottom  = 16 dp
+ *   ATAKStatusBar row content (13sp text / 14dp icon)          ≈ 20 dp
+ *   ATAKStatusBar total height                                  ≈ 36 dp
+ *   Typical Android system status bar                          ≈ 24 dp
+ *   Total top clearance                                        ≈ 60 dp
+ *   + 4 dp breathing room                                       = 64 dp
+ *
+ * This is a fixed dp constant because ATAKStatusBar has a fixed layout
+ * (no dynamic content that changes the bar height). The system status bar
+ * typically ranges 20–28 dp; 64 dp clears both extremes comfortably.
+ * setCompassMargins accepts raw pixels, so we convert at runtime via
+ * context.resources.displayMetrics.density.
+ */
+internal const val COMPASS_TOP_MARGIN_DP = 64
 
 /** Issue #75 — imperative holder for the self-marker's current dim state
  *  (stale restored fix vs live GPS). Shared between the activation path,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -236,6 +236,41 @@ fun TacticalMap(
                     }
                 }
             }
+            // Issue #80 — re-anchor drawing (and all other overlay) layers on
+            // EVERY style reload, regardless of the trigger.
+            //
+            // Root cause: MapLibre-Android wipes ALL GeoJSON source data when a
+            // new style is loaded. The explicit setStyle callbacks above re-push
+            // data for Compose-driven reloads (basemap swap, terrain toggle), but
+            // those callbacks are one-shot — they fire only for the specific
+            // setStyle call they are attached to. Any reload MapLibre triggers
+            // internally (tile-source retry, GL context loss, recovery from a
+            // failed style parse) is not covered, leaving the sources empty and
+            // all overlay layers invisible.
+            //
+            // addOnDidFinishLoadingStyleListener fires on the MAIN thread after
+            // every successful style load — both app-initiated and internal. Re-
+            // pushing here is idempotent (setGeoJson replaces source data in-
+            // place), so the explicit callbacks above are kept for their side-
+            // effects (LocationComponent re-apply, camera tilt, onStyleReady
+            // delegation); this listener is a universal safety net that closes the
+            // intermittent gap.
+            //
+            // iOS is immune to this class of bug because Mapbox v11
+            // AnnotationManagers survive style swaps natively — Android's hand-
+            // inserted style layers do not.
+            addOnDidFinishLoadingStyleListener {
+                getMapAsync { map ->
+                    map.getStyle { style ->
+                        ContactLayer.update(map, context, currentContacts)
+                        contactSymbolLayer.installInto(style, context)
+                        contactSymbolLayer.update(map, context, currentContacts)
+                        MeasurementLayer.update(map, currentMeasurementPoints)
+                        DrawingLayer.update(map, currentDrawings)
+                        currentGridCenter?.let { GridLayer.update(map, it) }
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/DrawingLayerStyleSurvivalTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/DrawingLayerStyleSurvivalTest.kt
@@ -1,0 +1,113 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.MapProvider
+
+/**
+ * Issue #80 — verify that the overlay style infrastructure (drawings-src,
+ * drawings-fill, drawings-outline) is present in the style JSON produced by
+ * [styleJsonForProvider] and [injectTerrain], in both plain-2D and 3D-terrain
+ * modes.
+ *
+ * [DrawingLayer.update] cannot be invoked from a JVM-only test (it calls
+ * MapLibre's [org.maplibre.android.maps.MapLibreMap]), and [DrawingLayer.toFeatures]
+ * is private. What we CAN assert — in pure JVM with no Android runtime — is
+ * that the style JSON always carries the three drawing artefacts
+ * (`drawings-src`, `drawings-fill`, `drawings-outline`) regardless of the
+ * [MapProvider] or terrain flag. If those keys are ever absent the
+ * [addOnDidFinishLoadingStyleListener] re-push registered in [TacticalMap]
+ * would write into a nonexistent source and drawings would disappear again.
+ */
+class DrawingLayerStyleSurvivalTest {
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private fun assertDrawingKeysPresent(styleJson: String, label: String) {
+        assertTrue("$label must contain drawings-src", styleJson.contains("drawings-src"))
+        assertTrue("$label must contain drawings-fill", styleJson.contains("drawings-fill"))
+        assertTrue("$label must contain drawings-outline", styleJson.contains("drawings-outline"))
+    }
+
+    // ── plain style (no terrain) ─────────────────────────────────────────
+
+    @Test fun osm_style_contains_drawing_artefacts() {
+        val style = styleJsonForProvider(MapProvider.OSM_RASTER, terrain3d = false)
+        assertDrawingKeysPresent(style, "OSM plain style")
+    }
+
+    @Test fun topo_style_contains_drawing_artefacts() {
+        val style = styleJsonForProvider(MapProvider.TOPO_HINT, terrain3d = false)
+        assertDrawingKeysPresent(style, "Topo plain style")
+    }
+
+    @Test fun satellite_style_contains_drawing_artefacts() {
+        val style = styleJsonForProvider(MapProvider.SATELLITE_HINT, terrain3d = false)
+        assertDrawingKeysPresent(style, "Satellite plain style")
+    }
+
+    @Test fun custom_wmts_valid_url_contains_drawing_artefacts() {
+        val style = styleJsonForProvider(
+            MapProvider.WMTS_CUSTOM,
+            customTileUrl = "https://example.org/{z}/{x}/{y}.png",
+            terrain3d = false,
+        )
+        assertDrawingKeysPresent(style, "Custom WMTS plain style")
+    }
+
+    @Test fun custom_wmts_invalid_url_falls_back_to_osm_with_drawing_artefacts() {
+        val style = styleJsonForProvider(
+            MapProvider.WMTS_CUSTOM,
+            customTileUrl = "",
+            terrain3d = false,
+        )
+        assertDrawingKeysPresent(style, "Custom WMTS fallback-OSM plain style")
+    }
+
+    // ── terrain-injected style ────────────────────────────────────────────
+
+    @Test fun osm_terrain_style_contains_drawing_artefacts() {
+        val style = styleJsonForProvider(MapProvider.OSM_RASTER, terrain3d = true)
+        assertDrawingKeysPresent(style, "OSM terrain style")
+    }
+
+    @Test fun topo_terrain_style_contains_drawing_artefacts() {
+        val style = styleJsonForProvider(MapProvider.TOPO_HINT, terrain3d = true)
+        assertDrawingKeysPresent(style, "Topo terrain style")
+    }
+
+    @Test fun satellite_terrain_style_contains_drawing_artefacts() {
+        val style = styleJsonForProvider(MapProvider.SATELLITE_HINT, terrain3d = true)
+        assertDrawingKeysPresent(style, "Satellite terrain style")
+    }
+
+    @Test fun terrain_injection_does_not_break_drawing_artefacts() {
+        // Verify that injectTerrain specifically doesn't remove the drawing
+        // source / layers when called directly on a known-good base style.
+        val base = buildTacticalStyle(
+            "Test",
+            "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+            "© OSM contributors",
+        )
+        val terrainStyle = injectTerrain(base)
+        assertDrawingKeysPresent(terrainStyle, "injectTerrain result")
+    }
+
+    // ── terrain-injected style also contains terrain-dem ─────────────────
+
+    @Test fun terrain_injection_adds_terrain_dem_source() {
+        val style = styleJsonForProvider(MapProvider.OSM_RASTER, terrain3d = true)
+        assertTrue(
+            "Terrain style must contain terrain-dem source",
+            style.contains("terrain-dem"),
+        )
+    }
+
+    @Test fun plain_style_does_not_contain_terrain_dem_source() {
+        val style = styleJsonForProvider(MapProvider.OSM_RASTER, terrain3d = false)
+        assertTrue(
+            "Plain style must NOT contain terrain-dem source",
+            !style.contains("terrain-dem"),
+        )
+    }
+}


### PR DESCRIPTION
## Root cause

`TacticalMap.kt` — `addOnDidFinishLoadingStyleListener` was absent. All overlay GeoJSON data was re-pushed only inside explicit `setStyle` callbacks (one-shot). Any style reload MapLibre triggers internally (GL context loss, tile-source retry, failed parse recovery) wiped `drawings-src`, `contacts-src`, `measurement-src`, and `grid-src` with no re-push path. Drawings became invisible until the next Compose-driven style change (e.g. terrain toggle), which happened to issue a new `setStyle` with its own re-push callback — which is why toggling 3D terrain "fixed" the invisible drawings.

iOS is structurally immune: Mapbox v11 AnnotationManagers survive style swaps natively. Android's hand-inserted style layers do not.

## Fix

Register `mapView.addOnDidFinishLoadingStyleListener` inside the `remember { MapView(...).apply { ... } }` block, alongside the existing `getMapAsync` setup. The listener fires on the **main thread** after **every** successful style load and re-pushes all overlay sources (contacts, contact symbols, measurements, drawings, grid). Re-pushing is idempotent (`setGeoJson` replaces source data in-place); the existing explicit-callback re-pushes are retained for their side-effects (LocationComponent bitmap re-registration, camera tilt, `onStyleReady` delegation to KML overlays).

## Test evidence

- `./gradlew testDebugUnitTest` — green; new `DrawingLayerStyleSurvivalTest` verifies `drawings-src`, `drawings-fill`, and `drawings-outline` survive both plain and terrain-injected style JSON
- `./gradlew assembleDebug` — green

## Manual repro (regression check)

1. Draw a circle/line/polygon on the 2D map
2. Switch basemap style (Settings → Map → any other provider)
3. Drawing must remain visible — was: invisible until terrain toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)