### PR TITLE
MeshCore mesh framework + config profiles with QR sync

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -196,6 +196,24 @@ dependencies {
     implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
     implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
 
+    // ZXing core — QR code generation for the config-profile QR sync feature.
+    // Pure Java, Apache-2.0, ~300 KB, no Android resources. Used only for
+    // encoding (ProfileQrGenerator); MLKit barcode-scanning handles decode
+    // so we don't pull in the full ZXing Android Embedded UI stack.
+    implementation("com.google.zxing:core:3.5.3")
+
+    // MLKit barcode scanning — QR decode in the in-app CameraX scanner.
+    // Runs on-device (no network), bundled model ~900 KB. Apache-2.0.
+    implementation("com.google.mlkit:barcode-scanning:17.3.0")
+
+    // CameraX — camera preview + frame analysis for the QR scanner UI.
+    // Consistent on API 26+ (our minSdk), replaces the fragmented Camera2 API.
+    val cameraxVersion = "1.4.0"
+    implementation("androidx.camera:camera-core:$cameraxVersion")
+    implementation("androidx.camera:camera-camera2:$cameraxVersion")
+    implementation("androidx.camera:camera-lifecycle:$cameraxVersion")
+    implementation("androidx.camera:camera-view:$cameraxVersion")
+
     // MAVLink Java codec for UAS Quick Connect drone control. MIT-licensed,
     // pure Java, MAVLink 2 support per the RAS-A IOP v1.2 (the DoD
     // interoperability standard the official ATAK UAS Tool 13.0 implements).

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- QR scanner — reads the camera for profile import. -->
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/MainActivity.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/MainActivity.kt
@@ -23,7 +23,6 @@ import soy.engindearing.omnitak.mobile.data.CSREnrollmentService
 import soy.engindearing.omnitak.mobile.data.ConnectionProtocol
 import soy.engindearing.omnitak.mobile.data.DeepLinkImport
 import soy.engindearing.omnitak.mobile.data.ImportedServerConfig
-import soy.engindearing.omnitak.mobile.data.ProfileQrCodec
 import soy.engindearing.omnitak.mobile.data.TAKServer
 import soy.engindearing.omnitak.mobile.ui.navigation.AppNav
 import soy.engindearing.omnitak.mobile.ui.theme.OmniTAKTheme
@@ -88,6 +87,8 @@ class MainActivity : ComponentActivity() {
 
         // Profile import takes priority — check BEFORE server-config because
         // both share the `omnitak://` scheme (profile = omnitak://profile?d=…).
+        // Route through the same ImportPreviewDialog used by the in-app scanner
+        // so the user can review and confirm before the profile is applied.
         if (DeepLinkImport.isProfileConfig(uri)) {
             val profile = DeepLinkImport.parseProfileConfig(uri)
             if (profile == null) {
@@ -95,16 +96,10 @@ class MainActivity : ComponentActivity() {
                 return
             }
             val app = applicationContext as OmniTAKApp
-            lifecycleScope.launch {
-                app.configProfileStore.saveProfile(profile)
-                app.configProfileStore.apply(profile)
-                Log.i("OmniTAK", "Imported profile '${profile.name}' from $uri")
-                Toast.makeText(
-                    this@MainActivity,
-                    "Profile \"${profile.name}\" imported",
-                    Toast.LENGTH_LONG,
-                ).show()
-            }
+            // Publish to the pending-import flow; AppNav observes it and
+            // shows ImportPreviewDialog — same flow as the in-app QR scanner.
+            app.pendingProfileImport.value = profile
+            Log.i("OmniTAK", "Queued deep-link profile import '${profile.name}' for user review")
             return
         }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/MainActivity.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/MainActivity.kt
@@ -23,6 +23,7 @@ import soy.engindearing.omnitak.mobile.data.CSREnrollmentService
 import soy.engindearing.omnitak.mobile.data.ConnectionProtocol
 import soy.engindearing.omnitak.mobile.data.DeepLinkImport
 import soy.engindearing.omnitak.mobile.data.ImportedServerConfig
+import soy.engindearing.omnitak.mobile.data.ProfileQrCodec
 import soy.engindearing.omnitak.mobile.data.TAKServer
 import soy.engindearing.omnitak.mobile.ui.navigation.AppNav
 import soy.engindearing.omnitak.mobile.ui.theme.OmniTAKTheme
@@ -84,6 +85,29 @@ class MainActivity : ComponentActivity() {
     private fun handleImportIntent(intent: Intent?) {
         if (intent?.action != Intent.ACTION_VIEW) return
         val uri = intent.data ?: return
+
+        // Profile import takes priority — check BEFORE server-config because
+        // both share the `omnitak://` scheme (profile = omnitak://profile?d=…).
+        if (DeepLinkImport.isProfileConfig(uri)) {
+            val profile = DeepLinkImport.parseProfileConfig(uri)
+            if (profile == null) {
+                Toast.makeText(this, "Invalid profile QR code", Toast.LENGTH_LONG).show()
+                return
+            }
+            val app = applicationContext as OmniTAKApp
+            lifecycleScope.launch {
+                app.configProfileStore.saveProfile(profile)
+                app.configProfileStore.apply(profile)
+                Log.i("OmniTAK", "Imported profile '${profile.name}' from $uri")
+                Toast.makeText(
+                    this@MainActivity,
+                    "Profile \"${profile.name}\" imported",
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+            return
+        }
+
         if (!DeepLinkImport.isServerConfig(uri)) return
 
         val cfg = DeepLinkImport.parseServerConfig(uri)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -27,11 +27,16 @@ import soy.engindearing.omnitak.mobile.domain.ConnectionState
 import soy.engindearing.omnitak.mobile.domain.DataPackageBootstrap
 import soy.engindearing.omnitak.mobile.domain.DrawingStore
 import soy.engindearing.omnitak.mobile.domain.MapCameraStore
-import soy.engindearing.omnitak.mobile.domain.MeshtasticCoTBridge
+import soy.engindearing.omnitak.mobile.domain.MeshCoTBridge
 import soy.engindearing.omnitak.mobile.domain.MeshCoTRouter
+import soy.engindearing.omnitak.mobile.domain.MeshFrameworkManager
 import soy.engindearing.omnitak.mobile.domain.SelfPositionBroadcaster
 import soy.engindearing.omnitak.mobile.domain.TAKConnectionService
 import soy.engindearing.omnitak.mobile.domain.MeshtasticManager
+import soy.engindearing.omnitak.mobile.domain.MeshCoreManager
+import soy.engindearing.omnitak.mobile.data.MeshFramework
+import soy.engindearing.omnitak.mobile.data.MeshtasticCoTConverter
+import soy.engindearing.omnitak.mobile.data.MeshCoreCoTConverter
 import soy.engindearing.omnitak.mobile.domain.ServerManager
 
 class OmniTAKApp : Application() {
@@ -149,9 +154,11 @@ class OmniTAKApp : Application() {
             combine(
                 serverManager.connectionState,
                 meshtastic.activeConnectionState,
-            ) { serverState, meshState ->
+                meshcore.activeConnectionState,
+            ) { serverState, meshState, meshCoreState ->
                 serverState is ConnectionState.Connected ||
-                    meshState is ConnectionState.Connected
+                    meshState is ConnectionState.Connected ||
+                    meshCoreState is ConnectionState.Connected
             }
                 .distinctUntilChanged()
                 .collect { eitherConnected ->
@@ -374,6 +381,63 @@ class OmniTAKApp : Application() {
             }
         }
     }
+
+    /** MeshCore companion-radio manager — the second mesh framework. Wired in
+     *  parallel to [meshtastic]: contacts' adverts decode to CoT (via
+     *  [meshCoreCoTBridge]); inbound DMs/channel text land in the same chat
+     *  store. The mesh screen + broadcaster switch onto this when the operator
+     *  selects MeshCore. */
+    val meshcore: MeshCoreManager by lazy {
+        MeshCoreManager(this).also { mgr ->
+            mgr.cotSink = { event ->
+                val selfUid = cachedPrefs.value.selfUid
+                val selfCallsign = cachedPrefs.value.callsign
+                val isSelf = (selfUid.isNotBlank() && event.uid == selfUid) ||
+                    (selfCallsign.isNotBlank() && event.callsign == selfCallsign)
+                if (!isSelf) {
+                    when (MeshCoTRouter.classify(event)) {
+                        MeshCoTRouter.Destination.CHAT -> {
+                            val senderCallsign = event.callsign ?: event.uid
+                            val convId = soy.engindearing.omnitak.mobile.data.ChatRoom.ALL_USERS
+                            val chatMsg = event.rawXml?.let {
+                                runCatching {
+                                    soy.engindearing.omnitak.mobile.data.ChatXml.parse(it, selfUid.ifBlank { null })
+                                }.getOrNull()
+                            } ?: soy.engindearing.omnitak.mobile.data.ChatMessage(
+                                id = event.uid,
+                                conversationId = convId,
+                                senderUid = event.uid,
+                                senderCallsign = senderCallsign,
+                                text = event.remarks.ifBlank { "[mesh chat]" },
+                                timeIso = event.timeIso
+                                    ?: soy.engindearing.omnitak.mobile.data.CotXml.isoMillis(),
+                                status = soy.engindearing.omnitak.mobile.data.ChatStatus.RECEIVED,
+                                isFromSelf = false,
+                            )
+                            chatStore.ingest(chatMsg)
+                        }
+                        MeshCoTRouter.Destination.CONTACT -> contactStore.ingest(event)
+                    }
+                }
+            }
+            mgr.chatSink = { msg ->
+                val title = when {
+                    msg.conversationId.startsWith("MESHCORE-DM-") -> "DM: ${msg.senderCallsign}"
+                    msg.conversationId.startsWith("MESHCORE-CH") -> {
+                        val ch = msg.conversationId.removePrefix("MESHCORE-CH")
+                        "MeshCore: Channel $ch"
+                    }
+                    else -> msg.senderCallsign
+                }
+                chatStore.upsertConversationIfMissing(
+                    id = msg.conversationId,
+                    title = title,
+                    isGroup = !msg.conversationId.startsWith("MESHCORE-DM-"),
+                )
+                chatStore.ingest(msg)
+            }
+        }
+    }
     val meshDeviceConfigStore: MeshDeviceConfigStore by lazy { MeshDeviceConfigStore(this) }
     val userPrefsStore: UserPrefsStore by lazy { UserPrefsStore(this) }
     val kmlOverlayStore: soy.engindearing.omnitak.mobile.data.KmlVectorOverlayStore by lazy {
@@ -433,8 +497,8 @@ class OmniTAKApp : Application() {
             sendCoT = { xml -> serverManager.sendCoT(xml) },
             locationFix = fixFlow,
             batteryProvider = ::readDeviceBatteryPercent,
-            sendToMesh = { event -> meshtastic.sendCoTOverMesh(event) },
-            meshConnected = { meshtastic.activeConnectionState.value is ConnectionState.Connected },
+            sendToMesh = { event -> activeMeshManager.sendCoTOverMesh(event) },
+            meshConnected = { activeMeshManager.activeConnectionState.value is ConnectionState.Connected },
             meshBroadcastEnabled = { broadcastOverMeshFlow.value },
             // Lambda, not a snapshot — the operator's interval pref now
             // applies to a running broadcaster instead of freezing at the
@@ -564,10 +628,11 @@ class OmniTAKApp : Application() {
         val DISABLED_BY_DEFAULT = setOf("soy.engindearing.diagnostics")
     }
 
-    val meshtasticCoTBridge: MeshtasticCoTBridge by lazy {
-        MeshtasticCoTBridge(
+    val meshtasticCoTBridge: MeshCoTBridge by lazy {
+        MeshCoTBridge(
             mesh = meshtastic,
             cotSink = { event -> contactStore.ingest(event) },
+            nodeToCoT = { MeshtasticCoTConverter.nodeToCoT(it) },
         ).also { bridge ->
             bridge.start()
             // Mirror the persisted prefs into the bridge so the
@@ -580,6 +645,36 @@ class OmniTAKApp : Application() {
             }
         }
     }
+
+    /** MeshCore-side CoT bridge — parallel to [meshtasticCoTBridge], but
+     *  converts MeshCore contacts (UID `MESHCORE-…`). Both bridges feed the
+     *  same contact store; only the active framework's manager produces
+     *  nodes (the other has no live connection), so running both is inert.
+     *  Honors the same `autoPublishMeshToTak` toggle. */
+    val meshCoreCoTBridge: MeshCoTBridge by lazy {
+        MeshCoTBridge(
+            mesh = meshcore,
+            cotSink = { event -> contactStore.ingest(event) },
+            nodeToCoT = { MeshCoreCoTConverter.nodeToCoT(it) },
+        ).also { bridge ->
+            bridge.start()
+            appScope.launch {
+                userPrefsStore.prefs
+                    .map { it.autoPublishMeshToTak }
+                    .distinctUntilChanged()
+                    .collect { bridge.enabled = it }
+            }
+        }
+    }
+
+    /** The mesh manager matching the operator's selected framework. Read off
+     *  the eagerly-cached prefs snapshot so non-suspending callers (the
+     *  broadcaster lambdas) can resolve it. Defaults to Meshtastic. */
+    val activeMeshManager: MeshFrameworkManager
+        get() = when (cachedPrefs.value.selectedMeshFramework) {
+            MeshFramework.MESHCORE -> meshcore
+            MeshFramework.MESHTASTIC -> meshtastic
+        }
 }
 
 /**

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -442,6 +442,15 @@ class OmniTAKApp : Application() {
     val meshDeviceConfigStore: MeshDeviceConfigStore by lazy { MeshDeviceConfigStore(this) }
     val userPrefsStore: UserPrefsStore by lazy { UserPrefsStore(this) }
 
+    /**
+     * Holds a profile decoded from a deep-link that has not yet been
+     * confirmed by the user. The UI observes this and presents
+     * [ImportPreviewDialog]; on confirm/dismiss it clears this to null.
+     * Using App-level state (not Activity-level) so the pending import
+     * survives an onNewIntent delivered to a resumed Activity.
+     */
+    val pendingProfileImport = MutableStateFlow<soy.engindearing.omnitak.mobile.data.ConfigProfile?>(null)
+
     /** Profile store — manages named config snapshots + QR sync. */
     val configProfileStore: ConfigProfileStore by lazy {
         ConfigProfileStore(

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.data.AdminResponse
 import soy.engindearing.omnitak.mobile.data.CertVault
+import soy.engindearing.omnitak.mobile.data.ConfigProfileStore
 import soy.engindearing.omnitak.mobile.data.LocationProvider
 import soy.engindearing.omnitak.mobile.data.MeshDeviceConfigStore
 import soy.engindearing.omnitak.mobile.data.SelfFixPersistence
@@ -376,6 +377,15 @@ class OmniTAKApp : Application() {
     }
     val meshDeviceConfigStore: MeshDeviceConfigStore by lazy { MeshDeviceConfigStore(this) }
     val userPrefsStore: UserPrefsStore by lazy { UserPrefsStore(this) }
+
+    /** Profile store — manages named config snapshots + QR sync. */
+    val configProfileStore: ConfigProfileStore by lazy {
+        ConfigProfileStore(
+            context = this,
+            userPrefsStore = userPrefsStore,
+            serverStore = TAKServerStore(this),
+        )
+    }
     val kmlOverlayStore: soy.engindearing.omnitak.mobile.data.KmlVectorOverlayStore by lazy {
         soy.engindearing.omnitak.mobile.data.KmlVectorOverlayStore(this)
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfile.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfile.kt
@@ -1,0 +1,122 @@
+package soy.engindearing.omnitak.mobile.data
+
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+/**
+ * A shareable configuration snapshot that a captain/staff generates and
+ * teammates import by scanning a QR code.
+ *
+ * SECURITY CONTRACT:
+ * - No private certs, cert passphrases, or server passwords ever live here.
+ * - [servers] strips all secrets via [ProfileServer.fromServer] before inclusion.
+ * - [enrollmentPointer] carries only connection parameters; the joining teammate
+ *   enrolls their own cert through the normal CSR flow.
+ * - Callsign is intentionally omitted — each teammate keeps their own.
+ *
+ * QR payload: `omnitak://profile?d=<base64url(gzip(json))>`
+ * Target < 2 KB so a standard QR (version ≤ 14) scans reliably at a glance.
+ */
+@Serializable
+data class ConfigProfile(
+    /** Stable UUID — survives rename. */
+    val id: String = UUID.randomUUID().toString(),
+    /** Human-readable label shown in the profile list and QR import preview. */
+    val name: String,
+
+    // ── Identity template ───────────────────────────────────────────────────
+    /** Default team color for teammates who import this profile. */
+    val team: String = "Cyan",
+    // Callsign is deliberately excluded — each operator sets their own.
+
+    // ── Servers (secrets stripped) ──────────────────────────────────────────
+    val servers: List<ProfileServer> = emptyList(),
+
+    // ── Enrollment pointer ──────────────────────────────────────────────────
+    /**
+     * Where a new teammate should enroll their client cert. Only present when
+     * the server requires mTLS (useTLS + username in [servers]). Points at the
+     * CSR enrollment HTTPS port (TAK default 8446).
+     */
+    val enrollmentPointer: EnrollmentPointer? = null,
+
+    // ── Map ─────────────────────────────────────────────────────────────────
+    val mapProvider: String = MapProvider.TOPO_HINT.name,
+    val customTileUrl: String = "",
+
+    // ── Units & coordinates ─────────────────────────────────────────────────
+    val coordFormat: String = CoordFormat.LATLON_DECIMAL.name,
+    val distanceUnit: String = DistanceUnit.METRIC.name,
+
+    // ── Feature toggles ─────────────────────────────────────────────────────
+    val callsignCardVisible: Boolean = true,
+    val gridEnabled: Boolean = false,
+    val drawingsVisible: Boolean = true,
+    val aircraftVisible: Boolean = true,
+    val contactsVisible: Boolean = true,
+    val useMilStdSelfSymbol: Boolean = true,
+
+    // ── Mesh settings ────────────────────────────────────────────────────────
+    val autoPublishMeshToTak: Boolean = true,
+    val broadcastOverMesh: Boolean = true,
+    val meshBroadcastIntervalSecs: Int = 30,
+    val meshNodesLayerVisible: Boolean = true,
+)
+
+/**
+ * A server entry safe for QR export: host/port/protocol only, no secrets.
+ *
+ * Cert names are intentionally included (non-secret) so teammates know which
+ * cert file they need to enroll; the actual P12 bytes and passphrase stay in
+ * the device CertVault.
+ */
+@Serializable
+data class ProfileServer(
+    val id: String,
+    val name: String,
+    val host: String,
+    val port: Int,
+    val protocol: String,
+    val useTLS: Boolean,
+    val allowUntrustedTls: Boolean = false,
+    val username: String? = null,
+    // password / certificatePassword / certificateName intentionally excluded.
+) {
+    companion object {
+        /** Strip secrets from a [TAKServer] before adding to a profile. */
+        fun fromServer(s: TAKServer): ProfileServer = ProfileServer(
+            id = s.id,
+            name = s.name,
+            host = s.host,
+            port = s.port,
+            protocol = s.protocol,
+            useTLS = s.useTLS,
+            allowUntrustedTls = s.allowUntrustedTls,
+            username = s.username,
+        )
+
+        /** Reconstitute a [TAKServer] from an imported profile server entry.
+         *  Secrets stay null — the operator enrolls their own cert afterward. */
+        fun toServer(ps: ProfileServer): TAKServer = TAKServer(
+            id = ps.id,
+            name = ps.name,
+            host = ps.host,
+            port = ps.port,
+            protocol = ps.protocol,
+            useTLS = ps.useTLS,
+            allowUntrustedTls = ps.allowUntrustedTls,
+            username = ps.username,
+        )
+    }
+}
+
+/** Where a teammate should hit the CSR enrollment endpoint. */
+@Serializable
+data class EnrollmentPointer(
+    val host: String,
+    val enrollmentPort: Int = 8446,
+    /** Full enrollment URL if different from the standard TAK pattern. */
+    val enrollUrl: String? = null,
+    val username: String? = null,
+    val trustSelfSigned: Boolean = true,
+)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfile.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfile.kt
@@ -69,6 +69,9 @@ data class ConfigProfile(
  * Cert names are intentionally included (non-secret) so teammates know which
  * cert file they need to enroll; the actual P12 bytes and passphrase stay in
  * the device CertVault.
+ *
+ * Username is intentionally excluded — it is PII (often the callsign) and
+ * the teammate enters their own credentials during the CSR enrollment flow.
  */
 @Serializable
 data class ProfileServer(
@@ -79,11 +82,10 @@ data class ProfileServer(
     val protocol: String,
     val useTLS: Boolean,
     val allowUntrustedTls: Boolean = false,
-    val username: String? = null,
-    // password / certificatePassword / certificateName intentionally excluded.
+    // username / password / certificatePassword / certificateName intentionally excluded.
 ) {
     companion object {
-        /** Strip secrets from a [TAKServer] before adding to a profile. */
+        /** Strip secrets and PII from a [TAKServer] before adding to a profile. */
         fun fromServer(s: TAKServer): ProfileServer = ProfileServer(
             id = s.id,
             name = s.name,
@@ -92,11 +94,14 @@ data class ProfileServer(
             protocol = s.protocol,
             useTLS = s.useTLS,
             allowUntrustedTls = s.allowUntrustedTls,
-            username = s.username,
+            // username intentionally excluded — PII; teammate enters at enrollment.
         )
 
         /** Reconstitute a [TAKServer] from an imported profile server entry.
-         *  Secrets stay null — the operator enrolls their own cert afterward. */
+         *  Secrets stay null — the operator enrolls their own cert afterward.
+         *  [allowUntrustedTls] is intentionally NOT propagated from the profile:
+         *  an imported QR must not silently disable TLS trust on the recipient's
+         *  device. The teammate can override it manually after import if needed. */
         fun toServer(ps: ProfileServer): TAKServer = TAKServer(
             id = ps.id,
             name = ps.name,
@@ -104,19 +109,25 @@ data class ProfileServer(
             port = ps.port,
             protocol = ps.protocol,
             useTLS = ps.useTLS,
-            allowUntrustedTls = ps.allowUntrustedTls,
-            username = ps.username,
+            allowUntrustedTls = false,
+            // username intentionally null — not in profile (PII); teammate provides at enrollment.
         )
     }
 }
 
-/** Where a teammate should hit the CSR enrollment endpoint. */
+/**
+ * Where a teammate should hit the CSR enrollment endpoint.
+ *
+ * Username is intentionally excluded from this pointer — it is PII
+ * (often the callsign) and each teammate enters their own credentials
+ * during the enrollment flow. Only connection parameters are shared.
+ */
 @Serializable
 data class EnrollmentPointer(
     val host: String,
     val enrollmentPort: Int = 8446,
     /** Full enrollment URL if different from the standard TAK pattern. */
     val enrollUrl: String? = null,
-    val username: String? = null,
+    // username intentionally excluded — PII; teammate enters at enrollment.
     val trustSelfSigned: Boolean = true,
 )

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfileStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfileStore.kt
@@ -1,0 +1,188 @@
+package soy.engindearing.omnitak.mobile.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.util.UUID
+
+private val Context.profileDataStore by preferencesDataStore(name = "config_profiles")
+
+/**
+ * DataStore-backed store for [ConfigProfile]s.
+ *
+ * Maintains a list of named profiles plus an "active profile" ID pointer.
+ * The active profile is informational only — the live config always lives in
+ * [UserPrefsStore] and [TAKServerStore]; switching profiles calls [apply]
+ * which writes to those stores directly.
+ *
+ * Schema: two DataStore keys
+ *  - `profiles_json`    — JSON array of [ConfigProfile]
+ *  - `active_profile_id` — String UUID of the active profile (may be empty/absent)
+ */
+class ConfigProfileStore(
+    private val context: Context,
+    private val userPrefsStore: UserPrefsStore,
+    private val serverStore: TAKServerStore,
+) {
+    private val KEY_PROFILES = stringPreferencesKey("profiles_json")
+    private val KEY_ACTIVE_ID = stringPreferencesKey("active_profile_id")
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    /** Observable list of all saved profiles. */
+    val profiles: Flow<List<ConfigProfile>> = context.profileDataStore.data.map { prefs ->
+        val raw = prefs[KEY_PROFILES] ?: return@map emptyList()
+        runCatching { json.decodeFromString<List<ConfigProfile>>(raw) }.getOrElse { emptyList() }
+    }
+
+    /** Observable active-profile ID (null if none selected). */
+    val activeProfileId: Flow<String?> = context.profileDataStore.data.map { prefs ->
+        prefs[KEY_ACTIVE_ID]?.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Snapshot the current live config into a new [ConfigProfile] and persist it.
+     *
+     * @param name Human-readable profile name (e.g. "Team Alpha").
+     * @param servers The live server list — fetched by the caller so this function
+     *   stays non-suspending with respect to TAKServerStore's cold-flow semantics.
+     *   Pass `serverStore.servers.first()` at the call site.
+     * @return The newly-created profile.
+     */
+    suspend fun snapshotCurrent(name: String, servers: List<TAKServer>): ConfigProfile {
+        val prefs = userPrefsStore.prefs.first()
+        val enrollmentPointer = buildEnrollmentPointer(servers)
+
+        val profile = ConfigProfile(
+            id = UUID.randomUUID().toString(),
+            name = name,
+            team = prefs.team,
+            servers = servers.map { ProfileServer.fromServer(it) },
+            enrollmentPointer = enrollmentPointer,
+            mapProvider = prefs.mapProvider.name,
+            customTileUrl = prefs.customTileUrl,
+            coordFormat = prefs.coordFormat.name,
+            distanceUnit = prefs.distanceUnit.name,
+            callsignCardVisible = prefs.callsignCardVisible,
+            gridEnabled = prefs.gridEnabled,
+            drawingsVisible = prefs.drawingsVisible,
+            aircraftVisible = prefs.aircraftVisible,
+            contactsVisible = prefs.contactsVisible,
+            useMilStdSelfSymbol = prefs.useMilStdSelfSymbol,
+            autoPublishMeshToTak = prefs.autoPublishMeshToTak,
+            broadcastOverMesh = prefs.broadcastOverMesh,
+            meshBroadcastIntervalSecs = prefs.meshBroadcastIntervalSecs,
+            meshNodesLayerVisible = prefs.meshNodesLayerVisible,
+        )
+
+        saveProfile(profile)
+        return profile
+    }
+
+    /**
+     * Apply a [ConfigProfile] to the live stores.
+     *
+     * - Applies all non-secret prefs to [UserPrefsStore].
+     * - Merges the profile's server list into [TAKServerStore] (no-op for duplicates).
+     * - Sets the active profile ID to this profile's ID.
+     * - Does NOT overwrite the operator's callsign (each teammate keeps their own).
+     * - Does NOT touch credentials — those remain in SecureCredentialStore / CertVault.
+     */
+    suspend fun apply(profile: ConfigProfile) {
+        // 1. Apply UserPrefs — keep the operator's callsign and self-fix.
+        userPrefsStore.update { current ->
+            current.copy(
+                team = profile.team,
+                mapProvider = runCatching { MapProvider.valueOf(profile.mapProvider) }.getOrElse { current.mapProvider },
+                customTileUrl = profile.customTileUrl,
+                coordFormat = runCatching { CoordFormat.valueOf(profile.coordFormat) }.getOrElse { current.coordFormat },
+                distanceUnit = runCatching { DistanceUnit.valueOf(profile.distanceUnit) }.getOrElse { current.distanceUnit },
+                callsignCardVisible = profile.callsignCardVisible,
+                gridEnabled = profile.gridEnabled,
+                drawingsVisible = profile.drawingsVisible,
+                aircraftVisible = profile.aircraftVisible,
+                contactsVisible = profile.contactsVisible,
+                useMilStdSelfSymbol = profile.useMilStdSelfSymbol,
+                autoPublishMeshToTak = profile.autoPublishMeshToTak,
+                broadcastOverMesh = profile.broadcastOverMesh,
+                meshBroadcastIntervalSecs = profile.meshBroadcastIntervalSecs.coerceIn(30, 60),
+                meshNodesLayerVisible = profile.meshNodesLayerVisible,
+                // Callsign intentionally preserved — teammates keep their own.
+                // Self-fix, selfUid, selfLat/Lon/Hae, camera prefs also preserved.
+            )
+        }
+
+        // 2. Merge servers — skip any whose endpoint already exists.
+        val existingServers = serverStore.servers.first()
+        val newServers = profile.servers
+            .map { ProfileServer.toServer(it) }
+            .filter { incoming -> existingServers.none { it.matchesEndpoint(incoming) } }
+        if (newServers.isNotEmpty()) {
+            serverStore.saveServers(existingServers + newServers)
+        }
+
+        // 3. Mark this profile as active.
+        setActiveProfileId(profile.id)
+    }
+
+    // ── CRUD ──────────────────────────────────────────────────────────────
+
+    suspend fun saveProfile(profile: ConfigProfile) {
+        context.profileDataStore.edit { prefs ->
+            val current = prefs[KEY_PROFILES]
+                ?.let { runCatching { json.decodeFromString<List<ConfigProfile>>(it) }.getOrElse { emptyList() } }
+                ?: emptyList()
+            val updated = current.filter { it.id != profile.id } + profile
+            prefs[KEY_PROFILES] = json.encodeToString(updated)
+        }
+    }
+
+    suspend fun renameProfile(id: String, newName: String) {
+        context.profileDataStore.edit { prefs ->
+            val current = prefs[KEY_PROFILES]
+                ?.let { runCatching { json.decodeFromString<List<ConfigProfile>>(it) }.getOrElse { emptyList() } }
+                ?: emptyList()
+            val updated = current.map { if (it.id == id) it.copy(name = newName) else it }
+            prefs[KEY_PROFILES] = json.encodeToString(updated)
+        }
+    }
+
+    suspend fun deleteProfile(id: String) {
+        context.profileDataStore.edit { prefs ->
+            val current = prefs[KEY_PROFILES]
+                ?.let { runCatching { json.decodeFromString<List<ConfigProfile>>(it) }.getOrElse { emptyList() } }
+                ?: emptyList()
+            prefs[KEY_PROFILES] = json.encodeToString(current.filter { it.id != id })
+            // If we just deleted the active profile, clear the pointer.
+            if (prefs[KEY_ACTIVE_ID] == id) prefs.remove(KEY_ACTIVE_ID)
+        }
+    }
+
+    suspend fun setActiveProfileId(id: String?) {
+        context.profileDataStore.edit { prefs ->
+            if (id == null) prefs.remove(KEY_ACTIVE_ID) else prefs[KEY_ACTIVE_ID] = id
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    /**
+     * Build an [EnrollmentPointer] from the server list if any server needs
+     * CSR enrollment (TLS + username). Picks the first such server.
+     */
+    private fun buildEnrollmentPointer(servers: List<TAKServer>): EnrollmentPointer? {
+        val enrollable = servers.firstOrNull { it.useTLS && !it.username.isNullOrBlank() }
+            ?: return null
+        return EnrollmentPointer(
+            host = enrollable.host,
+            enrollmentPort = 8446,
+            username = enrollable.username,
+        )
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfileStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfileStore.kt
@@ -175,6 +175,8 @@ class ConfigProfileStore(
     /**
      * Build an [EnrollmentPointer] from the server list if any server needs
      * CSR enrollment (TLS + username). Picks the first such server.
+     * Username is deliberately excluded — it is PII (often the callsign) and
+     * the enrolling teammate enters their own credentials during the CSR flow.
      */
     private fun buildEnrollmentPointer(servers: List<TAKServer>): EnrollmentPointer? {
         val enrollable = servers.firstOrNull { it.useTLS && !it.username.isNullOrBlank() }
@@ -182,7 +184,7 @@ class ConfigProfileStore(
         return EnrollmentPointer(
             host = enrollable.host,
             enrollmentPort = 8446,
-            username = enrollable.username,
+            // username intentionally omitted — see security contract on [EnrollmentPointer].
         )
     }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/DeepLinkImport.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/DeepLinkImport.kt
@@ -68,11 +68,13 @@ object DeepLinkImport {
      */
     fun parseProfileConfig(uri: Uri): ConfigProfile? = ProfileQrCodec.decode(uri)
 
-    /** Accept any URI we recognise as a server-onboarding payload. */
+    /** Accept any URI we recognise as a server-onboarding payload.
+     *  Restricted to `atak://` and `omnitak://` schemes only — HTTP/HTTPS
+     *  links from arbitrary sources could be used for drive-by server injection. */
     fun isServerConfig(uri: Uri?): Boolean {
         if (uri == null) return false
         val scheme = uri.scheme?.lowercase() ?: return false
-        if (scheme !in setOf("atak", "omnitak", "http", "https")) return false
+        if (scheme !in setOf("atak", "omnitak")) return false
         return !uri.getQueryParameter("host").isNullOrBlank()
     }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/DeepLinkImport.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/DeepLinkImport.kt
@@ -54,6 +54,20 @@ data class ImportedServerConfig(
 }
 
 object DeepLinkImport {
+    /**
+     * Returns true when the URI carries a configuration-profile payload
+     * (`omnitak://profile?d=…`). Check this BEFORE [isServerConfig] because
+     * the `omnitak://` scheme is shared between both URL shapes.
+     */
+    fun isProfileConfig(uri: Uri?): Boolean = ProfileQrCodec.isProfileUri(uri)
+
+    /**
+     * Decode a profile URI produced by [ProfileQrCodec.encode].
+     * Returns null if the URI is malformed or the JSON payload can't be
+     * parsed — callers should surface a user-visible error in that case.
+     */
+    fun parseProfileConfig(uri: Uri): ConfigProfile? = ProfileQrCodec.decode(uri)
+
     /** Accept any URI we recognise as a server-onboarding payload. */
     fun isServerConfig(uri: Uri?): Boolean {
         if (uri == null) return false

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreCoTConverter.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreCoTConverter.kt
@@ -58,8 +58,8 @@ object MeshCoreCoTConverter {
         )
     }
 
-    /** TAK UID for a MeshCore contact — `MESHCORE-<idHex8 upper>`. */
-    fun takUid(nodeId: Long): String = "MESHCORE-${"%08X".format(nodeId.toInt())}"
+    /** TAK UID for a MeshCore contact — `MESHCORE-<12 uppercase hex>` (6-byte prefix). */
+    fun takUid(nodeId: Long): String = "MESHCORE-${"%012X".format(nodeId)}"
 
     private fun buildRemarks(node: MeshNode): String {
         val sb = StringBuilder("MeshCore Node | ID: !${node.idHex}")
@@ -80,7 +80,7 @@ object MeshCoreCoTConverter {
         remarks: String,
     ): String {
         val hae = (position.altitudeM ?: 0).toDouble()
-        val nodeIdUpper = "%08X".format(node.id.toInt())
+        val nodeIdUpper = "%012X".format(node.id)
         val shortEsc = escape(node.shortName)
         val longEsc = escape(callsign)
         val lastHeardIso = CotXml.isoMillis(node.lastHeardEpoch * 1_000L)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreCoTConverter.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreCoTConverter.kt
@@ -1,0 +1,123 @@
+package soy.engindearing.omnitak.mobile.data
+
+/**
+ * Converts a MeshCore contact/advert [MeshNode] into a [CoTEvent] +
+ * matching XML. Parallel to [MeshtasticCoTConverter], but emits a
+ * MeshCore-flavored UID and extension block so a TAK server can tell a
+ * MeshCore contact apart from a Meshtastic one.
+ *
+ * v1 scope: a MeshCore contact's advertised lat/lon becomes a friendly
+ * civilian PLI (`a-f-G-U-C`). UID format: `MESHCORE-<idHex8>` — the node
+ * id here is the first 4 bytes of the contact's 32-byte public key
+ * (see [MeshCoreFrameCodec.nodeIdFromPubKey]). A node with no advertised
+ * position produces no CoT (a point-less event is useless on a map).
+ */
+object MeshCoreCoTConverter {
+
+    /** Default stale window for mesh contacts — mirror Meshtastic's 5 min. */
+    private const val DEFAULT_STALE_SECONDS = 300L
+
+    fun nodeToCoT(
+        node: MeshNode,
+        staleSeconds: Long = DEFAULT_STALE_SECONDS,
+        nowMs: Long = System.currentTimeMillis(),
+    ): CoTEvent? {
+        val position = node.position ?: return null
+        val time = CotXml.isoMillis(nowMs)
+        val staleIso = CotXml.isoMillis(nowMs + staleSeconds * 1_000)
+
+        val uid = takUid(node.id)
+        val type = "a-f-G-U-C"
+        val callsign = node.longName.ifBlank { node.shortName.ifBlank { "Node ${node.idHex}" } }
+
+        val remarks = buildRemarks(node)
+        val xml = buildXml(
+            uid = uid,
+            type = type,
+            time = time,
+            stale = staleIso,
+            node = node,
+            position = position,
+            callsign = callsign,
+            remarks = remarks,
+        )
+
+        return CoTEvent(
+            uid = uid,
+            type = type,
+            lat = position.lat,
+            lon = position.lon,
+            hae = (position.altitudeM ?: 0).toDouble(),
+            ce = 50.0,
+            le = 50.0,
+            timeIso = time,
+            staleIso = staleIso,
+            callsign = callsign,
+            remarks = remarks,
+            rawXml = xml,
+        )
+    }
+
+    /** TAK UID for a MeshCore contact — `MESHCORE-<idHex8 upper>`. */
+    fun takUid(nodeId: Long): String = "MESHCORE-${"%08X".format(nodeId.toInt())}"
+
+    private fun buildRemarks(node: MeshNode): String {
+        val sb = StringBuilder("MeshCore Node | ID: !${node.idHex}")
+        node.snr?.let { sb.append(" | SNR: ${"%.1f".format(it)}dB") }
+        node.hopDistance?.let { sb.append(" | Hops: $it") }
+        node.batteryLevel?.let { sb.append(" | Bat: $it%") }
+        return sb.toString()
+    }
+
+    private fun buildXml(
+        uid: String,
+        type: String,
+        time: String,
+        stale: String,
+        node: MeshNode,
+        position: MeshPosition,
+        callsign: String,
+        remarks: String,
+    ): String {
+        val hae = (position.altitudeM ?: 0).toDouble()
+        val nodeIdUpper = "%08X".format(node.id.toInt())
+        val shortEsc = escape(node.shortName)
+        val longEsc = escape(callsign)
+        val lastHeardIso = CotXml.isoMillis(node.lastHeardEpoch * 1_000L)
+        val snr = node.snr ?: 0.0
+        val hops = node.hopDistance ?: 0
+        val battery = node.batteryLevel ?: -1
+        val remarksEsc = escape(remarks)
+        val detail = buildString {
+            append("<detail>")
+            append("<contact callsign=\"$longEsc\"/>")
+            append("<__group name=\"Cyan\" role=\"Team Member\"/>")
+            append("<usericon iconsetpath=\"COT_MAPPING_2525C/a-f-G\"/>")
+            append("<precisionlocation altsrc=\"GPS\" geopointsrc=\"MeshCore\"/>")
+            append("<status readiness=\"true\"/>")
+            append("<remarks>$remarksEsc</remarks>")
+            append("<__meshcore__>")
+            append("<node_id>$nodeIdUpper</node_id>")
+            append("<short_name>$shortEsc</short_name>")
+            append("<long_name>$longEsc</long_name>")
+            append("<snr>$snr</snr>")
+            append("<hop_distance>$hops</hop_distance>")
+            append("<battery>$battery</battery>")
+            append("<last_heard>$lastHeardIso</last_heard>")
+            append("</__meshcore__>")
+            append("<takv device=\"MeshCore\" platform=\"OmniTAK\" os=\"Android\" version=\"0.1.0\"/>")
+            append("</detail>")
+        }
+        return CotXml.buildEvent(
+            uid = uid,
+            type = type,
+            how = "m-g",
+            lat = position.lat, lon = position.lon, hae = hae, ce = 50.0, le = 50.0,
+            timeIso = time,
+            staleIso = stale,
+            detailXml = detail,
+        )
+    }
+
+    private fun escape(s: String): String = CotXml.escape(s)
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreFrameCodec.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreFrameCodec.kt
@@ -53,6 +53,7 @@ object MeshCoreFrameCodec {
     const val RESP_CHANNEL_MSG: Byte = 0x08
     const val RESP_CONTACT_MSG_V3: Byte = 0x10
     const val RESP_CHANNEL_MSG_V3: Byte = 0x11
+    const val RESP_DEVICE_INFO: Byte = 0x0D
     const val RESP_BATTERY: Byte = 0x0C
     const val RESP_CODE_STATS: Byte = 0x18
     const val RESP_NO_MORE_MSGS: Byte = 0x0A
@@ -184,6 +185,18 @@ object MeshCoreFrameCodec {
         /** No more queued messages. */
         data object NoMoreMessages : Decoded
 
+        /**
+         * RESP_DEVICE_INFO (0x0D) — build/firmware metadata from the companion
+         * radio. Parsed from [MeshCoreFrameCodec.parseDeviceInfo].
+         */
+        data class DeviceInfo(
+            val fwCode: Int,
+            val maxContacts: Int,
+            val maxChannels: Int,
+            val manufacturer: String,
+            val version: String,
+        ) : Decoded
+
         /** A frame we recognise the code of but don't model in v1. */
         data class Unhandled(val code: Int) : Decoded
     }
@@ -198,6 +211,7 @@ object MeshCoreFrameCodec {
             PUSH_MESSAGES_WAITING -> Decoded.MessagesWaiting
             RESP_NO_MORE_MSGS -> Decoded.NoMoreMessages
             RESP_SELF_INFO -> parseSelfInfo(pkt) ?: Decoded.Unhandled(code.toInt() and 0xFF)
+            RESP_DEVICE_INFO -> parseDeviceInfo(pkt) ?: Decoded.Unhandled(code.toInt() and 0xFF)
             RESP_BATTERY -> parseBattery(pkt)
             RESP_CODE_STATS -> parseStatsBattery(pkt)
             PUSH_CODE_NEW_ADVERT, PUSH_CODE_ADVERT, RESP_CODE_CONTACT ->
@@ -280,6 +294,40 @@ object MeshCoreFrameCodec {
         }.getOrNull()
     }
 
+    /**
+     * RESP_DEVICE_INFO (0x0D) — firmware/build metadata.
+     * Layout (≥4 bytes, full form ≥77 bytes):
+     *  [0]=0x0D [1]=fwCode [2]=maxContacts/2 [3]=maxChannels
+     *  [20..59]=manufacturer (c-string, 40 bytes) [60..79]=version (c-string, 20 bytes)
+     * Matches the reference `logDeviceInfo` in BtConnectionManager.java.
+     */
+    private fun parseDeviceInfo(pkt: ByteArray): Decoded.DeviceInfo? {
+        if (pkt.size < 4) return null
+        return runCatching {
+            val fwCode = pkt[1].toInt() and 0xFF
+            val maxContactsHalf = pkt[2].toInt() and 0xFF
+            val maxChannels = pkt[3].toInt() and 0xFF
+            val manufacturer = if (pkt.size >= 77) decodeCString(pkt, 20, 40) else ""
+            val version = if (pkt.size >= 77) decodeCString(pkt, 60, 20) else ""
+            Decoded.DeviceInfo(
+                fwCode = fwCode,
+                maxContacts = maxContactsHalf * 2,
+                maxChannels = maxChannels,
+                manufacturer = manufacturer,
+                version = version,
+            )
+        }.getOrNull()
+    }
+
+    /** Decode a null-terminated C-string from [src] at [off] for up to [maxLen] bytes. */
+    private fun decodeCString(src: ByteArray, off: Int, maxLen: Int): String {
+        if (off < 0 || maxLen <= 0 || src.size <= off) return ""
+        val end = minOf(src.size, off + maxLen)
+        var n = off
+        while (n < end && src[n] != 0.toByte()) n++
+        return String(src, off, n - off, StandardCharsets.UTF_8).trim()
+    }
+
     /** RESP_BATTERY: `[0x0C][mv lo][mv hi]`. */
     private fun parseBattery(pkt: ByteArray): Decoded? {
         if (pkt.size < 3) return Decoded.Unhandled(RESP_BATTERY.toInt() and 0xFF)
@@ -340,19 +388,23 @@ object MeshCoreFrameCodec {
 
     /**
      * MeshCore identifies a node by its 32-byte public key. We collapse that
-     * to a 32-bit id (the first 4 bytes, big-endian) so it slots into the
-     * framework-neutral [MeshNode.id]/[CoTEvent] machinery. Two distinct
-     * pubkeys colliding in 4 bytes is astronomically unlikely on a tactical
-     * mesh, and the full pubkey hex is still kept in the contact name/remarks.
+     * to a 48-bit id (the first **6** bytes, big-endian) so it slots into the
+     * framework-neutral [MeshNode.id]/[CoTEvent] machinery while matching the
+     * 6-byte prefix the firmware uses to key contacts. A [Long] holds 48 bits
+     * without overflow. The full pubkey hex is kept in the contact name/remarks.
+     *
+     * CoT UID format: `MESHCORE-<12 uppercase hex>` (6 bytes = 12 hex chars).
      */
     fun nodeIdFromPubKey(pubKeyHex: String): Long {
         val hex = pubKeyHex.trim()
-        if (hex.length < 8) return 0L
+        if (hex.length < 12) return 0L
         return runCatching {
-            ((hex.substring(0, 2).toLong(16) shl 24) or
-                (hex.substring(2, 4).toLong(16) shl 16) or
-                (hex.substring(4, 6).toLong(16) shl 8) or
-                hex.substring(6, 8).toLong(16)) and 0xFFFFFFFFL
+            ((hex.substring(0, 2).toLong(16) shl 40) or
+                (hex.substring(2, 4).toLong(16) shl 32) or
+                (hex.substring(4, 6).toLong(16) shl 24) or
+                (hex.substring(6, 8).toLong(16) shl 16) or
+                (hex.substring(8, 10).toLong(16) shl 8) or
+                hex.substring(10, 12).toLong(16))
         }.getOrDefault(0L)
     }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreFrameCodec.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreFrameCodec.kt
@@ -1,0 +1,396 @@
+package soy.engindearing.omnitak.mobile.data
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Encoder/decoder for the MeshCore **companion** BLE protocol.
+ *
+ * Ported from the TAK-MeshCore ATAK plugin's `BtConnectionManager.java`
+ * (MeshCore companion firmware v1.x). Each companion frame is exactly one
+ * BLE characteristic write (to the Nordic-UART RX char) or one notification
+ * (from the TX char) — there is **no length prefix on the BLE path**; the
+ * GATT layer delimits frames. So this codec works on whole frames: it
+ * builds command byte arrays and parses notification byte arrays.
+ *
+ * v1 scope (companion command codes):
+ *  - encode: APP_START 0x01, SEND_SELF_ADVERT 0x07, SET_ADVERT_LATLON 0x0E,
+ *    SEND_TXT_MSG 0x02, GET_NEXT_MSG 0x0A, GET_BATTERY 0x14, DEVICE_QUERY 0x16.
+ *  - decode (response/push codes): RESP_CONTACT_MSG 0x07, RESP_CHANNEL_MSG 0x08,
+ *    RESP_BATTERY 0x0C, RESP_CODE_STATS 0x18, RESP_SELF_INFO 0x05, advert
+ *    pushes 0x80 / 0x8A / contact 0x03, MESSAGES_WAITING 0x83, NO_MORE 0x0A.
+ *
+ * Multi-byte integers are little-endian (firmware native). Lat/Lon are
+ * E6 fixed-point ints. All offsets match the reference exactly; where the
+ * reference probes multiple firmware layouts we take the documented
+ * companion-radio-upstream layout (the v1.16.0 our test rig runs).
+ */
+object MeshCoreFrameCodec {
+
+    // region command codes ------------------------------------------------
+    const val CMD_APP_START: Byte = 0x01
+    const val CMD_SEND_TXT_MSG: Byte = 0x02
+    const val CMD_SEND_SELF_ADVERT: Byte = 0x07
+    const val CMD_SET_ADVERT_LATLON: Byte = 0x0E
+    const val CMD_GET_NEXT_MSG: Byte = 0x0A
+    const val CMD_GET_BATTERY: Byte = 0x14
+    const val CMD_DEVICE_QUERY: Byte = 0x16
+    const val CMD_GET_STATS: Byte = 0x38
+
+    private const val TXT_TYPE_PLAIN: Byte = 0x00
+    private const val DEVICE_QUERY_ARG: Byte = 0x03
+    private const val STATS_TYPE_CORE: Byte = 0x00
+    /** Companion app id the firmware expects in APP_START (mirrors the
+     *  reference `meshcore-flutter`). The firmware doesn't validate it
+     *  beyond presence, so any client identifier works. */
+    private const val COMPANION_APP_ID = "meshcore-flutter"
+    // endregion
+
+    // region response / push codes ---------------------------------------
+    const val RESP_SELF_INFO: Byte = 0x05
+    const val RESP_CONTACT_MSG: Byte = 0x07
+    const val RESP_CHANNEL_MSG: Byte = 0x08
+    const val RESP_CONTACT_MSG_V3: Byte = 0x10
+    const val RESP_CHANNEL_MSG_V3: Byte = 0x11
+    const val RESP_BATTERY: Byte = 0x0C
+    const val RESP_CODE_STATS: Byte = 0x18
+    const val RESP_NO_MORE_MSGS: Byte = 0x0A
+    const val RESP_CODE_CONTACT: Byte = 0x03
+    val PUSH_MESSAGES_WAITING: Byte = 0x83.toByte()
+    val PUSH_CODE_ADVERT: Byte = 0x80.toByte()
+    val PUSH_CODE_NEW_ADVERT: Byte = 0x8A.toByte()
+    private const val ADV_TYPE_REPEATER = 0x02
+    // endregion
+
+    // ====================================================================
+    // ENCODE
+    // ====================================================================
+
+    /**
+     * APP_START — the companion handshake. Byte 0 is the code; bytes 1..7
+     * are reserved (zero); the app id string follows at offset 8. The node
+     * replies with a RESP_SELF_INFO (0x05) frame.
+     */
+    fun buildAppStart(appId: String = COMPANION_APP_ID): ByteArray {
+        val app = appId.toByteArray(StandardCharsets.UTF_8)
+        val out = ByteArray(8 + app.size)
+        out[0] = CMD_APP_START
+        System.arraycopy(app, 0, out, 8, app.size)
+        return out
+    }
+
+    /** GET_NEXT_MSG — drains one queued inbound frame from the node. */
+    fun buildGetNextMessage(): ByteArray = byteArrayOf(CMD_GET_NEXT_MSG)
+
+    /** DEVICE_QUERY — asks the node for its device info (fw/contacts/etc). */
+    fun buildDeviceQuery(): ByteArray = byteArrayOf(CMD_DEVICE_QUERY, DEVICE_QUERY_ARG)
+
+    /** GET_BATTERY — node replies RESP_BATTERY (0x0C). */
+    fun buildGetBattery(): ByteArray = byteArrayOf(CMD_GET_BATTERY)
+
+    /** GET_STATS(core) — node replies RESP_CODE_STATS (0x18), also carries battery mv. */
+    fun buildGetStats(): ByteArray = byteArrayOf(CMD_GET_STATS, STATS_TYPE_CORE)
+
+    /** SEND_SELF_ADVERT — broadcasts this node's advert (incl. its set lat/lon). */
+    fun buildSendSelfAdvert(): ByteArray = byteArrayOf(CMD_SEND_SELF_ADVERT)
+
+    /**
+     * SET_ADVERT_LATLON — stores the lat/lon/alt the node will broadcast in
+     * its next self-advert. E6 fixed-point, little-endian. Returns null for
+     * an out-of-range coordinate so the caller can skip the write.
+     */
+    fun buildSetAdvertLatLon(lat: Double, lon: Double, altMeters: Double = 0.0): ByteArray? {
+        if (lat.isNaN() || lon.isNaN() || lat < -90.0 || lat > 90.0 || lon < -180.0 || lon > 180.0) {
+            return null
+        }
+        val latE6 = Math.round(lat * 1_000_000.0).toInt()
+        val lonE6 = Math.round(lon * 1_000_000.0).toInt()
+        val alt = if (altMeters.isNaN()) 0 else Math.round(altMeters).toInt()
+        val out = ByteArray(13)
+        ByteBuffer.wrap(out).order(ByteOrder.LITTLE_ENDIAN).apply {
+            put(CMD_SET_ADVERT_LATLON)
+            putInt(latE6)
+            putInt(lonE6)
+            putInt(alt)
+        }
+        return out
+    }
+
+    /**
+     * SEND_TXT_MSG — a native pubkey-to-pubkey direct message. Layout:
+     * `[0x02][txtType=plain][attempt=0][ts LE int][pubKeyPrefix(6)][utf8 text]`.
+     * The recipient must be a contact on the node (firmware matches the first
+     * 6 bytes of the pubkey). Returns null on an invalid pubkey prefix.
+     */
+    fun buildSendTxtMsg(
+        pubKeyHex: String,
+        text: String,
+        nowSec: Int = (System.currentTimeMillis() / 1000L).toInt(),
+    ): ByteArray? {
+        val prefix = pubKeyPrefixBytes(pubKeyHex, 6) ?: return null
+        val msg = text.toByteArray(StandardCharsets.UTF_8)
+        val buf = ByteBuffer.allocate(13 + msg.size).order(ByteOrder.LITTLE_ENDIAN)
+        buf.put(CMD_SEND_TXT_MSG)
+        buf.put(TXT_TYPE_PLAIN)
+        buf.put(0x00) // attempt
+        buf.putInt(nowSec)
+        buf.put(prefix)
+        buf.put(msg)
+        return buf.array()
+    }
+
+    // ====================================================================
+    // DECODE
+    // ====================================================================
+
+    /** Result of decoding one inbound companion frame. */
+    sealed interface Decoded {
+        /** A contact/advert with (optionally) an advertised position. */
+        data class Contact(
+            val node: MeshNode,
+            val isRepeater: Boolean,
+        ) : Decoded
+
+        /** This node's own self-info (after APP_START). */
+        data class SelfInfo(
+            val pubKeyHex: String,
+            val nodeName: String,
+            val lat: Double?,
+            val lon: Double?,
+        ) : Decoded
+
+        /** A native pubkey-to-pubkey direct message. */
+        data class ContactMessage(
+            val senderPubKeyPrefixHex: String,
+            val text: String,
+        ) : Decoded
+
+        /** A channel (group) message. */
+        data class ChannelMessage(
+            val channelIndex: Int,
+            val text: String,
+        ) : Decoded
+
+        /** Battery reading in millivolts (+ derived percent). */
+        data class Battery(
+            val milliVolts: Int,
+            val percent: Int,
+        ) : Decoded
+
+        /** The node has queued messages — caller should GET_NEXT_MSG. */
+        data object MessagesWaiting : Decoded
+
+        /** No more queued messages. */
+        data object NoMoreMessages : Decoded
+
+        /** A frame we recognise the code of but don't model in v1. */
+        data class Unhandled(val code: Int) : Decoded
+    }
+
+    /**
+     * Decode one inbound companion frame (a single BLE TX notification).
+     * Returns null for an empty/degenerate frame.
+     */
+    fun decode(pkt: ByteArray?, nowMs: Long = System.currentTimeMillis()): Decoded? {
+        if (pkt == null || pkt.isEmpty()) return null
+        return when (val code = pkt[0]) {
+            PUSH_MESSAGES_WAITING -> Decoded.MessagesWaiting
+            RESP_NO_MORE_MSGS -> Decoded.NoMoreMessages
+            RESP_SELF_INFO -> parseSelfInfo(pkt) ?: Decoded.Unhandled(code.toInt() and 0xFF)
+            RESP_BATTERY -> parseBattery(pkt)
+            RESP_CODE_STATS -> parseStatsBattery(pkt)
+            PUSH_CODE_NEW_ADVERT, PUSH_CODE_ADVERT, RESP_CODE_CONTACT ->
+                parseAdvertContact(pkt, nowMs) ?: Decoded.Unhandled(code.toInt() and 0xFF)
+            RESP_CONTACT_MSG -> parseContactMessage(pkt, v3 = false)
+            RESP_CONTACT_MSG_V3 -> parseContactMessage(pkt, v3 = true)
+            RESP_CHANNEL_MSG -> parseChannelMessage(pkt, v3 = false)
+            RESP_CHANNEL_MSG_V3 -> parseChannelMessage(pkt, v3 = true)
+            else -> Decoded.Unhandled(code.toInt() and 0xFF)
+        }
+    }
+
+    /**
+     * Advert/contact frame. Layout (companion-radio upstream, ≥144 bytes):
+     *  [0]=code [1..32]=pubkey [33]=advType [100..131]=name(null-padded)
+     *  [132..135]=advert ts (LE) [136..139]=latE6 (LE) [140..143]=lonE6 (LE)
+     */
+    private fun parseAdvertContact(pkt: ByteArray, nowMs: Long): Decoded.Contact? {
+        if (pkt.size < 144) return null
+        val type = pkt[33].toInt() and 0xFF
+        val pubKeyHex = bytesToHex(pkt, 1, 32).ifEmpty { return null }
+
+        val rawName = String(pkt, 100, 32, StandardCharsets.UTF_8)
+        val nul = rawName.indexOf('\u0000')
+        var name = (if (nul >= 0) rawName.substring(0, nul) else rawName).trim()
+        if (name.isEmpty()) name = "MeshCore " + "%08X".format(nodeIdFromPubKey(pubKeyHex).toInt())
+
+        val bb = ByteBuffer.wrap(pkt).order(ByteOrder.LITTLE_ENDIAN)
+        val tsSec = bb.getInt(132).toLong() and 0xFFFFFFFFL
+        val latE6 = bb.getInt(136)
+        val lonE6 = bb.getInt(140)
+        val hasPosition = !(latE6 == 0 && lonE6 == 0)
+        val lat = latE6 / 1_000_000.0
+        val lon = lonE6 / 1_000_000.0
+
+        val nodeId = nodeIdFromPubKey(pubKeyHex)
+        val position = if (hasPosition && validLatLon(lat, lon)) {
+            MeshPosition(lat = lat, lon = lon, altitudeM = null)
+        } else {
+            null
+        }
+        // Prefer the advert timestamp (node clock) when present; else now.
+        val lastHeard = if (tsSec in 1..4_294_967_295L) tsSec else nowMs / 1000L
+        val node = MeshNode(
+            id = nodeId,
+            shortName = "%08X".format(nodeId.toInt()),
+            longName = name,
+            position = position,
+            lastHeardEpoch = lastHeard,
+        )
+        return Decoded.Contact(node, isRepeater = type == ADV_TYPE_REPEATER)
+    }
+
+    /**
+     * RESP_SELF_INFO. Layout (companion-radio upstream, ≥58 bytes):
+     *  [0]=code [1]=advType [2]=txPower [3]=maxTx [4..35]=pubkey
+     *  [36..39]=latE6 [40..43]=lonE6 ... [58..]=node name
+     */
+    private fun parseSelfInfo(pkt: ByteArray): Decoded.SelfInfo? {
+        if (pkt.size < 58) return null
+        return runCatching {
+            val bb = ByteBuffer.wrap(pkt).order(ByteOrder.LITTLE_ENDIAN)
+            val latE6 = bb.getInt(36)
+            val lonE6 = bb.getInt(40)
+            val pubKeyHex = bytesToHex(pkt, 4, 32)
+            val name = if (pkt.size > 58) {
+                String(pkt, 58, pkt.size - 58, StandardCharsets.UTF_8).trim()
+            } else {
+                ""
+            }
+            val lat = latE6 / 1_000_000.0
+            val lon = lonE6 / 1_000_000.0
+            val valid = validLatLon(lat, lon) && !(latE6 == 0 && lonE6 == 0)
+            Decoded.SelfInfo(
+                pubKeyHex = pubKeyHex,
+                nodeName = name,
+                lat = if (valid) lat else null,
+                lon = if (valid) lon else null,
+            )
+        }.getOrNull()
+    }
+
+    /** RESP_BATTERY: `[0x0C][mv lo][mv hi]`. */
+    private fun parseBattery(pkt: ByteArray): Decoded? {
+        if (pkt.size < 3) return Decoded.Unhandled(RESP_BATTERY.toInt() and 0xFF)
+        val mv = (pkt[1].toInt() and 0xFF) or ((pkt[2].toInt() and 0xFF) shl 8)
+        return batteryOrNull(mv) ?: Decoded.Unhandled(RESP_BATTERY.toInt() and 0xFF)
+    }
+
+    /** RESP_CODE_STATS(core): `[0x18][type=0x00][mv lo][mv hi]...`. */
+    private fun parseStatsBattery(pkt: ByteArray): Decoded? {
+        if (pkt.size < 4 || (pkt[1].toInt() and 0xFF) != (STATS_TYPE_CORE.toInt() and 0xFF)) {
+            return Decoded.Unhandled(RESP_CODE_STATS.toInt() and 0xFF)
+        }
+        val mv = (pkt[2].toInt() and 0xFF) or ((pkt[3].toInt() and 0xFF) shl 8)
+        return batteryOrNull(mv) ?: Decoded.Unhandled(RESP_CODE_STATS.toInt() and 0xFF)
+    }
+
+    private fun batteryOrNull(mv: Int): Decoded.Battery? {
+        val pct = batteryMvToPercent(mv)
+        if (pct < 0) return null
+        return Decoded.Battery(mv, pct)
+    }
+
+    /**
+     * RESP_CONTACT_MSG. Sender pubkey prefix (6B) at offset 1 (v1) or 4 (v3).
+     * txtType byte at 8 (v1) / 11 (v3); text at 13 (v1) / 16 (v3), +4 when
+     * txtType == 2 (timestamped). Plain UTF-8 body.
+     */
+    private fun parseContactMessage(pkt: ByteArray, v3: Boolean): Decoded? {
+        val prefixOff = if (v3) 4 else 1
+        val txtTypeIndex = if (v3) 11 else 8
+        var off = if (v3) 16 else 13
+        if (pkt.size < prefixOff + 6 || pkt.size <= txtTypeIndex) {
+            return Decoded.Unhandled(pkt[0].toInt() and 0xFF)
+        }
+        val senderPrefix = bytesToHex(pkt, prefixOff, 6)
+        if (pkt[txtTypeIndex].toInt() == 2) off += 4
+        if (pkt.size < off) return Decoded.Unhandled(pkt[0].toInt() and 0xFF)
+        val text = String(pkt, off, pkt.size - off, StandardCharsets.UTF_8)
+        return Decoded.ContactMessage(senderPrefix, text)
+    }
+
+    /**
+     * RESP_CHANNEL_MSG. Channel index at offset 1 (v1) / 4 (v3); text at
+     * offset 8 (v1) / 11 (v3).
+     */
+    private fun parseChannelMessage(pkt: ByteArray, v3: Boolean): Decoded? {
+        val idxOff = if (v3) 4 else 1
+        val textOff = if (v3) 11 else 8
+        if (pkt.size <= textOff) return Decoded.Unhandled(pkt[0].toInt() and 0xFF)
+        val idx = (pkt[idxOff].toInt() and 0xFF).let { if (it in 0..7) it else 0 }
+        val text = String(pkt, textOff, pkt.size - textOff, StandardCharsets.UTF_8)
+        return Decoded.ChannelMessage(idx, text)
+    }
+
+    // ====================================================================
+    // HELPERS
+    // ====================================================================
+
+    /**
+     * MeshCore identifies a node by its 32-byte public key. We collapse that
+     * to a 32-bit id (the first 4 bytes, big-endian) so it slots into the
+     * framework-neutral [MeshNode.id]/[CoTEvent] machinery. Two distinct
+     * pubkeys colliding in 4 bytes is astronomically unlikely on a tactical
+     * mesh, and the full pubkey hex is still kept in the contact name/remarks.
+     */
+    fun nodeIdFromPubKey(pubKeyHex: String): Long {
+        val hex = pubKeyHex.trim()
+        if (hex.length < 8) return 0L
+        return runCatching {
+            ((hex.substring(0, 2).toLong(16) shl 24) or
+                (hex.substring(2, 4).toLong(16) shl 16) or
+                (hex.substring(4, 6).toLong(16) shl 8) or
+                hex.substring(6, 8).toLong(16)) and 0xFFFFFFFFL
+        }.getOrDefault(0L)
+    }
+
+    /** Convert battery millivolts to a 0..100 percent (LiPo 3.3–4.2 V), or -1. */
+    fun batteryMvToPercent(mv: Int): Int {
+        if (mv <= 0) return -1
+        val minMv = 3300
+        val maxMv = 4200
+        if (mv <= minMv) return 0
+        if (mv >= maxMv) return 100
+        return Math.round(100f * (mv - minMv) / (maxMv - minMv))
+    }
+
+    /** First [byteCount] bytes of a hex pubkey as raw bytes, or null. */
+    fun pubKeyPrefixBytes(pubKeyHex: String?, byteCount: Int): ByteArray? {
+        if (pubKeyHex == null) return null
+        val hex = pubKeyHex.trim()
+        if (hex.length < byteCount * 2) return null
+        return runCatching {
+            ByteArray(byteCount) { i ->
+                hex.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+            }
+        }.getOrNull()
+    }
+
+    private fun validLatLon(lat: Double, lon: Double): Boolean =
+        !lat.isNaN() && !lon.isNaN() &&
+            lat in -90.0..90.0 && lon in -180.0..180.0 &&
+            !(Math.abs(lat) < 0.000001 && Math.abs(lon) < 0.000001)
+
+    private fun bytesToHex(src: ByteArray, off: Int, len: Int): String {
+        if (off < 0 || len <= 0 || src.size < off + len) return ""
+        val sb = StringBuilder(len * 2)
+        for (i in off until off + len) {
+            val b = src[i].toInt() and 0xFF
+            if (b < 0x10) sb.append('0')
+            sb.append(Integer.toHexString(b))
+        }
+        return sb.toString()
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreUartClient.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreUartClient.kt
@@ -1,0 +1,461 @@
+package soy.engindearing.omnitak.mobile.data
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.Context
+import android.os.Build
+import android.os.ParcelUuid
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import soy.engindearing.omnitak.mobile.domain.ConnectionState
+import java.util.ArrayDeque
+import java.util.Locale
+import java.util.UUID
+
+/**
+ * BLE transport for a **MeshCore companion** radio over the Nordic UART
+ * service. Hand-rolled against the raw Android GATT API (mirroring the
+ * TAK-MeshCore plugin's `BtConnectionManager`), not the Nordic BleManager
+ * the Meshtastic client uses — the MeshCore companion path is a simple
+ * write-to-RX / notify-on-TX command channel where each notification is
+ * exactly one companion frame.
+ *
+ * Wire:
+ *  - Service `6E400001-…`, RX (write) `6E400002-…`, TX (notify) `6E400003-…`,
+ *    CCCD `00002902-…`.
+ *  - Scan filter: NUS service UUID, with a name fallback ("MeshCore-").
+ *  - On connect: request MTU 512, discover services, enable TX notify, then
+ *    flip to Connected (the manager runs the APP_START handshake).
+ *  - [send] writes one companion command to RX (queued, one in-flight at a
+ *    time — `writeCharacteristic` is async and only one may be pending).
+ *  - Each TX notification payload is emitted verbatim on [frames] — the
+ *    manager/codec decode whole frames (no length prefix on the BLE path).
+ *
+ * Implements [MeshTransport]; default pairing PIN guidance (123456 / OLED
+ * code) is surfaced via [PAIRING_PIN].
+ */
+@SuppressLint("MissingPermission")
+class MeshCoreUartClient(context: Context) : MeshTransport {
+
+    private val appContext = context.applicationContext
+
+    private val _state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
+    override val state: StateFlow<ConnectionState> = _state.asStateFlow()
+
+    private val _frames = MutableSharedFlow<ByteArray>(extraBufferCapacity = 64)
+    override val frames: SharedFlow<ByteArray> = _frames.asSharedFlow()
+
+    private val _bytesReceived = MutableStateFlow(0L)
+    val bytesReceived: StateFlow<Long> = _bytesReceived.asStateFlow()
+
+    private val _rssi = MutableStateFlow(0)
+    val rssi: StateFlow<Int> = _rssi.asStateFlow()
+
+    private val _scanResults = MutableSharedFlow<BleScanResult>(extraBufferCapacity = 64)
+    val scanResults: SharedFlow<BleScanResult> = _scanResults.asSharedFlow()
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private val bluetoothAdapter: BluetoothAdapter? = run {
+        val mgr = appContext.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        mgr?.adapter
+    }
+
+    private var gatt: BluetoothGatt? = null
+    private var rxChar: BluetoothGattCharacteristic? = null
+    private var txChar: BluetoothGattCharacteristic? = null
+
+    private val writeQueue = ArrayDeque<ByteArray>()
+    private var writeInFlight = false
+    private val writeLock = Any()
+
+    private var scanning = false
+    private var scanJob: Job? = null
+
+    // region Scan ---------------------------------------------------------
+
+    private val scanCallback = object : ScanCallback() {
+        override fun onScanResult(callbackType: Int, result: ScanResult) {
+            val device = result.device ?: return
+            // Trust the hardware NUS filter; also accept by name as a fallback
+            // for chipsets that don't surface the service UUID in the record.
+            val name = runCatching { device.name }.getOrNull() ?: result.scanRecord?.deviceName
+            if (!advertisesNus(result) && !matchesMeshCoreName(name)) return
+            _scanResults.tryEmit(
+                BleScanResult(name = name, address = device.address, rssi = result.rssi),
+            )
+        }
+
+        override fun onScanFailed(errorCode: Int) {
+            Log.w(TAG, "MeshCore BLE scan failed: $errorCode")
+        }
+    }
+
+    /** Start an NUS-filtered BLE scan; results stream on [scanResults]. */
+    fun startScan(timeoutMs: Long = 10_000) {
+        val scanner = bluetoothAdapter?.bluetoothLeScanner ?: run {
+            Log.w(TAG, "no BluetoothLeScanner — Bluetooth disabled?")
+            return
+        }
+        if (scanning) return
+        scanning = true
+        val filter = ScanFilter.Builder()
+            .setServiceUuid(ParcelUuid(UUID_UART_SERVICE))
+            .build()
+        val settings = ScanSettings.Builder()
+            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+            .build()
+        runCatching { scanner.startScan(listOf(filter), settings, scanCallback) }
+            .onFailure {
+                Log.w(TAG, "startScan threw: ${it.message}")
+                scanning = false
+                return
+            }
+        scanJob?.cancel()
+        scanJob = scope.launch {
+            delay(timeoutMs)
+            stopScan()
+        }
+    }
+
+    fun stopScan() {
+        if (!scanning) return
+        scanning = false
+        scanJob?.cancel()
+        runCatching { bluetoothAdapter?.bluetoothLeScanner?.stopScan(scanCallback) }
+    }
+
+    private fun advertisesNus(result: ScanResult): Boolean {
+        val uuids = result.scanRecord?.serviceUuids ?: return false
+        return uuids.any { it?.uuid == UUID_UART_SERVICE }
+    }
+
+    private fun matchesMeshCoreName(name: String?): Boolean {
+        val t = name?.trim().orEmpty()
+        if (t.isEmpty()) return false
+        return t.regionMatches(0, NAME_PREFIX, 0, NAME_PREFIX.length, ignoreCase = true) ||
+            t.lowercase(Locale.US).contains("meshcore")
+    }
+
+    // endregion
+
+    // region Connect / Disconnect ----------------------------------------
+
+    /**
+     * Connect to the MeshCore radio at [address]. Returns true once the TX
+     * notification is enabled (link ready for the APP_START handshake), or
+     * false on failure / timeout.
+     *
+     * Pairing: an unbonded device triggers Android's system pairing dialog
+     * lazily on the first GATT access (standard passkey-entry — the 6-digit
+     * code shows on the node's OLED, or [PAIRING_PIN] for screenless nodes).
+     */
+    suspend fun connectToAddress(address: String, timeoutMs: Long = 20_000): Boolean {
+        val adapter = bluetoothAdapter ?: return false
+        val device = runCatching { adapter.getRemoteDevice(address) }.getOrNull() ?: return false
+        stopScan()
+        closeGatt()
+        _state.value = ConnectionState.Connecting(address)
+        clearWriteQueue()
+
+        synchronized(this) {
+            gatt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                device.connectGatt(appContext, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+            } else {
+                @Suppress("DEPRECATION")
+                device.connectGatt(appContext, false, gattCallback)
+            }
+        }
+        if (gatt == null) {
+            _state.value = ConnectionState.Failed("connectGatt returned null")
+            return false
+        }
+
+        // Poll the state flow until Connected/Failed or timeout.
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            when (val s = _state.value) {
+                is ConnectionState.Connected -> return true
+                is ConnectionState.Failed -> return false
+                else -> delay(100)
+            }
+        }
+        _state.value = ConnectionState.Failed("connect timeout")
+        closeGatt()
+        return false
+    }
+
+    override fun disconnect() {
+        clearWriteQueue()
+        closeGatt()
+        _state.value = ConnectionState.Disconnected
+    }
+
+    private fun closeGatt() {
+        synchronized(this) {
+            runCatching {
+                gatt?.disconnect()
+                gatt?.close()
+            }
+            gatt = null
+            rxChar = null
+            txChar = null
+        }
+    }
+
+    // endregion
+
+    // region TX -----------------------------------------------------------
+
+    /**
+     * [MeshTransport.send] — queue one companion command for the RX char.
+     * Only one GATT write may be in flight; the queue drains as each
+     * `onCharacteristicWrite` callback fires.
+     */
+    override suspend fun send(payload: ByteArray): Boolean {
+        if (payload.isEmpty()) return false
+        if (_state.value !is ConnectionState.Connected) return false
+        synchronized(writeLock) {
+            writeQueue.addLast(payload)
+            if (writeInFlight) return true
+            writeInFlight = true
+        }
+        drainWriteQueue()
+        return true
+    }
+
+    private fun drainWriteQueue() {
+        val g = gatt
+        val ch = rxChar
+        if (g == null || ch == null) {
+            synchronized(writeLock) { writeInFlight = false }
+            return
+        }
+        val next: ByteArray? = synchronized(writeLock) { writeQueue.peekFirst() }
+        if (next == null) {
+            synchronized(writeLock) { writeInFlight = false }
+            return
+        }
+        val ok = writeToRx(g, ch, next)
+        if (!ok) {
+            // Retry shortly; keep the frame at the head of the queue.
+            scope.launch {
+                delay(150)
+                drainWriteQueue()
+            }
+        }
+        // else: wait for onCharacteristicWrite to pop + drain the next.
+    }
+
+    @Suppress("DEPRECATION")
+    private fun writeToRx(g: BluetoothGatt, ch: BluetoothGattCharacteristic, value: ByteArray): Boolean {
+        return runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                g.writeCharacteristic(
+                    ch,
+                    value,
+                    BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT,
+                ) == BluetoothGatt.GATT_SUCCESS
+            } else {
+                ch.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+                ch.value = value
+                g.writeCharacteristic(ch)
+            }
+        }.getOrDefault(false)
+    }
+
+    private fun clearWriteQueue() {
+        synchronized(writeLock) {
+            writeQueue.clear()
+            writeInFlight = false
+        }
+    }
+
+    // endregion
+
+    // region GATT callback ------------------------------------------------
+
+    private val gattCallback = object : BluetoothGattCallback() {
+        override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) {
+            Log.i(TAG, "onConnectionStateChange status=$status newState=$newState")
+            if (newState == BluetoothProfile.STATE_CONNECTED) {
+                gatt = g
+                runCatching { g.requestMtu(REQUESTED_MTU) }
+                runCatching { g.discoverServices() }
+            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                clearWriteQueue()
+                if (_state.value is ConnectionState.Connected ||
+                    _state.value is ConnectionState.Connecting
+                ) {
+                    _state.value = ConnectionState.Disconnected
+                }
+                closeGatt()
+            }
+        }
+
+        override fun onMtuChanged(g: BluetoothGatt, mtu: Int, status: Int) {
+            Log.i(TAG, "MTU negotiated: $mtu (status=$status)")
+        }
+
+        override fun onServicesDiscovered(g: BluetoothGatt, status: Int) {
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                _state.value = ConnectionState.Failed("service discovery failed")
+                closeGatt()
+                return
+            }
+            val svc: BluetoothGattService? = g.getService(UUID_UART_SERVICE)
+            if (svc == null) {
+                _state.value = ConnectionState.Failed("MeshCore UART service not found")
+                closeGatt()
+                return
+            }
+            rxChar = svc.getCharacteristic(UUID_UART_RX)
+            txChar = svc.getCharacteristic(UUID_UART_TX)
+            if (rxChar == null || txChar == null) {
+                _state.value = ConnectionState.Failed("MeshCore RX/TX characteristic missing")
+                closeGatt()
+                return
+            }
+            // Enable notifications on TX.
+            g.setCharacteristicNotification(txChar, true)
+            val ccc = txChar?.getDescriptor(UUID_CCC)
+            if (ccc == null) {
+                _state.value = ConnectionState.Failed("MeshCore CCC descriptor missing")
+                closeGatt()
+                return
+            }
+            writeCccEnable(g, ccc)
+        }
+
+        @Suppress("DEPRECATION")
+        private fun writeCccEnable(g: BluetoothGatt, ccc: BluetoothGattDescriptor) {
+            runCatching {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    g.writeDescriptor(ccc, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
+                } else {
+                    ccc.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                    g.writeDescriptor(ccc)
+                }
+            }
+        }
+
+        override fun onDescriptorWrite(g: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int) {
+            if (descriptor.uuid != UUID_CCC) return
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                _state.value = ConnectionState.Failed("notification enable failed")
+                closeGatt()
+                return
+            }
+            // Link is ready — the manager runs APP_START + the poll loop.
+            _state.value = ConnectionState.Connected(
+                gatt?.device?.address ?: "MeshCore",
+                useTLS = false,
+            )
+        }
+
+        // Android 13+ value-carrying overload.
+        override fun onCharacteristicChanged(
+            g: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            value: ByteArray,
+        ) {
+            if (characteristic.uuid != UUID_UART_TX) return
+            emitFrame(value)
+        }
+
+        // Pre-13 overload — read value off the characteristic.
+        @Suppress("DEPRECATION")
+        @Deprecated("Deprecated in Java")
+        override fun onCharacteristicChanged(g: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) return
+            if (characteristic.uuid != UUID_UART_TX) return
+            emitFrame(characteristic.value)
+        }
+
+        override fun onCharacteristicWrite(
+            g: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            status: Int,
+        ) {
+            // Pop the frame we just attempted and drain the next.
+            synchronized(writeLock) {
+                writeQueue.pollFirst()
+            }
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                Log.w(TAG, "MeshCore BLE write failed: status=$status")
+            }
+            drainWriteQueue()
+        }
+
+        override fun onReadRemoteRssi(g: BluetoothGatt, rssi: Int, status: Int) {
+            if (status == BluetoothGatt.GATT_SUCCESS) _rssi.value = rssi
+        }
+    }
+
+    private fun emitFrame(value: ByteArray?) {
+        val payload = value ?: return
+        if (payload.isEmpty()) return
+        _bytesReceived.value += payload.size.toLong()
+        _frames.tryEmit(payload.copyOf())
+    }
+
+    /** Sample link RSSI (best-effort; result lands on [rssi]). */
+    fun requestRssi() {
+        runCatching { gatt?.readRemoteRssi() }
+    }
+
+    // endregion
+
+    data class BleScanResult(
+        val name: String?,
+        val address: String,
+        val rssi: Int,
+    )
+
+    companion object {
+        private const val TAG = "MeshCoreBle"
+
+        val UUID_UART_SERVICE: UUID = UUID.fromString("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+        val UUID_UART_RX: UUID = UUID.fromString("6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+        val UUID_UART_TX: UUID = UUID.fromString("6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
+        val UUID_CCC: UUID = UUID.fromString("00002902-0000-1000-8000-00805F9B34FB")
+
+        /** Firmware BLE name prefix (`BLE_NAME_PREFIX`). */
+        const val NAME_PREFIX = "MeshCore-"
+
+        /** Default pairing PIN for screenless nodes (firmware `BLE_PIN_CODE`). */
+        const val PAIRING_PIN = 123456
+
+        const val REQUESTED_MTU = 512
+
+        /** Runtime BLE permissions (Android 12+). */
+        val RUNTIME_PERMISSIONS: Array<String> = arrayOf(
+            Manifest.permission.BLUETOOTH_SCAN,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        )
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshTransport.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshTransport.kt
@@ -1,0 +1,37 @@
+package soy.engindearing.omnitak.mobile.data
+
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import soy.engindearing.omnitak.mobile.domain.ConnectionState
+
+/**
+ * Framework-neutral byte transport for a mesh radio link.
+ *
+ * Captures the small surface a [soy.engindearing.omnitak.mobile.domain.MeshFrameworkManager]
+ * needs from its underlying link, regardless of whether that link is a
+ * Meshtastic TCP/BLE socket or a MeshCore Nordic-UART companion radio:
+ *  - [state]  — the live connection state.
+ *  - [frames] — inbound payloads. For Meshtastic this is one FromRadio
+ *               protobuf payload per emission; for MeshCore companion
+ *               BLE it is one companion notification frame per emission.
+ *  - [send]   — write one outbound payload (framing is the impl's job).
+ *  - [disconnect] — tear the link down.
+ *
+ * The Meshtastic clients keep their richer transport-specific APIs
+ * ([MeshtasticBleClient.sendToRadio], [MeshtasticTcpClient.sendBytes],
+ * scan helpers, etc.); this interface is the common denominator that
+ * lets the manager layer stay transport-agnostic. Extracting it does
+ * not change Meshtastic wire behavior — the concrete methods still do
+ * exactly what they did before.
+ */
+interface MeshTransport {
+    val state: StateFlow<ConnectionState>
+    val frames: SharedFlow<ByteArray>
+
+    /** Write one outbound payload. Returns true on a successful
+     *  wire-layer dispatch. */
+    suspend fun send(payload: ByteArray): Boolean
+
+    /** Tear down the link. May be called when already disconnected. */
+    fun disconnect()
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticBleClient.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticBleClient.kt
@@ -223,6 +223,27 @@ class MeshtasticBleClient(context: Context) : BleManager(context) {
         _state.value = ConnectionState.Disconnected
     }
 
+    /**
+     * [MeshTransport] view over this client.
+     *
+     * Exposed as an adapter rather than `MeshtasticBleClient : MeshTransport`
+     * because Nordic's [BleManager.disconnect] is `public final` and returns
+     * a `DisconnectRequest` — a same-name `disconnect(): Unit` from the
+     * interface would be an irreconcilable accidental-override clash. The
+     * adapter delegates [MeshTransport.send] to [sendToRadio] (byte-identical
+     * Meshtastic behavior) and [MeshTransport.disconnect] to a fire-and-forget
+     * [disconnectClean] on this client's own IO scope — the same teardown the
+     * manager already drives.
+     */
+    val asTransport: MeshTransport = object : MeshTransport {
+        override val state: StateFlow<ConnectionState> get() = this@MeshtasticBleClient.state
+        override val frames: SharedFlow<ByteArray> get() = this@MeshtasticBleClient.frames
+        override suspend fun send(payload: ByteArray): Boolean = sendToRadio(payload)
+        override fun disconnect() {
+            scope.launch { disconnectClean() }
+        }
+    }
+
     // endregion
 
     // region TX ---------------------------------------------------------

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticTcpClient.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticTcpClient.kt
@@ -30,17 +30,17 @@ import kotlin.coroutines.coroutineContext
  * comes in the follow-up once the meshtastic `.proto` set is wired
  * into the Gradle build.
  */
-class MeshtasticTcpClient {
+class MeshtasticTcpClient : MeshTransport {
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var connectJob: Job? = null
     private var socket: Socket? = null
 
     private val _state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
-    val state: StateFlow<ConnectionState> = _state.asStateFlow()
+    override val state: StateFlow<ConnectionState> = _state.asStateFlow()
 
     private val _frames = MutableSharedFlow<ByteArray>(extraBufferCapacity = 64)
-    val frames: SharedFlow<ByteArray> = _frames.asSharedFlow()
+    override val frames: SharedFlow<ByteArray> = _frames.asSharedFlow()
 
     private val _bytesReceived = MutableStateFlow(0L)
     val bytesReceived: StateFlow<Long> = _bytesReceived.asStateFlow()
@@ -68,11 +68,14 @@ class MeshtasticTcpClient {
         }
     }
 
-    fun disconnect() {
+    override fun disconnect() {
         connectJob?.cancel()
         cleanup()
         _state.value = ConnectionState.Disconnected
     }
+
+    /** [MeshTransport.send] — TCP delegates to the framed [sendBytes]. */
+    override suspend fun send(payload: ByteArray): Boolean = sendBytes(payload)
 
     /**
      * Encodes + writes a ToRadio protobuf payload. Caller is responsible

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ProfileQrCodec.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ProfileQrCodec.kt
@@ -100,7 +100,31 @@ object ProfileQrCodec {
         return bos.toByteArray()
     }
 
+    /**
+     * Decompress gzip data with a hard cap of [MAX_GUNZIP_BYTES] (64 KiB).
+     * Throws [IllegalArgumentException] if the decompressed stream exceeds
+     * the limit — prevents a hostile QR from OOM-ing the app via a gzip bomb.
+     */
     private fun gunzip(data: ByteArray): ByteArray {
-        GZIPInputStream(ByteArrayInputStream(data)).use { return it.readBytes() }
+        GZIPInputStream(ByteArrayInputStream(data)).use { gz ->
+            val out = ByteArrayOutputStream()
+            val buf = ByteArray(4096)
+            var total = 0
+            while (true) {
+                val n = gz.read(buf)
+                if (n < 0) break
+                total += n
+                if (total > MAX_GUNZIP_BYTES) {
+                    throw IllegalArgumentException(
+                        "Profile QR payload exceeds ${MAX_GUNZIP_BYTES / 1024} KiB limit — likely a gzip bomb"
+                    )
+                }
+                out.write(buf, 0, n)
+            }
+            return out.toByteArray()
+        }
     }
+
+    /** Maximum decompressed payload size accepted from a QR code (64 KiB). */
+    private const val MAX_GUNZIP_BYTES = 65_536
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ProfileQrCodec.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ProfileQrCodec.kt
@@ -1,0 +1,106 @@
+package soy.engindearing.omnitak.mobile.data
+
+import android.net.Uri
+import kotlinx.serialization.json.Json
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+import java.util.Base64
+
+/**
+ * Encodes and decodes [ConfigProfile]s as compact QR-friendly URIs.
+ *
+ * Format: `omnitak://profile?d=<base64url(gzip(json))>`
+ *
+ * Design:
+ *  - JSON → gzip → base64url (URL-safe, no padding) keeps the payload
+ *    under ~2 KB for a typical profile so a single QR (version ≤ 14,
+ *    error-correction L) scans in under a second on any modern phone.
+ *  - No secrets: [ConfigProfile] excludes certs, passphrases, and passwords.
+ *  - Self-contained: no server round-trip; the teammate's camera app decodes
+ *    the link, taps it, and OmniTAK imports inline.
+ *
+ * Deep-link interception is registered in [DeepLinkImport.isProfileConfig] so
+ * the app handles the `omnitak://profile` URL from any entry point
+ * (camera scan → default browser → app, or in-app QR scanner).
+ */
+object ProfileQrCodec {
+
+    private val SCHEME = "omnitak"
+    private val HOST = "profile"
+    private val PARAM = "d"
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    // ── Encode ────────────────────────────────────────────────────────────
+
+    /**
+     * Encode a [ConfigProfile] into a URI string suitable for QR generation.
+     *
+     * Example output:
+     * `omnitak://profile?d=H4sIAAAAAAAAA6tWKkktLlGyUlJQKs9ILUpVslIqS8z...`
+     */
+    fun encode(profile: ConfigProfile): String {
+        val jsonBytes = json.encodeToString(ConfigProfile.serializer(), profile).toByteArray(Charsets.UTF_8)
+        val compressed = gzip(jsonBytes)
+        val encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(compressed)
+        return "$SCHEME://$HOST?$PARAM=$encoded"
+    }
+
+    // ── Decode ────────────────────────────────────────────────────────────
+
+    /**
+     * Decode a URI produced by [encode] back into a [ConfigProfile].
+     * Returns null and logs nothing — callers decide how to surface parse errors.
+     */
+    fun decode(uri: Uri): ConfigProfile? {
+        if (!isProfileUri(uri)) return null
+        val encoded = uri.getQueryParameter(PARAM) ?: return null
+        return runCatching {
+            val compressed = Base64.getUrlDecoder().decode(encoded)
+            val jsonBytes = gunzip(compressed)
+            json.decodeFromString(ConfigProfile.serializer(), String(jsonBytes, Charsets.UTF_8))
+        }.getOrNull()
+    }
+
+    /**
+     * Decode a raw URI string. Works on both Android (via [Uri.parse]) and
+     * the JVM test environment (manually extracts the `d=` query param).
+     */
+    fun decode(uriString: String): ConfigProfile? = runCatching {
+        // Fast path: try Android Uri.parse.
+        val uri = Uri.parse(uriString)
+        if (isProfileUri(uri)) return@runCatching decode(uri)
+        // Fallback: manual parse so JVM unit tests don't need Robolectric.
+        if (!uriString.startsWith("$SCHEME://$HOST?")) return@runCatching null
+        val query = uriString.substringAfter("$SCHEME://$HOST?")
+        val encoded = query.split("&")
+            .firstOrNull { it.startsWith("$PARAM=") }
+            ?.removePrefix("$PARAM=") ?: return@runCatching null
+        if (encoded.isBlank()) return@runCatching null
+        val compressed = Base64.getUrlDecoder().decode(encoded)
+        val jsonBytes = gunzip(compressed)
+        json.decodeFromString(ConfigProfile.serializer(), String(jsonBytes, Charsets.UTF_8))
+    }.getOrNull()
+
+    /** Returns true if this URI carries a profile payload. */
+    fun isProfileUri(uri: Uri?): Boolean {
+        if (uri == null) return false
+        return uri.scheme?.lowercase() == SCHEME &&
+            uri.host?.lowercase() == HOST &&
+            !uri.getQueryParameter(PARAM).isNullOrBlank()
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private fun gzip(data: ByteArray): ByteArray {
+        val bos = ByteArrayOutputStream()
+        GZIPOutputStream(bos).use { it.write(data) }
+        return bos.toByteArray()
+    }
+
+    private fun gunzip(data: ByteArray): ByteArray {
+        GZIPInputStream(ByteArrayInputStream(data)).use { return it.readBytes() }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ProfileQrGenerator.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/ProfileQrGenerator.kt
@@ -1,0 +1,61 @@
+package soy.engindearing.omnitak.mobile.data
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.qrcode.QRCodeWriter
+
+/**
+ * Renders a [ConfigProfile] QR code as an Android [Bitmap].
+ *
+ * Uses the ZXing `core` library (pure Java, no Android resources).
+ * Error-correction level M is the default: tolerates ~15% surface damage
+ * (good for printed/laminated team cards) while keeping the module count
+ * low enough to scan from across a table.
+ */
+object ProfileQrGenerator {
+
+    /**
+     * Generate a square [Bitmap] containing the QR code for [profile].
+     *
+     * @param profile  The profile to encode.
+     * @param sizePx   Width and height of the output bitmap in pixels.
+     *                 512 × 512 is a safe default for Compose `Image`.
+     * @param darkColor Foreground colour (default opaque black).
+     * @param lightColor Background colour (default opaque white).
+     * @return Rendered bitmap, or null if encoding fails (shouldn't happen for
+     *         well-formed profiles, but callers should handle null defensively).
+     */
+    fun generate(
+        profile: ConfigProfile,
+        sizePx: Int = 512,
+        darkColor: Int = Color.BLACK,
+        lightColor: Int = Color.WHITE,
+    ): Bitmap? {
+        val content = ProfileQrCodec.encode(profile)
+        return renderQr(content, sizePx, darkColor, lightColor)
+    }
+
+    /**
+     * Render any string as a QR [Bitmap]. Exposed for testing.
+     */
+    fun renderQr(
+        content: String,
+        sizePx: Int = 512,
+        darkColor: Int = Color.BLACK,
+        lightColor: Int = Color.WHITE,
+    ): Bitmap? = runCatching {
+        val hints = mapOf(
+            EncodeHintType.CHARACTER_SET to "UTF-8",
+            EncodeHintType.MARGIN to 2,
+        )
+        val matrix = QRCodeWriter().encode(content, BarcodeFormat.QR_CODE, sizePx, sizePx, hints)
+        val pixels = IntArray(sizePx * sizePx) { idx ->
+            if (matrix[idx % sizePx, idx / sizePx]) darkColor else lightColor
+        }
+        Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888).also {
+            it.setPixels(pixels, 0, sizePx, 0, 0, sizePx, sizePx)
+        }
+    }.getOrNull()
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -17,6 +17,10 @@ enum class DistanceUnit { METRIC, IMPERIAL }
 enum class CoordFormat { LATLON_DECIMAL, LATLON_DMS, MGRS, UTM, TWD97 }
 enum class MapProvider { OSM_RASTER, SATELLITE_HINT, TOPO_HINT, WMTS_CUSTOM }
 
+/** Mesh framework the operator's radio speaks. Drives which manager the
+ *  mesh screen + CoT bridge + broadcaster route through. */
+enum class MeshFramework { MESHTASTIC, MESHCORE }
+
 /**
  * Operator preferences — callsign, units, coord format, tile choice.
  * All string-backed in DataStore so the schema stays trivial; enum
@@ -99,6 +103,11 @@ data class UserPrefs(
     /** How often (seconds) PPLI is sent over the mesh. Coerced to 30..60
      *  so LoRa bandwidth is respected. */
     val meshBroadcastIntervalSecs: Int = 30,
+    /** Which mesh framework the connected radio speaks. Defaults to
+     *  Meshtastic for backwards compatibility — every existing install
+     *  runs Meshtastic. Selecting MeshCore switches the mesh screen, CoT
+     *  bridge, and broadcaster onto the MeshCore companion BLE path. */
+    val selectedMeshFramework: MeshFramework = MeshFramework.MESHTASTIC,
     /** 3D terrain map mode — tilts the camera and renders DEM relief
      *  (AWS Terrarium tiles). Parity with the iOS Cesium 3D globe
      *  toggle. Default off — 2D top-down is the tactical default. */
@@ -151,6 +160,7 @@ class UserPrefsStore(private val context: Context) {
     private val KEY_GYB_LAST_DEVICE = stringPreferencesKey("gyb_last_device_address")
     private val KEY_BROADCAST_OVER_MESH = booleanPreferencesKey("broadcast_over_mesh")
     private val KEY_MESH_BROADCAST_INTERVAL = intPreferencesKey("mesh_broadcast_interval_secs")
+    private val KEY_MESH_FRAMEWORK = stringPreferencesKey("selected_mesh_framework")
     private val KEY_MAP_3D = booleanPreferencesKey("map_3d_enabled")
     private val KEY_CESIUM_GLOBE = booleanPreferencesKey("cesium_globe_enabled")
     private val KEY_TOOLBAR_ITEMS = stringPreferencesKey("toolbar_item_ids")
@@ -190,6 +200,7 @@ class UserPrefsStore(private val context: Context) {
             p[KEY_GYB_LAST_DEVICE] = next.gybLastDeviceAddress
             p[KEY_BROADCAST_OVER_MESH] = next.broadcastOverMesh
             p[KEY_MESH_BROADCAST_INTERVAL] = next.meshBroadcastIntervalSecs.coerceIn(30, 60)
+            p[KEY_MESH_FRAMEWORK] = next.selectedMeshFramework.name
             p[KEY_MAP_3D] = next.map3dEnabled
             p[KEY_CESIUM_GLOBE] = next.cesiumGlobeEnabled
             p[KEY_TOOLBAR_ITEMS] = next.toolbarItemIds.joinToString(",")
@@ -254,6 +265,11 @@ class UserPrefsStore(private val context: Context) {
         update { it.copy(meshBroadcastIntervalSecs = value.coerceIn(30, 60)) }
     }
 
+    /** Persist the operator's chosen mesh framework (Meshtastic | MeshCore). */
+    suspend fun setSelectedMeshFramework(value: MeshFramework) {
+        update { it.copy(selectedMeshFramework = value) }
+    }
+
     /**
      * Read the stable EUD UID, generating + persisting one on first
      * call. Every wire CoT event tied to this device — PPLI, GeoChat,
@@ -301,6 +317,9 @@ class UserPrefsStore(private val context: Context) {
         gybLastDeviceAddress = p[KEY_GYB_LAST_DEVICE] ?: "",
         broadcastOverMesh = p[KEY_BROADCAST_OVER_MESH] ?: true,
         meshBroadcastIntervalSecs = p[KEY_MESH_BROADCAST_INTERVAL]?.coerceIn(30, 60) ?: 30,
+        selectedMeshFramework = p[KEY_MESH_FRAMEWORK]
+            ?.let { runCatching { MeshFramework.valueOf(it) }.getOrNull() }
+            ?: MeshFramework.MESHTASTIC,
         map3dEnabled = p[KEY_MAP_3D] ?: false,
         cesiumGlobeEnabled = p[KEY_CESIUM_GLOBE] ?: false,
         toolbarItemIds = p[KEY_TOOLBAR_ITEMS]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoTBridge.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoTBridge.kt
@@ -8,22 +8,28 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.data.CoTEvent
 import soy.engindearing.omnitak.mobile.data.MeshNode
-import soy.engindearing.omnitak.mobile.data.MeshtasticCoTConverter
 
 /**
- * Bridges [MeshtasticManager.nodes] into the active TAK output sink as
- * CoT events. Mirrors iOS `MeshtasticCOTBridge.swift` — observe the
- * node table, convert each updated node to a [CoTEvent], and ship it
- * off to whatever publishes events to the active server (the
+ * Bridges a [MeshFrameworkManager]'s node table into the active TAK
+ * output sink as CoT events. Mirrors iOS `MeshtasticCOTBridge.swift` —
+ * observe the node table, convert each updated node to a [CoTEvent], and
+ * ship it off to whatever publishes events to the active server (the
  * [ContactStore.ingest] sink in the Android case).
+ *
+ * The node→CoT conversion is injected ([nodeToCoT]) so the same bridge
+ * serves any mesh framework: Meshtastic nodes go through
+ * [soy.engindearing.omnitak.mobile.data.MeshtasticCoTConverter];
+ * MeshCore contacts through
+ * [soy.engindearing.omnitak.mobile.data.MeshCoreCoTConverter].
  *
  * Re-emits a node only when its content changes (lat/lon/snr/battery
  * shifted) so we don't spam the server with identical updates every
  * StateFlow re-collection.
  */
-class MeshtasticCoTBridge(
-    private val mesh: MeshtasticManager,
+class MeshCoTBridge(
+    private val mesh: MeshFrameworkManager,
     private val cotSink: (CoTEvent) -> Unit,
+    private val nodeToCoT: (MeshNode) -> CoTEvent?,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
 
@@ -40,7 +46,7 @@ class MeshtasticCoTBridge(
                 for ((id, node) in table) {
                     val fp = NodeFingerprint.of(node)
                     if (lastSent[id] == fp) continue
-                    val event = MeshtasticCoTConverter.nodeToCoT(node) ?: continue
+                    val event = nodeToCoT(node) ?: continue
                     runCatching { cotSink(event) }
                         .onFailure { Log.w(TAG, "cotSink failed for node ${node.idHex}: ${it.message}") }
                     lastSent[id] = fp

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoreManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoreManager.kt
@@ -1,0 +1,345 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import soy.engindearing.omnitak.mobile.data.ChatMessage
+import soy.engindearing.omnitak.mobile.data.ChatStatus
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.CotXml
+import soy.engindearing.omnitak.mobile.data.MeshCoreFrameCodec
+import soy.engindearing.omnitak.mobile.data.MeshCoreUartClient
+import soy.engindearing.omnitak.mobile.data.MeshNode
+
+/**
+ * Application-scoped MeshCore state holder — the MeshCore-side parallel to
+ * [MeshtasticManager]. Owns a [MeshCoreUartClient] companion-BLE transport
+ * and exposes a node table + connection state to the mesh screen + CoT
+ * bridge through [MeshFrameworkManager].
+ *
+ * v1 scope:
+ *  - On connect: run APP_START, then poll GET_NEXT_MSG (~2.5 s) to drain the
+ *    node's inbound queue (this is exactly how the reference plugin behaves).
+ *  - Inbound contacts/adverts → node table (positions → CoT PLI via the
+ *    [MeshCoTBridge] + [soy.engindearing.omnitak.mobile.data.MeshCoreCoTConverter]).
+ *  - Inbound text (contact DM / channel msg) → [chatSink] as a GeoChat.
+ *  - Outbound self-position → SET_ADVERT_LATLON + SEND_SELF_ADVERT.
+ *  - Outbound GeoChat → SEND_TXT_MSG to a target contact (pubkey lookup).
+ *
+ * NOT in scope (v2): AX.25 channel-datagram TAK interop.
+ */
+class MeshCoreManager(private val context: Context? = null) : MeshFrameworkManager {
+
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    private val _nodes = MutableStateFlow<Map<Long, MeshNode>>(emptyMap())
+    override val nodes: StateFlow<Map<Long, MeshNode>> = _nodes.asStateFlow()
+
+    /** nodeId → full pubkey hex, so outbound DMs can recover the 32-byte key
+     *  the firmware matches on (we collapse ids to 4 bytes for the node map). */
+    private val pubKeyByNodeId = HashMap<Long, String>()
+
+    private var client: MeshCoreUartClient? = null
+    private var frameCollector: Job? = null
+    private var pollJob: Job? = null
+    @Volatile private var connected = false
+
+    @Volatile override var cotSink: ((CoTEvent) -> Unit)? = null
+    @Volatile override var chatSink: ((ChatMessage) -> Unit)? = null
+
+    /** Latest battery percent reported by the node, or -1. */
+    @Volatile var batteryPercent: Int = -1
+        private set
+
+    /** This node's own pubkey hex (from APP_START self-info), or empty. */
+    @Volatile var selfPubKeyHex: String = ""
+        private set
+
+    private val _activeTransport = MutableStateFlow(false)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override val activeConnectionState: StateFlow<ConnectionState> =
+        _activeTransport.flatMapLatest { active ->
+            if (active) clientOrNull()?.state ?: flowOf(ConnectionState.Disconnected)
+            else flowOf(ConnectionState.Disconnected)
+        }.stateIn(scope, SharingStarted.Eagerly, ConnectionState.Disconnected)
+
+    fun ensureBleReady(): Boolean = clientOrNull() != null
+
+    private fun clientOrNull(): MeshCoreUartClient? {
+        client?.let { return it }
+        val ctx = context ?: return null
+        return MeshCoreUartClient(ctx).also { client = it }
+    }
+
+    /** BLE link state for the MeshCore tab. */
+    fun bleState(): StateFlow<ConnectionState>? = clientOrNull()?.state
+    fun bleBytesReceived(): StateFlow<Long>? = clientOrNull()?.bytesReceived
+    fun bleRssi(): StateFlow<Int>? = client?.rssi
+
+    // region Scan ---------------------------------------------------------
+
+    override suspend fun startMeshScan(timeoutMs: Long): Flow<MeshScanResult>? {
+        val c = clientOrNull() ?: return null
+        c.startScan(timeoutMs)
+        return c.scanResults.map { MeshScanResult(it.name, it.address, it.rssi) }
+    }
+
+    /** Concrete-typed BLE scan for the MeshCore pane (parallels
+     *  [MeshtasticManager.startBleScan]). Null when BLE is unavailable. */
+    suspend fun startBleScan(timeoutMs: Long = 10_000): Flow<MeshCoreUartClient.BleScanResult>? {
+        val c = clientOrNull() ?: return null
+        c.startScan(timeoutMs)
+        return c.scanResults
+    }
+
+    override fun stopMeshScan() {
+        client?.stopScan()
+    }
+
+    // endregion
+
+    // region Connect / Disconnect ----------------------------------------
+
+    override suspend fun connectBle(deviceAddress: String): Boolean {
+        val c = clientOrNull() ?: run {
+            Log.w(TAG, "connectBle called but MeshCore client unavailable")
+            return false
+        }
+        frameCollector?.cancel()
+        _activeTransport.value = true
+        frameCollector = scope.launch {
+            c.frames.collect { frame -> handleFrame(frame) }
+        }
+        val ok = c.connectToAddress(deviceAddress)
+        if (ok) {
+            connected = true
+            // Companion handshake: APP_START → self-info, then a steady
+            // GET_NEXT_MSG poll loop draining contacts/adverts/messages.
+            c.send(MeshCoreFrameCodec.buildAppStart())
+            c.send(MeshCoreFrameCodec.buildDeviceQuery())
+            c.send(MeshCoreFrameCodec.buildGetBattery())
+            c.send(MeshCoreFrameCodec.buildGetNextMessage())
+            startPollLoop()
+            Log.i(TAG, "MeshCore connected — APP_START sent, polling started")
+        } else {
+            _activeTransport.value = false
+            frameCollector?.cancel()
+        }
+        return ok
+    }
+
+    override fun disconnect() {
+        connected = false
+        pollJob?.cancel()
+        pollJob = null
+        frameCollector?.cancel()
+        frameCollector = null
+        client?.disconnect()
+        _activeTransport.value = false
+    }
+
+    private fun startPollLoop() {
+        pollJob?.cancel()
+        pollJob = scope.launch {
+            while (isActive && connected) {
+                delay(POLL_INTERVAL_MS)
+                if (!connected) break
+                client?.send(MeshCoreFrameCodec.buildGetNextMessage())
+                // Periodically refresh battery + sample RSSI for the UI.
+                client?.requestRssi()
+            }
+        }
+    }
+
+    // endregion
+
+    // region Inbound ------------------------------------------------------
+
+    private fun handleFrame(frame: ByteArray) {
+        when (val d = MeshCoreFrameCodec.decode(frame)) {
+            is MeshCoreFrameCodec.Decoded.MessagesWaiting -> {
+                client?.let { c -> scope.launch { c.send(MeshCoreFrameCodec.buildGetNextMessage()) } }
+            }
+            is MeshCoreFrameCodec.Decoded.NoMoreMessages -> Unit
+            is MeshCoreFrameCodec.Decoded.Contact -> {
+                upsertContact(d.node, frame)
+                // Drain the queue promptly while frames are flowing.
+                client?.let { c -> scope.launch { c.send(MeshCoreFrameCodec.buildGetNextMessage()) } }
+            }
+            is MeshCoreFrameCodec.Decoded.SelfInfo -> {
+                selfPubKeyHex = d.pubKeyHex
+                Log.i(TAG, "MeshCore self-info node='${d.nodeName}' pubkey=${d.pubKeyHex.take(12)}…")
+            }
+            is MeshCoreFrameCodec.Decoded.Battery -> {
+                batteryPercent = d.percent
+                // Fold battery into known nodes? No — battery here is the
+                // local node's, not a contact's. Just track it for the UI.
+            }
+            is MeshCoreFrameCodec.Decoded.ContactMessage -> {
+                routeInboundText(d.senderPubKeyPrefixHex, d.text)
+                client?.let { c -> scope.launch { c.send(MeshCoreFrameCodec.buildGetNextMessage()) } }
+            }
+            is MeshCoreFrameCodec.Decoded.ChannelMessage -> {
+                routeInboundChannelText(d.channelIndex, d.text)
+                client?.let { c -> scope.launch { c.send(MeshCoreFrameCodec.buildGetNextMessage()) } }
+            }
+            is MeshCoreFrameCodec.Decoded.Unhandled ->
+                Log.v(TAG, "MeshCore unhandled frame code=0x${Integer.toHexString(d.code)} (${frame.size}B)")
+            null -> Log.v(TAG, "MeshCore empty/undecodable frame (${frame.size}B)")
+        }
+    }
+
+    private fun upsertContact(node: MeshNode, advertFrame: ByteArray) {
+        // Recover the full pubkey hex (bytes 1..32) so we can DM this contact.
+        if (advertFrame.size >= 33) {
+            val pubKeyHex = bytesToHex(advertFrame, 1, 32)
+            if (pubKeyHex.isNotEmpty()) pubKeyByNodeId[node.id] = pubKeyHex
+        }
+        val existing = _nodes.value[node.id]
+        val merged = if (existing != null) {
+            node.copy(
+                position = node.position ?: existing.position,
+                snr = node.snr ?: existing.snr,
+                hopDistance = node.hopDistance ?: existing.hopDistance,
+                batteryLevel = node.batteryLevel ?: existing.batteryLevel,
+                longName = node.longName.ifBlank { existing.longName },
+                shortName = node.shortName.ifBlank { existing.shortName },
+            )
+        } else {
+            node
+        }
+        _nodes.value = _nodes.value + (merged.id to merged)
+    }
+
+    /** Inbound native DM → GeoChat keyed by the sender's pubkey prefix. */
+    private fun routeInboundText(senderPrefixHex: String, text: String) {
+        if (text.isBlank()) return
+        val nodeId = MeshCoreFrameCodec.nodeIdFromPubKey(senderPrefixHex)
+        val node = _nodes.value[nodeId]
+        val callsign = node?.longName?.takeIf { it.isNotBlank() }
+            ?: node?.shortName?.takeIf { it.isNotBlank() }
+            ?: "MeshCore ${senderPrefixHex.take(8)}"
+        val now = System.currentTimeMillis()
+        val msg = ChatMessage(
+            conversationId = meshCoreDmConversationId(nodeId),
+            senderUid = "MESHCORE-${"%08X".format(nodeId.toInt())}",
+            senderCallsign = callsign,
+            text = text,
+            timeIso = CotXml.isoSeconds(now),
+            status = ChatStatus.RECEIVED,
+            isFromSelf = false,
+        )
+        Log.i(TAG, "RX MeshCore DM from $callsign: $text")
+        runCatching { chatSink?.invoke(msg) }
+            .onFailure { Log.w(TAG, "chatSink failed: ${it.message}") }
+    }
+
+    private fun routeInboundChannelText(channelIndex: Int, text: String) {
+        if (text.isBlank()) return
+        val now = System.currentTimeMillis()
+        val msg = ChatMessage(
+            conversationId = meshCoreChannelConversationId(channelIndex),
+            senderUid = "MESHCORE-CH$channelIndex",
+            senderCallsign = "MeshCore Ch $channelIndex",
+            text = text,
+            timeIso = CotXml.isoSeconds(now),
+            status = ChatStatus.RECEIVED,
+            isFromSelf = false,
+        )
+        Log.i(TAG, "RX MeshCore channel $channelIndex text: $text")
+        runCatching { chatSink?.invoke(msg) }
+            .onFailure { Log.w(TAG, "chatSink failed: ${it.message}") }
+    }
+
+    fun meshCoreDmConversationId(nodeId: Long): String =
+        "MESHCORE-DM-${"%08X".format(nodeId.toInt())}"
+
+    fun meshCoreChannelConversationId(channelIndex: Int): String =
+        "MESHCORE-CH$channelIndex"
+
+    // endregion
+
+    // region Outbound -----------------------------------------------------
+
+    /**
+     * Send a plain-text chat over MeshCore as a native pubkey-to-pubkey DM
+     * ([MeshCoreFrameCodec.buildSendTxtMsg]). MeshCore has no AX.25-less
+     * broadcast text in v1 scope, so a message with no resolvable target is
+     * dropped (returns false) rather than guessed.
+     *
+     * [toNodeId] is the collapsed 4-byte node id; we map it back to the
+     * contact's full pubkey to address the DM.
+     */
+    override suspend fun sendMeshChat(text: String, channelIndex: Int, toNodeId: UInt?): Boolean {
+        if (text.isEmpty() || !connected) return false
+        val targetId = toNodeId?.toLong()?.and(0xFFFFFFFFL)
+        val pubKeyHex = targetId?.let { pubKeyByNodeId[it] }
+        if (pubKeyHex == null) {
+            Log.w(TAG, "sendMeshChat: no MeshCore contact pubkey for target=$toNodeId — dropping")
+            return false
+        }
+        val cmd = MeshCoreFrameCodec.buildSendTxtMsg(pubKeyHex, text) ?: return false
+        return client?.send(cmd) ?: false
+    }
+
+    /**
+     * Bridge a CoT event onto MeshCore.
+     *  - GeoChat (`b-t-f`): forwarded as a native DM when a target pubkey is
+     *    known; otherwise dropped (no broadcast text in v1).
+     *  - PLI / self-position (everything else): store the lat/lon in the
+     *    node's advert (SET_ADVERT_LATLON) and broadcast it (SEND_SELF_ADVERT)
+     *    so MeshCore peers plot this operator.
+     */
+    override suspend fun sendCoTOverMesh(event: CoTEvent, channelIndex: UInt): Boolean {
+        if (!connected) return false
+        if (event.type == "b-t-f") {
+            // GeoChat — only DM is in scope; need a resolvable recipient.
+            // CoT chat carries no MeshCore pubkey, so v1 cannot fan a server
+            // GeoChat out to MeshCore peers. Skip rather than misroute.
+            Log.v(TAG, "sendCoTOverMesh: MeshCore GeoChat fan-out not in v1 scope — skipping")
+            return false
+        }
+        // Self/PLI position broadcast.
+        val latLon = MeshCoreFrameCodec.buildSetAdvertLatLon(event.lat, event.lon, event.hae)
+            ?: return false
+        val c = client ?: return false
+        val a = c.send(latLon)
+        val b = c.send(MeshCoreFrameCodec.buildSendSelfAdvert())
+        return a && b
+    }
+
+    // endregion
+
+    private fun bytesToHex(src: ByteArray, off: Int, len: Int): String {
+        if (off < 0 || len <= 0 || src.size < off + len) return ""
+        val sb = StringBuilder(len * 2)
+        for (i in off until off + len) {
+            val v = src[i].toInt() and 0xFF
+            if (v < 0x10) sb.append('0')
+            sb.append(Integer.toHexString(v))
+        }
+        return sb.toString()
+    }
+
+    companion object {
+        private const val TAG = "MeshCoreManager"
+        private const val POLL_INTERVAL_MS = 2_500L
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoreManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoreManager.kt
@@ -2,6 +2,7 @@ package soy.engindearing.omnitak.mobile.domain
 
 import android.content.Context
 import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -52,8 +53,9 @@ class MeshCoreManager(private val context: Context? = null) : MeshFrameworkManag
     override val nodes: StateFlow<Map<Long, MeshNode>> = _nodes.asStateFlow()
 
     /** nodeId → full pubkey hex, so outbound DMs can recover the 32-byte key
-     *  the firmware matches on (we collapse ids to 4 bytes for the node map). */
-    private val pubKeyByNodeId = HashMap<Long, String>()
+     *  the firmware matches on (we collapse ids to 6 bytes for the node map).
+     *  ConcurrentHashMap: written from the BLE/frame thread, read from coroutine senders. */
+    private val pubKeyByNodeId = ConcurrentHashMap<Long, String>()
 
     private var client: MeshCoreUartClient? = null
     private var frameCollector: Job? = null
@@ -200,6 +202,9 @@ class MeshCoreManager(private val context: Context? = null) : MeshFrameworkManag
                 routeInboundChannelText(d.channelIndex, d.text)
                 client?.let { c -> scope.launch { c.send(MeshCoreFrameCodec.buildGetNextMessage()) } }
             }
+            is MeshCoreFrameCodec.Decoded.DeviceInfo ->
+                Log.i(TAG, "MeshCore device-info fwCode=${d.fwCode} maxContacts=${d.maxContacts}" +
+                    " maxChannels=${d.maxChannels} mfg='${d.manufacturer}' ver='${d.version}'")
             is MeshCoreFrameCodec.Decoded.Unhandled ->
                 Log.v(TAG, "MeshCore unhandled frame code=0x${Integer.toHexString(d.code)} (${frame.size}B)")
             null -> Log.v(TAG, "MeshCore empty/undecodable frame (${frame.size}B)")
@@ -232,6 +237,11 @@ class MeshCoreManager(private val context: Context? = null) : MeshFrameworkManag
     private fun routeInboundText(senderPrefixHex: String, text: String) {
         if (text.isBlank()) return
         val nodeId = MeshCoreFrameCodec.nodeIdFromPubKey(senderPrefixHex)
+        // Record the 6-byte prefix as a pubkey stand-in so outbound DM replies
+        // can resolve the target even if the sender has never sent an advert.
+        if (nodeId != 0L && senderPrefixHex.length >= 12) {
+            pubKeyByNodeId.putIfAbsent(nodeId, senderPrefixHex)
+        }
         val node = _nodes.value[nodeId]
         val callsign = node?.longName?.takeIf { it.isNotBlank() }
             ?: node?.shortName?.takeIf { it.isNotBlank() }
@@ -239,7 +249,7 @@ class MeshCoreManager(private val context: Context? = null) : MeshFrameworkManag
         val now = System.currentTimeMillis()
         val msg = ChatMessage(
             conversationId = meshCoreDmConversationId(nodeId),
-            senderUid = "MESHCORE-${"%08X".format(nodeId.toInt())}",
+            senderUid = "MESHCORE-${"%012X".format(nodeId)}",
             senderCallsign = callsign,
             text = text,
             timeIso = CotXml.isoSeconds(now),
@@ -269,7 +279,7 @@ class MeshCoreManager(private val context: Context? = null) : MeshFrameworkManag
     }
 
     fun meshCoreDmConversationId(nodeId: Long): String =
-        "MESHCORE-DM-${"%08X".format(nodeId.toInt())}"
+        "MESHCORE-DM-${"%012X".format(nodeId)}"
 
     fun meshCoreChannelConversationId(channelIndex: Int): String =
         "MESHCORE-CH$channelIndex"

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshFrameworkManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshFrameworkManager.kt
@@ -1,0 +1,65 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.ChatMessage
+import soy.engindearing.omnitak.mobile.data.MeshNode
+
+/**
+ * Framework-agnostic mesh manager surface.
+ *
+ * Captures the part of [MeshtasticManager]'s public API that the UI and
+ * [OmniTAKApp] actually drive, so a second framework ([MeshCoreManager])
+ * can slot into the same wiring: the CoT bridge, the self-position
+ * broadcaster, and the mesh screen all talk to this interface instead of
+ * a concrete manager.
+ *
+ * `MeshtasticManager` keeps its richer Meshtastic-specific API
+ * (admin-config read-back, TCP-vs-BLE tab state flows, etc.); this
+ * interface is the common denominator. Extracting it leaves Meshtastic
+ * behavior unchanged.
+ */
+interface MeshFrameworkManager {
+    /** Node table keyed by node id. The CoT bridge observes this. */
+    val nodes: StateFlow<Map<Long, MeshNode>>
+
+    /** Connection state of whichever transport is currently active
+     *  (or [ConnectionState.Disconnected] when none is). */
+    val activeConnectionState: StateFlow<ConnectionState>
+
+    /** Sink for CoT events decoded off the mesh (PLI/markers/chat).
+     *  Wired by [OmniTAKApp] into the contact/chat stores. */
+    var cotSink: ((CoTEvent) -> Unit)?
+
+    /** Sink for plain text messages decoded off the mesh, surfaced in
+     *  the Chat tab. */
+    var chatSink: ((ChatMessage) -> Unit)?
+
+    /** Open a BLE session to the radio at [deviceAddress]. */
+    suspend fun connectBle(deviceAddress: String): Boolean
+
+    /** Tear down whatever transport is active. */
+    fun disconnect()
+
+    /** Send a plain-text chat message over the active mesh transport. */
+    suspend fun sendMeshChat(text: String, channelIndex: Int = 0, toNodeId: UInt? = null): Boolean
+
+    /** Send a CoT event (self-PLI or GeoChat) over the active mesh
+     *  transport. Returns true on wire-layer dispatch. */
+    suspend fun sendCoTOverMesh(event: CoTEvent, channelIndex: UInt = 0u): Boolean
+
+    /** Start a BLE scan, returning a flow of framework-neutral hits.
+     *  Null when BLE is unavailable (e.g. no Context / radio off). */
+    suspend fun startMeshScan(timeoutMs: Long = 10_000): Flow<MeshScanResult>?
+
+    /** Stop an in-flight BLE scan. */
+    fun stopMeshScan()
+}
+
+/** Framework-neutral BLE discovery result for the mesh framework picker. */
+data class MeshScanResult(
+    val name: String?,
+    val address: String,
+    val rssi: Int,
+)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.io.ByteArrayOutputStream
@@ -62,12 +63,12 @@ import soy.engindearing.omnitak.mobile.data.MeshtasticTcpClient
  * provides the matching TX path over the active TCP transport — BLE
  * TX hooks in as a follow-up.
  */
-class MeshtasticManager(private val context: Context? = null) {
+class MeshtasticManager(private val context: Context? = null) : MeshFrameworkManager {
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     private val _nodes = MutableStateFlow<Map<Long, MeshNode>>(emptyMap())
-    val nodes: StateFlow<Map<Long, MeshNode>> = _nodes.asStateFlow()
+    override val nodes: StateFlow<Map<Long, MeshNode>> = _nodes.asStateFlow()
 
     val tcpClient = MeshtasticTcpClient()
     private var bleClient: MeshtasticBleClient? = null
@@ -105,7 +106,7 @@ class MeshtasticManager(private val context: Context? = null) {
      * showed as "No device connected" in Device Settings.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    val activeConnectionState: StateFlow<ConnectionState> =
+    override val activeConnectionState: StateFlow<ConnectionState> =
         _activeTransport.flatMapLatest { transport ->
             when (transport) {
                 MeshConnectionType.TCP -> tcpClient.state
@@ -130,7 +131,7 @@ class MeshtasticManager(private val context: Context? = null) {
     /** Sink for CoT events parsed off the mesh — wired up by
      *  [OmniTAKApp] to [ContactStore.ingest] so portnum-72 ATAK-plugin
      *  payloads flow into the same map pipeline as TCP-server CoT. */
-    @Volatile var cotSink: ((CoTEvent) -> Unit)? = null
+    @Volatile override var cotSink: ((CoTEvent) -> Unit)? = null
 
     fun connectTcp(host: String, port: Int = 4403) {
         // Tearing down a BLE session before opening the TCP one is
@@ -157,7 +158,7 @@ class MeshtasticManager(private val context: Context? = null) {
      * parser. Requires the manager to have been constructed with a
      * Context (`MeshtasticManager(applicationContext)`).
      */
-    suspend fun connectBle(deviceAddress: String): Boolean {
+    override suspend fun connectBle(deviceAddress: String): Boolean {
         val client = bleClientOrNull() ?: run {
             Log.w(TAG, "connectBle called but BLE client unavailable")
             return false
@@ -215,10 +216,17 @@ class MeshtasticManager(private val context: Context? = null) {
         bleClient?.stopScan()
     }
 
+    /** [MeshFrameworkManager] scan — maps the Meshtastic BLE scan results
+     *  into the framework-neutral [MeshScanResult] the picker consumes. */
+    override suspend fun startMeshScan(timeoutMs: Long): Flow<MeshScanResult>? =
+        startBleScan(timeoutMs)?.map { MeshScanResult(it.name, it.address, it.rssi) }
+
+    override fun stopMeshScan() = stopBleScan()
+
     /** RSSI of the active BLE link, or null if BLE not initialized. */
     fun bleRssi(): StateFlow<Int>? = bleClient?.rssi
 
-    fun disconnect() {
+    override fun disconnect() {
         when (_activeTransport.value) {
             MeshConnectionType.TCP -> tcpClient.disconnect()
             MeshConnectionType.BLUETOOTH -> {
@@ -388,7 +396,7 @@ class MeshtasticManager(private val context: Context? = null) {
      * [OmniTAKApp] to [ChatStore.ingest] so the Chat tab surfaces them
      * in a "Mesh: channel N" conversation.
      */
-    @Volatile var chatSink: ((ChatMessage) -> Unit)? = null
+    @Volatile override var chatSink: ((ChatMessage) -> Unit)? = null
 
     /**
      * GAP-122 — send a text message over the Meshtastic transport on
@@ -401,7 +409,7 @@ class MeshtasticManager(private val context: Context? = null) {
      * instead of the broadcast address. Recipients see it as a DM in
      * conversation "MESH-DM-<myNodeId>".
      */
-    suspend fun sendMeshChat(text: String, channelIndex: Int = 0, toNodeId: UInt? = null): Boolean {
+    override suspend fun sendMeshChat(text: String, channelIndex: Int, toNodeId: UInt?): Boolean {
         if (text.isEmpty()) return false
         val transport = _activeTransport.value ?: return false
         val payload = text.toByteArray(Charsets.UTF_8)
@@ -485,7 +493,7 @@ class MeshtasticManager(private val context: Context? = null) {
      * writes go through the toRadio characteristic on
      * [MeshtasticBleClient.sendToRadio] (chunked at the negotiated MTU).
      */
-    suspend fun sendCoTOverMesh(event: CoTEvent, channelIndex: UInt = 0u): Boolean {
+    override suspend fun sendCoTOverMesh(event: CoTEvent, channelIndex: UInt): Boolean {
         // Phase 2: Emit standard TAKPacket (atak.proto) for interop with stock
         // Meshtastic ATAK Plugin, Meshtastic phone-app TAK role, and the
         // TAK_Meshtastic_Gateway. The MeshPacket wrapper still uses

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
@@ -38,6 +38,7 @@ import soy.engindearing.omnitak.mobile.ui.screens.MapScreen
 import soy.engindearing.omnitak.mobile.ui.screens.MeshDeviceSettingsScreen
 import soy.engindearing.omnitak.mobile.ui.screens.MeshTopologyScreen
 import soy.engindearing.omnitak.mobile.ui.screens.MeshtasticScreen
+import soy.engindearing.omnitak.mobile.ui.screens.ProfilesScreen
 import soy.engindearing.omnitak.mobile.ui.screens.ServersScreen
 import soy.engindearing.omnitak.mobile.ui.screens.SettingsScreen
 import soy.engindearing.omnitak.mobile.ui.screens.UASScreen
@@ -243,7 +244,11 @@ fun AppNav() {
                     onOpenAbout = { nav.navigate("about") },
                     onOpenPlugins = { pluginId -> nav.navigate("settings/plugin/$pluginId") },
                     onOpenPluginsList = { nav.navigate("plugins") },
+                    onOpenProfiles = { nav.navigate("settings/profiles") },
                 )
+            }
+            composable("settings/profiles") {
+                ProfilesScreen(onBack = { nav.popBackStack() })
             }
             composable("about") { AboutScreen() }
             // Top-level Plugins list (reads from PluginRegistry).

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
@@ -34,6 +34,7 @@ import soy.engindearing.omnitak.mobile.ui.screens.AboutScreen
 import soy.engindearing.omnitak.mobile.ui.screens.AddServerScreen
 import soy.engindearing.omnitak.mobile.ui.screens.ChatScreen
 import soy.engindearing.omnitak.mobile.ui.screens.EnrollServerScreen
+import soy.engindearing.omnitak.mobile.ui.screens.ImportPreviewDialog
 import soy.engindearing.omnitak.mobile.ui.screens.MapScreen
 import soy.engindearing.omnitak.mobile.ui.screens.MeshDeviceSettingsScreen
 import soy.engindearing.omnitak.mobile.ui.screens.MeshTopologyScreen
@@ -356,6 +357,23 @@ fun AppNav() {
     if (showKmlOverlays) {
         soy.engindearing.omnitak.mobile.ui.components.KmlOverlaysSheet(
             onDismiss = { showKmlOverlays = false },
+        )
+    }
+
+    // Deep-link profile import — show the same ImportPreviewDialog the
+    // in-app QR scanner uses, so the user can review before applying.
+    val pendingImport by app.pendingProfileImport.collectAsState()
+    pendingImport?.let { candidate ->
+        ImportPreviewDialog(
+            profile = candidate,
+            onConfirm = {
+                app.pendingProfileImport.value = null
+                scope.launch {
+                    app.configProfileStore.saveProfile(candidate)
+                    app.configProfileStore.apply(candidate)
+                }
+            },
+            onDismiss = { app.pendingProfileImport.value = null },
         )
     }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
@@ -550,18 +550,29 @@ private suspend fun sendChatInner(
 ) {
     val senderUid = app.userPrefsStore.ensureSelfUid()
 
-    // GAP-122 / GAP-124 — Mesh conversations route through
-    // MeshtasticManager (portnum 1) instead of the TAK server's CoT
-    // GeoChat path. Channel chat → broadcast on a channel index;
-    // DM → directed packet to the peer's nodenum (parsed back from the
-    // 8-hex-char suffix on the convo id).
-    if (convo.id.startsWith("MESH-CH") || convo.id.startsWith("MESH-DM-")) {
-        val channelIndex = if (convo.id.startsWith("MESH-CH")) {
-            convo.id.removePrefix("MESH-CH").toIntOrNull() ?: 0
-        } else 0
-        val toNodeId: UInt? = if (convo.id.startsWith("MESH-DM-")) {
-            convo.id.removePrefix("MESH-DM-").toLongOrNull(16)?.toUInt()
-        } else null
+    // GAP-122 / GAP-124 — Mesh conversations route through the active mesh
+    // framework manager (Meshtastic portnum 1 or MeshCore native DM) instead
+    // of the TAK server's CoT GeoChat path.
+    // MESH-CH*/MESH-DM-* → Meshtastic (portnum 1).
+    // MESHCORE-CH*/MESHCORE-DM-* → MeshCore (native pubkey-to-pubkey DM).
+    if (convo.id.startsWith("MESH-CH") || convo.id.startsWith("MESH-DM-") ||
+        convo.id.startsWith("MESHCORE-CH") || convo.id.startsWith("MESHCORE-DM-")
+    ) {
+        val isMeshCore = convo.id.startsWith("MESHCORE-")
+        val channelIndex = when {
+            convo.id.startsWith("MESH-CH") -> convo.id.removePrefix("MESH-CH").toIntOrNull() ?: 0
+            convo.id.startsWith("MESHCORE-CH") -> convo.id.removePrefix("MESHCORE-CH").toIntOrNull() ?: 0
+            else -> 0
+        }
+        // toNodeId: for DM conversations the nodeId is the hex suffix.
+        // Meshtastic uses 32-bit ids (8 hex); MeshCore uses 48-bit (12 hex).
+        val toNodeId: UInt? = when {
+            convo.id.startsWith("MESH-DM-") ->
+                convo.id.removePrefix("MESH-DM-").toLongOrNull(16)?.toUInt()
+            convo.id.startsWith("MESHCORE-DM-") ->
+                convo.id.removePrefix("MESHCORE-DM-").toLongOrNull(16)?.and(0xFFFFFFFFL)?.toUInt()
+            else -> null
+        }
         val msgId = UUID.randomUUID().toString()
         val outgoing = ChatMessage(
             id = msgId,
@@ -574,7 +585,9 @@ private suspend fun sendChatInner(
             isFromSelf = true,
         )
         app.chatStore.markOutgoing(outgoing)
-        val sent = app.meshtastic.sendMeshChat(text, channelIndex, toNodeId)
+        // Route through the active framework so a MeshCore-selected operator's
+        // chat goes to MeshCoreManager, not the dead MeshtasticManager.
+        val sent = app.activeMeshManager.sendMeshChat(text, channelIndex, toNodeId)
         app.chatStore.updateMessageStatus(
             conversationId = convo.id,
             messageId = msgId,
@@ -616,8 +629,9 @@ private suspend fun sendChatInner(
 
     // Off-grid mesh GeoChat — portnum-72 b-t-f TAKMessage so operators
     // with radios and NO server can exchange chat. Step 2 of off-grid plan.
-    // Keep the existing MESH-CH*/MESH-DM-* portnum-1 path unchanged (above).
-    val meshState = app.meshtastic.activeConnectionState.value
+    // Keep the existing MESH-CH*/MESH-DM-* / MESHCORE-* path unchanged (above).
+    val activeMesh = app.activeMeshManager
+    val meshState = activeMesh.activeConnectionState.value
     val latestPrefs = app.userPrefsStore.prefs.first()
     var meshSent = false
     if (meshState is soy.engindearing.omnitak.mobile.domain.ConnectionState.Connected &&
@@ -636,7 +650,7 @@ private suspend fun sendChatInner(
         // flagship off-grid case (radio, no server) a successful mesh
         // delivery used to render FAILED because only the server result
         // was consulted. Real mesh errors get logged, not swallowed.
-        meshSent = runCatching { app.meshtastic.sendCoTOverMesh(meshCotEvent) }
+        meshSent = runCatching { activeMesh.sendCoTOverMesh(meshCotEvent) }
             .onFailure { t ->
                 android.util.Log.w(
                     "ChatScreen",

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshtasticScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshtasticScreen.kt
@@ -572,6 +572,7 @@ private fun MeshCorePane(
                 meshCore.stopMeshScan()
                 coScope.launch { meshCore.connectBle(addr) }
             },
+            deviceNoun = "MeshCore radios",
         )
 
         if (connected) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshtasticScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshtasticScreen.kt
@@ -31,6 +31,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -56,9 +59,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.OmniTAKApp
+import soy.engindearing.omnitak.mobile.data.MeshCoreUartClient
+import soy.engindearing.omnitak.mobile.data.MeshFramework
 import soy.engindearing.omnitak.mobile.data.MeshNode
 import soy.engindearing.omnitak.mobile.data.MeshtasticBleClient
 import soy.engindearing.omnitak.mobile.domain.ConnectionState
+import soy.engindearing.omnitak.mobile.domain.MeshCoreManager
 import soy.engindearing.omnitak.mobile.domain.MeshtasticManager
 import soy.engindearing.omnitak.mobile.ui.components.BleScanList
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
@@ -74,17 +80,25 @@ fun MeshtasticScreen(
 ) {
     val app = LocalContext.current.applicationContext as OmniTAKApp
     val mesh = app.meshtastic
-    // Touching this lazy property kicks the bridge into active
+    val meshCore = app.meshcore
+    // Touching these lazy properties kicks each CoT bridge into active
     // collection so any nodes ingested below light up on the map.
     remember { app.meshtasticCoTBridge }
-    val nodes by mesh.nodes.collectAsState()
-    val connectionState by mesh.state.collectAsState()
-    val bleState = mesh.bleState()?.collectAsState()?.value
-    val anyConnected = connectionState is ConnectionState.Connected ||
-        bleState is ConnectionState.Connected
+    remember { app.meshCoreCoTBridge }
     val userPrefs by app.userPrefsStore.prefs.collectAsState(
         initial = soy.engindearing.omnitak.mobile.data.UserPrefs(),
     )
+    val framework = userPrefs.selectedMeshFramework
+    val nodes by mesh.nodes.collectAsState()
+    val meshCoreNodes by meshCore.nodes.collectAsState()
+    val connectionState by mesh.state.collectAsState()
+    val bleState = mesh.bleState()?.collectAsState()?.value
+    val meshCoreState = meshCore.bleState()?.collectAsState()?.value
+    val anyConnected = when (framework) {
+        MeshFramework.MESHTASTIC ->
+            connectionState is ConnectionState.Connected || bleState is ConnectionState.Connected
+        MeshFramework.MESHCORE -> meshCoreState is ConnectionState.Connected
+    }
     val coScope = rememberCoroutineScope()
 
     var selectedTab by remember { mutableStateOf(0) }
@@ -181,7 +195,10 @@ fun MeshtasticScreen(
                             enabled = anyConnected,
                             onClick = {
                                 menuOpen = false
-                                mesh.disconnect()
+                                when (framework) {
+                                    MeshFramework.MESHTASTIC -> mesh.disconnect()
+                                    MeshFramework.MESHCORE -> meshCore.disconnect()
+                                }
                             },
                         )
                     }
@@ -198,33 +215,65 @@ fun MeshtasticScreen(
                 .fillMaxSize()
                 .padding(inner),
         ) {
-            TabRow(
-                selectedTabIndex = selectedTab,
-                containerColor = TacticalBackground,
-                contentColor = TacticalAccent,
+            // Mesh framework selector — Meshtastic | MeshCore. Persists to
+            // UserPrefs.selectedMeshFramework and switches the panes below.
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
             ) {
-                Tab(
-                    selected = selectedTab == 0,
-                    onClick = { selectedTab = 0 },
-                    text = { Text("TCP") },
-                )
-                Tab(
-                    selected = selectedTab == 1,
-                    onClick = { selectedTab = 1 },
-                    text = { Text("BLE") },
-                )
+                MeshFramework.entries.forEachIndexed { index, fw ->
+                    SegmentedButton(
+                        selected = framework == fw,
+                        onClick = {
+                            if (framework != fw) {
+                                coScope.launch { app.userPrefsStore.setSelectedMeshFramework(fw) }
+                            }
+                        },
+                        shape = SegmentedButtonDefaults.itemShape(index, MeshFramework.entries.size),
+                    ) {
+                        Text(if (fw == MeshFramework.MESHTASTIC) "Meshtastic" else "MeshCore")
+                    }
+                }
             }
-            when (selectedTab) {
-                0 -> TcpPane(
-                    mesh,
-                    nodes.values.sortedByDescending { it.lastHeardEpoch },
-                    nodes.size,
-                    onOpenChat = onOpenChat,
-                )
-                else -> BlePane(
-                    mesh,
-                    nodes.values.sortedByDescending { it.lastHeardEpoch },
-                    nodes.size,
+
+            when (framework) {
+                MeshFramework.MESHTASTIC -> {
+                    TabRow(
+                        selectedTabIndex = selectedTab,
+                        containerColor = TacticalBackground,
+                        contentColor = TacticalAccent,
+                    ) {
+                        Tab(
+                            selected = selectedTab == 0,
+                            onClick = { selectedTab = 0 },
+                            text = { Text("TCP") },
+                        )
+                        Tab(
+                            selected = selectedTab == 1,
+                            onClick = { selectedTab = 1 },
+                            text = { Text("BLE") },
+                        )
+                    }
+                    when (selectedTab) {
+                        0 -> TcpPane(
+                            mesh,
+                            nodes.values.sortedByDescending { it.lastHeardEpoch },
+                            nodes.size,
+                            onOpenChat = onOpenChat,
+                        )
+                        else -> BlePane(
+                            mesh,
+                            nodes.values.sortedByDescending { it.lastHeardEpoch },
+                            nodes.size,
+                            onOpenChat = onOpenChat,
+                        )
+                    }
+                }
+                MeshFramework.MESHCORE -> MeshCorePane(
+                    meshCore,
+                    meshCoreNodes.values.sortedByDescending { it.lastHeardEpoch },
+                    meshCoreNodes.size,
                     onOpenChat = onOpenChat,
                 )
             }
@@ -440,6 +489,152 @@ private fun BlePane(
             NodeList(sortedNodes, onOpenChat = onOpenChat)
         }
         Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun MeshCorePane(
+    meshCore: MeshCoreManager,
+    sortedNodes: List<MeshNode>,
+    nodeCount: Int,
+    onOpenChat: (String) -> Unit = {},
+) {
+    // Make sure the MeshCore client exists so we can observe its state.
+    LaunchedEffect(Unit) { meshCore.ensureBleReady() }
+
+    val coScope = rememberCoroutineScope()
+    val bleStateFlow = meshCore.bleState()
+    val bleBytesFlow = meshCore.bleBytesReceived()
+    val rssiFlow = meshCore.bleRssi()
+
+    val bleState = bleStateFlow?.collectAsState()?.value ?: ConnectionState.Disconnected
+    val bleBytes = bleBytesFlow?.collectAsState()?.value ?: 0L
+    val bleRssi = rssiFlow?.collectAsState()?.value ?: 0
+
+    var isScanning by remember { mutableStateOf(false) }
+    val results = remember { mutableStateListOf<MeshCoreUartClient.BleScanResult>() }
+
+    DisposableEffect(Unit) {
+        onDispose { meshCore.stopMeshScan() }
+    }
+
+    val stateLabel = when (val s = bleState) {
+        ConnectionState.Disconnected -> "Disconnected"
+        is ConnectionState.Connecting -> "Connecting to ${s.serverName}…"
+        is ConnectionState.Connected -> "Connected to ${s.serverName}"
+        is ConnectionState.Failed -> "Failed: ${s.reason}"
+    }
+    val connected = bleState is ConnectionState.Connected
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        SectionHeader("MeshCore companion (BLE)")
+        Text(
+            "Pair OmniTAK with a MeshCore companion radio over BLE (Nordic UART). " +
+                "Contacts' advertised positions plot as PLI; inbound messages land in Chat. " +
+                "If Android asks for a PIN, use the code on the node's screen, or " +
+                "${MeshCoreUartClient.PAIRING_PIN} if it has no screen.",
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+            style = MaterialTheme.typography.bodySmall,
+        )
+
+        BleScanList(
+            isScanning = isScanning,
+            onStartScan = {
+                results.clear()
+                isScanning = true
+                coScope.launch {
+                    val flow = meshCore.startBleScan() ?: run {
+                        isScanning = false
+                        return@launch
+                    }
+                    flow.collect { hit ->
+                        if (results.none { it.address == hit.address }) results.add(hit)
+                    }
+                }
+            },
+            onStopScan = {
+                isScanning = false
+                meshCore.stopMeshScan()
+            },
+            results = results.map {
+                soy.engindearing.omnitak.mobile.ui.components.BleDeviceItem(
+                    name = it.name, address = it.address, rssi = it.rssi,
+                )
+            },
+            onConnect = { addr ->
+                isScanning = false
+                meshCore.stopMeshScan()
+                coScope.launch { meshCore.connectBle(addr) }
+            },
+        )
+
+        if (connected) {
+            OutlinedButton(
+                onClick = { meshCore.disconnect() },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text("Disconnect") }
+        }
+
+        HorizontalDivider(color = TacticalSurface)
+
+        SectionHeader("Link")
+        KeyValueRow(label = "State", value = stateLabel)
+        KeyValueRow(label = "Bytes RX", value = "$bleBytes")
+        KeyValueRow(label = "RSSI", value = if (bleRssi == 0) "—" else "$bleRssi dBm")
+        KeyValueRow(label = "Contacts", value = "$nodeCount")
+
+        HorizontalDivider(color = TacticalSurface)
+
+        SectionHeader("Contacts")
+        if (sortedNodes.isEmpty()) {
+            Text(
+                "No contacts yet. Connect to a MeshCore companion radio; its known " +
+                    "contacts' adverts will populate here as they're heard.",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        } else {
+            MeshCoreNodeList(meshCore, sortedNodes, onOpenChat = onOpenChat)
+        }
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun MeshCoreNodeList(
+    meshCore: MeshCoreManager,
+    nodes: List<MeshNode>,
+    onOpenChat: (String) -> Unit = {},
+) {
+    val app = LocalContext.current.applicationContext as OmniTAKApp
+    var detailNode by remember { mutableStateOf<MeshNode?>(null) }
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        nodes.forEach { n ->
+            NodeRow(node = n, onClick = { detailNode = n })
+        }
+    }
+    detailNode?.let { selected ->
+        soy.engindearing.omnitak.mobile.ui.components.MeshNodeDetailSheet(
+            node = selected,
+            onDismiss = { detailNode = null },
+            onMessage = {
+                val convoId = meshCore.meshCoreDmConversationId(selected.id)
+                val title = "DM: ${selected.longName.ifBlank { selected.shortName.ifBlank { selected.idHex } }}"
+                app.chatStore.upsertConversationIfMissing(
+                    id = convoId,
+                    title = title,
+                    isGroup = false,
+                )
+                detailNode = null
+                onOpenChat(convoId)
+            },
+        )
     }
 }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ProfilesScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ProfilesScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -109,7 +110,7 @@ private const val TAG = "ProfilesScreen"
  *  - "Generate QR" → shows a QR code for sharing.
  *  - "Scan to import" → CameraX + MLKit scanner with an import preview/confirm dialog.
  */
-@OptIn(ExperimentalMaterial3Api::class)
+@kotlin.OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfilesScreen(onBack: () -> Unit = {}) {
     val context = LocalContext.current
@@ -353,7 +354,7 @@ private fun ProfileRow(
 
 // ── Snapshot dialog ──────────────────────────────────────────────────────────
 
-@OptIn(ExperimentalMaterial3Api::class)
+@kotlin.OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SnapshotDialog(onConfirm: (String) -> Unit, onDismiss: () -> Unit) {
     var name by remember { mutableStateOf("") }
@@ -403,7 +404,7 @@ private fun SnapshotDialog(onConfirm: (String) -> Unit, onDismiss: () -> Unit) {
 
 // ── Rename dialog ────────────────────────────────────────────────────────────
 
-@OptIn(ExperimentalMaterial3Api::class)
+@kotlin.OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun RenameDialog(current: String, onConfirm: (String) -> Unit, onDismiss: () -> Unit) {
     var name by remember { mutableStateOf(current) }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ProfilesScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ProfilesScreen.kt
@@ -1,0 +1,704 @@
+package soy.engindearing.omnitak.mobile.ui.screens
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.OptIn
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.core.content.ContextCompat
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import soy.engindearing.omnitak.mobile.OmniTAKApp
+import soy.engindearing.omnitak.mobile.data.ConfigProfile
+import soy.engindearing.omnitak.mobile.data.ConfigProfileStore
+import soy.engindearing.omnitak.mobile.data.ProfileQrCodec
+import soy.engindearing.omnitak.mobile.data.ProfileQrGenerator
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalSurface
+import java.util.concurrent.Executors
+
+private const val TAG = "ProfilesScreen"
+
+/**
+ * Full-screen profile manager.
+ *
+ * Features:
+ *  - List all saved profiles; active profile highlighted.
+ *  - Tap profile → switch (apply) it.
+ *  - Long-press (via trailing icons) to rename or delete.
+ *  - "Snapshot current" → names and saves the live config.
+ *  - "Generate QR" → shows a QR code for sharing.
+ *  - "Scan to import" → CameraX + MLKit scanner with an import preview/confirm dialog.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfilesScreen(onBack: () -> Unit = {}) {
+    val context = LocalContext.current
+    val app = context.applicationContext as OmniTAKApp
+    val store = app.configProfileStore
+    val scope = rememberCoroutineScope()
+
+    val profiles by store.profiles.collectAsState(initial = emptyList())
+    val activeId by store.activeProfileId.collectAsState(initial = null)
+
+    // ── Dialog state ────────────────────────────────────────────────────────
+    var showSnapshotDialog by remember { mutableStateOf(false) }
+    var profileForQr by remember { mutableStateOf<ConfigProfile?>(null) }
+    var profileForRename by remember { mutableStateOf<ConfigProfile?>(null) }
+    var profileForDelete by remember { mutableStateOf<ConfigProfile?>(null) }
+    var showScanner by remember { mutableStateOf(false) }
+    var importCandidate by remember { mutableStateOf<ConfigProfile?>(null) }
+
+    Scaffold(
+        containerColor = TacticalBackground,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        "Config Profiles",
+                        color = MaterialTheme.colorScheme.onBackground,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Filled.Close, contentDescription = "Back", tint = MaterialTheme.colorScheme.onBackground)
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showScanner = true }) {
+                        Icon(Icons.Filled.QrCodeScanner, contentDescription = "Scan QR", tint = TacticalAccent)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = TacticalBackground),
+            )
+        },
+    ) { inner: PaddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            // ── Snapshot button ────────────────────────────────────────────
+            Button(
+                onClick = { showSnapshotDialog = true },
+                colors = ButtonDefaults.buttonColors(containerColor = TacticalAccent),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Icons.Filled.Add, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("Snapshot current config", fontWeight = FontWeight.SemiBold)
+            }
+
+            if (profiles.isEmpty()) {
+                Spacer(Modifier.height(24.dp))
+                Text(
+                    "No profiles yet. Snapshot your current settings to create one.",
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            } else {
+                Text(
+                    "SAVED PROFILES",
+                    color = TacticalAccent,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.SemiBold,
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    items(profiles, key = { it.id }) { profile ->
+                        ProfileRow(
+                            profile = profile,
+                            isActive = profile.id == activeId,
+                            onSwitch = {
+                                scope.launch {
+                                    store.apply(profile)
+                                }
+                            },
+                            onGenerateQr = { profileForQr = profile },
+                            onRename = { profileForRename = profile },
+                            onDelete = { profileForDelete = profile },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Snapshot dialog ─────────────────────────────────────────────────────
+    if (showSnapshotDialog) {
+        SnapshotDialog(
+            onConfirm = { name ->
+                showSnapshotDialog = false
+                scope.launch {
+                    val servers = app.serverManager.servers.value
+                    store.snapshotCurrent(name, servers)
+                }
+            },
+            onDismiss = { showSnapshotDialog = false },
+        )
+    }
+
+    // ── QR display dialog ───────────────────────────────────────────────────
+    profileForQr?.let { profile ->
+        QrDialog(profile = profile, onDismiss = { profileForQr = null })
+    }
+
+    // ── Rename dialog ───────────────────────────────────────────────────────
+    profileForRename?.let { profile ->
+        RenameDialog(
+            current = profile.name,
+            onConfirm = { newName ->
+                profileForRename = null
+                scope.launch { store.renameProfile(profile.id, newName) }
+            },
+            onDismiss = { profileForRename = null },
+        )
+    }
+
+    // ── Delete confirmation ─────────────────────────────────────────────────
+    profileForDelete?.let { profile ->
+        AlertDialog(
+            onDismissRequest = { profileForDelete = null },
+            containerColor = TacticalSurface,
+            title = { Text("Delete profile?", color = MaterialTheme.colorScheme.onBackground) },
+            text = {
+                Text(
+                    "\"${profile.name}\" will be removed. This doesn't affect your current config.",
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    profileForDelete = null
+                    scope.launch { store.deleteProfile(profile.id) }
+                }) {
+                    Text("Delete", color = Color(0xFFFF5252))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { profileForDelete = null }) {
+                    Text("Cancel", color = TacticalAccent)
+                }
+            },
+        )
+    }
+
+    // ── QR scanner ──────────────────────────────────────────────────────────
+    if (showScanner) {
+        QrScannerDialog(
+            onScanned = { uri ->
+                val profile = runCatching { ProfileQrCodec.decode(uri) }.getOrNull()
+                if (profile != null) {
+                    importCandidate = profile
+                }
+                showScanner = false
+            },
+            onDismiss = { showScanner = false },
+        )
+    }
+
+    // ── Import preview/confirm dialog ───────────────────────────────────────
+    importCandidate?.let { candidate ->
+        ImportPreviewDialog(
+            profile = candidate,
+            onConfirm = {
+                importCandidate = null
+                scope.launch {
+                    store.saveProfile(candidate)
+                    store.apply(candidate)
+                }
+            },
+            onDismiss = { importCandidate = null },
+        )
+    }
+}
+
+// ── Profile row ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun ProfileRow(
+    profile: ConfigProfile,
+    isActive: Boolean,
+    onSwitch: () -> Unit,
+    onGenerateQr: () -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = if (isActive) TacticalAccent.copy(alpha = 0.15f) else TacticalSurface,
+        ),
+        shape = RoundedCornerShape(10.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onSwitch),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (isActive) {
+                        Icon(Icons.Filled.Check, contentDescription = null, tint = TacticalAccent, modifier = Modifier.size(16.dp))
+                        Spacer(Modifier.width(4.dp))
+                    }
+                    Text(profile.name, color = MaterialTheme.colorScheme.onBackground, fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal)
+                }
+                Text(
+                    buildString {
+                        append("Team ${profile.team}")
+                        if (profile.servers.isNotEmpty()) append(" · ${profile.servers.size} server${if (profile.servers.size != 1) "s" else ""}")
+                    },
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            IconButton(onClick = onGenerateQr) {
+                Icon(Icons.Filled.QrCode, contentDescription = "Generate QR", tint = TacticalAccent)
+            }
+            IconButton(onClick = onRename) {
+                Icon(Icons.Filled.Edit, contentDescription = "Rename", tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f))
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Filled.Delete, contentDescription = "Delete", tint = Color(0xFFFF5252).copy(alpha = 0.8f))
+            }
+        }
+    }
+}
+
+// ── Snapshot dialog ──────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SnapshotDialog(onConfirm: (String) -> Unit, onDismiss: () -> Unit) {
+    var name by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = TacticalSurface,
+        title = { Text("Save current config", color = MaterialTheme.colorScheme.onBackground) },
+        text = {
+            Column {
+                Text(
+                    "Name this profile so teammates know what it's for (e.g. \"Alpha Team\").",
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(bottom = 12.dp),
+                )
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Profile name") },
+                    singleLine = true,
+                    colors = TextFieldDefaults.colors(
+                        focusedTextColor = MaterialTheme.colorScheme.onBackground,
+                        unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+                        focusedContainerColor = TacticalSurface,
+                        unfocusedContainerColor = TacticalSurface,
+                        focusedIndicatorColor = TacticalAccent,
+                        unfocusedIndicatorColor = TacticalAccent.copy(alpha = 0.4f),
+                        focusedLabelColor = TacticalAccent,
+                        unfocusedLabelColor = TacticalAccent.copy(alpha = 0.6f),
+                        cursorColor = TacticalAccent,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = name.isNotBlank(),
+                onClick = { onConfirm(name.trim()) },
+            ) { Text("Save", color = if (name.isNotBlank()) TacticalAccent else TacticalAccent.copy(alpha = 0.4f)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel", color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)) }
+        },
+    )
+}
+
+// ── Rename dialog ────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RenameDialog(current: String, onConfirm: (String) -> Unit, onDismiss: () -> Unit) {
+    var name by remember { mutableStateOf(current) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = TacticalSurface,
+        title = { Text("Rename profile", color = MaterialTheme.colorScheme.onBackground) },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Profile name") },
+                singleLine = true,
+                colors = TextFieldDefaults.colors(
+                    focusedTextColor = MaterialTheme.colorScheme.onBackground,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+                    focusedContainerColor = TacticalSurface,
+                    unfocusedContainerColor = TacticalSurface,
+                    focusedIndicatorColor = TacticalAccent,
+                    unfocusedIndicatorColor = TacticalAccent.copy(alpha = 0.4f),
+                    focusedLabelColor = TacticalAccent,
+                    unfocusedLabelColor = TacticalAccent.copy(alpha = 0.6f),
+                    cursorColor = TacticalAccent,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(
+                enabled = name.isNotBlank() && name != current,
+                onClick = { onConfirm(name.trim()) },
+            ) { Text("Rename", color = if (name.isNotBlank()) TacticalAccent else TacticalAccent.copy(alpha = 0.4f)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel", color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)) }
+        },
+    )
+}
+
+// ── QR display dialog ────────────────────────────────────────────────────────
+
+@Composable
+private fun QrDialog(profile: ConfigProfile, onDismiss: () -> Unit) {
+    var bitmap by remember { mutableStateOf<Bitmap?>(null) }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(profile.id) {
+        bitmap = withContext(Dispatchers.Default) {
+            ProfileQrGenerator.generate(profile, sizePx = 512)
+        }
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(16.dp))
+                .background(TacticalSurface)
+                .padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                profile.name,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Teammates scan this to sync your config.\nCallsigns are kept individual.",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            val bmp = bitmap
+            if (bmp == null) {
+                CircularProgressIndicator(color = TacticalAccent, modifier = Modifier.size(80.dp))
+            } else {
+                Image(
+                    bitmap = bmp.asImageBitmap(),
+                    contentDescription = "QR code for ${profile.name}",
+                    modifier = Modifier
+                        .size(260.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color.White)
+                        .padding(8.dp),
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Text(
+                "Team ${profile.team} · ${profile.servers.size} server${if (profile.servers.size != 1) "s" else ""}",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(Modifier.height(12.dp))
+            TextButton(onClick = onDismiss) {
+                Text("Done", color = TacticalAccent, fontWeight = FontWeight.SemiBold)
+            }
+        }
+    }
+}
+
+// ── QR scanner dialog ────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalGetImage::class)
+@Composable
+private fun QrScannerDialog(
+    onScanned: (android.net.Uri) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Camera permission gate
+    var cameraGranted by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+    val permLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        cameraGranted = granted
+    }
+    LaunchedEffect(Unit) {
+        if (!cameraGranted) permLauncher.launch(Manifest.permission.CAMERA)
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(16.dp))
+                .background(TacticalSurface)
+                .padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                "Scan team QR code",
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(Modifier.height(12.dp))
+
+            if (!cameraGranted) {
+                Text(
+                    "Camera permission required to scan QR codes.",
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            } else {
+                val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
+                val executor = remember { Executors.newSingleThreadExecutor() }
+                var scanned by remember { mutableStateOf(false) }
+                val barcodeScanner = remember { BarcodeScanning.getClient() }
+
+                DisposableEffect(Unit) {
+                    onDispose {
+                        barcodeScanner.close()
+                        executor.shutdown()
+                    }
+                }
+
+                Box(
+                    modifier = Modifier
+                        .size(260.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color.Black),
+                ) {
+                    AndroidView(
+                        factory = { ctx ->
+                            val previewView = PreviewView(ctx)
+                            cameraProviderFuture.addListener({
+                                val provider = cameraProviderFuture.get()
+                                val preview = Preview.Builder().build().also {
+                                    it.surfaceProvider = previewView.surfaceProvider
+                                }
+                                val analysis = ImageAnalysis.Builder()
+                                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                                    .build()
+                                analysis.setAnalyzer(executor) { imageProxy ->
+                                    if (scanned) { imageProxy.close(); return@setAnalyzer }
+                                    val mediaImage = imageProxy.image
+                                    if (mediaImage != null) {
+                                        val inputImage = InputImage.fromMediaImage(
+                                            mediaImage,
+                                            imageProxy.imageInfo.rotationDegrees,
+                                        )
+                                        barcodeScanner.process(inputImage)
+                                            .addOnSuccessListener { barcodes ->
+                                                val qr = barcodes.firstOrNull { it.format == Barcode.FORMAT_QR_CODE }
+                                                val raw = qr?.rawValue
+                                                if (!raw.isNullOrBlank() && !scanned) {
+                                                    val uri = runCatching { android.net.Uri.parse(raw) }.getOrNull()
+                                                    if (uri != null && ProfileQrCodec.isProfileUri(uri)) {
+                                                        scanned = true
+                                                        onScanned(uri)
+                                                    }
+                                                }
+                                            }
+                                            .addOnCompleteListener { imageProxy.close() }
+                                    } else {
+                                        imageProxy.close()
+                                    }
+                                }
+                                runCatching {
+                                    provider.unbindAll()
+                                    provider.bindToLifecycle(
+                                        lifecycleOwner,
+                                        CameraSelector.DEFAULT_BACK_CAMERA,
+                                        preview,
+                                        analysis,
+                                    )
+                                }.onFailure { Log.e(TAG, "CameraX bind failed", it) }
+                            }, ContextCompat.getMainExecutor(ctx))
+                            previewView
+                        },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Point at an OmniTAK team QR code",
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+            TextButton(onClick = onDismiss) {
+                Text("Cancel", color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f))
+            }
+        }
+    }
+}
+
+// ── Import preview dialog ─────────────────────────────────────────────────────
+
+@Composable
+private fun ImportPreviewDialog(
+    profile: ConfigProfile,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = TacticalSurface,
+        title = { Text("Import config profile?", color = MaterialTheme.colorScheme.onBackground) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                Text(
+                    profile.name,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.SemiBold,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                Spacer(Modifier.height(8.dp))
+                ProfileDetailRow("Team", profile.team)
+                ProfileDetailRow("Servers", "${profile.servers.size} server${if (profile.servers.size != 1) "s" else ""}")
+                if (profile.servers.isNotEmpty()) {
+                    profile.servers.forEach { server ->
+                        Text(
+                            "  · ${server.name} (${server.host}:${server.port})",
+                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
+                ProfileDetailRow("Map", profile.mapProvider.replace("_", " ").lowercase().replaceFirstChar { it.titlecase() })
+                ProfileDetailRow("Coords", profile.coordFormat.replace("_", " "))
+                ProfileDetailRow("Units", profile.distanceUnit.lowercase().replaceFirstChar { it.titlecase() })
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Your callsign will not be changed. Servers that already exist won't be duplicated.",
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text("Import & Apply", color = TacticalAccent, fontWeight = FontWeight.SemiBold) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel", color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)) }
+        },
+    )
+}
+
+@Composable
+private fun ProfileDetailRow(label: String, value: String) {
+    Row(modifier = Modifier.padding(vertical = 2.dp)) {
+        Text(
+            "$label: ",
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(value, color = MaterialTheme.colorScheme.onBackground, style = MaterialTheme.typography.bodySmall)
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ProfilesScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ProfilesScreen.kt
@@ -643,7 +643,7 @@ private fun QrScannerDialog(
 // ── Import preview dialog ─────────────────────────────────────────────────────
 
 @Composable
-private fun ImportPreviewDialog(
+internal fun ImportPreviewDialog(
     profile: ConfigProfile,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -62,6 +62,7 @@ import soy.engindearing.omnitak.mobile.data.DistanceUnit
 import soy.engindearing.omnitak.mobile.data.MapProvider
 import soy.engindearing.omnitak.mobile.data.UserPrefs
 import soy.engindearing.omnitak.mobile.domain.ConnectionState
+import androidx.compose.material.icons.filled.ManageAccounts
 import soy.engindearing.omnitak.mobile.ui.components.GybDeviceSheet
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
@@ -74,6 +75,7 @@ fun SettingsScreen(
     onOpenAbout: () -> Unit = {},
     onOpenPlugins: (pluginId: String) -> Unit = {},
     onOpenPluginsList: () -> Unit = {},
+    onOpenProfiles: () -> Unit = {},
 ) {
     val app = LocalContext.current.applicationContext as OmniTAKApp
     val prefs by app.userPrefsStore.prefs.collectAsState(initial = UserPrefs())
@@ -127,6 +129,47 @@ fun SettingsScreen(
                 value = prefs.team,
                 onSelect = { v -> mutate { it.copy(team = v) } },
             )
+
+            // ── Configuration Profiles ──────────────────────────────────────
+            // Profiles let a captain snapshot their config and share it with
+            // teammates via a QR code (omnitak://profile?d=…). Active profile
+            // name is shown as a subtitle so the operator knows which one they're
+            // running.
+            SectionHeader("Configuration Profiles")
+            val activeProfileId by app.configProfileStore.activeProfileId.collectAsState(initial = null)
+            val allProfiles by app.configProfileStore.profiles.collectAsState(initial = emptyList())
+            val activeProfileName = allProfiles.firstOrNull { it.id == activeProfileId }?.name
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable { onOpenProfiles() }
+                    .padding(vertical = 10.dp, horizontal = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Filled.ManageAccounts,
+                    contentDescription = null,
+                    tint = TacticalAccent,
+                    modifier = Modifier.size(22.dp),
+                )
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Manage profiles", color = MaterialTheme.colorScheme.onBackground)
+                    Text(
+                        if (activeProfileName != null) "Active: $activeProfileName"
+                        else if (allProfiles.isEmpty()) "No profiles saved yet"
+                        else "${allProfiles.size} profile${if (allProfiles.size != 1) "s" else ""} saved",
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Icon(
+                    Icons.Filled.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                )
+            }
 
             SectionHeader(Loc.t("settings.section.interface"))
             Row(

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -63,6 +63,7 @@ import soy.engindearing.omnitak.mobile.data.MapProvider
 import soy.engindearing.omnitak.mobile.data.UserPrefs
 import soy.engindearing.omnitak.mobile.domain.ConnectionState
 import androidx.compose.material.icons.filled.ManageAccounts
+import androidx.compose.material3.Icon
 import soy.engindearing.omnitak.mobile.ui.components.GybDeviceSheet
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfileTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfileTest.kt
@@ -1,0 +1,265 @@
+package soy.engindearing.omnitak.mobile.data
+
+import android.net.Uri
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [ConfigProfile] serialization, [ProfileQrCodec] round-trip,
+ * and [ProfileServer] secret-stripping.
+ *
+ * JVM-only (no Android context needed): ProfileQrCodec uses
+ * [java.util.Base64] (available on JVM 8+) and stock java.util.zip.
+ * [android.net.Uri] from the `org.robolectric:robolectric` jar would be
+ * needed for Uri.parse in a real device test; here we test the raw
+ * encode/decode helpers without Uri.
+ */
+class ConfigProfileTest {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    // ── ConfigProfile serialization ───────────────────────────────────────
+
+    @Test
+    fun profileSerializationRoundTrip() {
+        val profile = ConfigProfile(
+            id = "test-id",
+            name = "Alpha Team",
+            team = "Cyan",
+            servers = listOf(
+                ProfileServer(
+                    id = "srv1",
+                    name = "TAK HQ",
+                    host = "tak.example.com",
+                    port = 8089,
+                    protocol = "tls",
+                    useTLS = true,
+                    username = "operator",
+                    // No password field in ProfileServer — by design.
+                )
+            ),
+            enrollmentPointer = EnrollmentPointer(
+                host = "tak.example.com",
+                enrollmentPort = 8446,
+                username = "operator",
+                trustSelfSigned = true,
+            ),
+            mapProvider = MapProvider.TOPO_HINT.name,
+            customTileUrl = "",
+            coordFormat = CoordFormat.MGRS.name,
+            distanceUnit = DistanceUnit.IMPERIAL.name,
+        )
+
+        val encoded = json.encodeToString(ConfigProfile.serializer(), profile)
+        val decoded = json.decodeFromString(ConfigProfile.serializer(), encoded)
+
+        assertEquals(profile.id, decoded.id)
+        assertEquals(profile.name, decoded.name)
+        assertEquals(profile.team, decoded.team)
+        assertEquals(profile.coordFormat, decoded.coordFormat)
+        assertEquals(profile.distanceUnit, decoded.distanceUnit)
+        assertEquals(1, decoded.servers.size)
+        assertEquals("tak.example.com", decoded.servers[0].host)
+        assertEquals(8089, decoded.servers[0].port)
+        assertEquals("operator", decoded.servers[0].username)
+        assertNotNull(decoded.enrollmentPointer)
+        assertEquals(8446, decoded.enrollmentPointer!!.enrollmentPort)
+    }
+
+    @Test
+    fun profileSerializationWithUnknownFieldsIsIgnored() {
+        // Simulate a newer profile version with an extra field — must decode without error.
+        val rawJson = """
+            {
+              "id": "id1",
+              "name": "Beta Team",
+              "team": "Red",
+              "unknownFutureField": 42,
+              "servers": [],
+              "mapProvider": "OSM_RASTER",
+              "customTileUrl": "",
+              "coordFormat": "LATLON_DECIMAL",
+              "distanceUnit": "METRIC",
+              "callsignCardVisible": true,
+              "gridEnabled": false,
+              "drawingsVisible": true,
+              "aircraftVisible": true,
+              "contactsVisible": true,
+              "useMilStdSelfSymbol": true,
+              "autoPublishMeshToTak": true,
+              "broadcastOverMesh": true,
+              "meshBroadcastIntervalSecs": 30,
+              "meshNodesLayerVisible": true
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(ConfigProfile.serializer(), rawJson)
+        assertEquals("Beta Team", decoded.name)
+        assertEquals("Red", decoded.team)
+    }
+
+    // ── ProfileServer secret-stripping ────────────────────────────────────
+
+    @Test
+    fun profileServerFromServerStripsSecrets() {
+        val server = TAKServer(
+            id = "abc",
+            name = "Secure Server",
+            host = "tak.example.com",
+            port = 8089,
+            protocol = "tls",
+            useTLS = true,
+            username = "operator",
+            password = "s3cr3t",
+            certificatePassword = "certpass",
+            certificateName = "client.p12",
+        )
+        val profileServer = ProfileServer.fromServer(server)
+
+        // Secrets must be excluded.
+        assertEquals("operator", profileServer.username)
+        // No password field in ProfileServer — verified at class definition level.
+        assertEquals("abc", profileServer.id)
+        assertEquals("tak.example.com", profileServer.host)
+        assertEquals(8089, profileServer.port)
+        assertTrue(profileServer.useTLS)
+    }
+
+    @Test
+    fun profileServerToServerHasNoSecrets() {
+        val ps = ProfileServer(
+            id = "srv1",
+            name = "TAK Server",
+            host = "tak.mil",
+            port = 8089,
+            protocol = "tls",
+            useTLS = true,
+            username = "operator",
+        )
+        val server = ProfileServer.toServer(ps)
+
+        assertEquals("tak.mil", server.host)
+        assertEquals("operator", server.username)
+        // Secrets must be null — the teammate enrolls their own cert.
+        assertNull("password must not be set on import", server.password)
+        assertNull("certificatePassword must not be set on import", server.certificatePassword)
+        assertNull("certificateName must not be set on import", server.certificateName)
+    }
+
+    // ── ProfileQrCodec round-trip ─────────────────────────────────────────
+
+    @Test
+    fun qrCodecEncodeDecodeRoundTrip() {
+        val profile = ConfigProfile(
+            id = "qr-test",
+            name = "QR Test Profile",
+            team = "Blue",
+            servers = listOf(
+                ProfileServer(
+                    id = "s1",
+                    name = "HQ",
+                    host = "hq.example.org",
+                    port = 8089,
+                    protocol = "tls",
+                    useTLS = true,
+                )
+            ),
+            coordFormat = CoordFormat.MGRS.name,
+            distanceUnit = DistanceUnit.IMPERIAL.name,
+            broadcastOverMesh = false,
+            meshBroadcastIntervalSecs = 45,
+        )
+
+        val uriString = ProfileQrCodec.encode(profile)
+
+        // Payload must start with the correct scheme.
+        assertTrue("Expected omnitak://profile URI, got: $uriString",
+            uriString.startsWith("omnitak://profile?d="))
+
+        // Decode via the string overload (JVM-safe).
+        val decoded = ProfileQrCodec.decode(uriString)
+
+        assertNotNull("Decoded profile must not be null", decoded)
+        assertEquals(profile.id, decoded!!.id)
+        assertEquals(profile.name, decoded.name)
+        assertEquals(profile.team, decoded.team)
+        assertEquals(profile.coordFormat, decoded.coordFormat)
+        assertEquals(profile.distanceUnit, decoded.distanceUnit)
+        assertEquals(false, decoded.broadcastOverMesh)
+        assertEquals(45, decoded.meshBroadcastIntervalSecs)
+        assertEquals(1, decoded.servers.size)
+        assertEquals("hq.example.org", decoded.servers[0].host)
+    }
+
+    @Test
+    fun qrCodecEncodedPayloadIsReasonablySmall() {
+        // A profile with 3 servers should still produce a QR-friendly payload
+        // (< 2048 bytes in the URI string).
+        val profile = ConfigProfile(
+            name = "Large Team Profile",
+            team = "Dark Blue",
+            servers = (1..3).map { i ->
+                ProfileServer(
+                    id = "server-$i",
+                    name = "TAK Server $i",
+                    host = "tak$i.example.com",
+                    port = 8089,
+                    protocol = "tls",
+                    useTLS = true,
+                    username = "operator$i",
+                )
+            },
+            enrollmentPointer = EnrollmentPointer("tak1.example.com", 8446, username = "operator1"),
+        )
+        val uriString = ProfileQrCodec.encode(profile)
+        assertTrue(
+            "QR URI too large for reliable scanning: ${uriString.length} bytes (limit 2048)",
+            uriString.length < 2048,
+        )
+    }
+
+    @Test
+    fun qrCodecRejectsNonProfileUri() {
+        val decoded = ProfileQrCodec.decode("omnitak://server?host=tak.example.com&port=8089")
+        assertNull("Non-profile URI must decode to null", decoded)
+    }
+
+    @Test
+    fun qrCodecRejectsGarbageInput() {
+        val decoded = ProfileQrCodec.decode("not-a-uri-at-all!!!")
+        assertNull("Garbage input must decode to null", decoded)
+    }
+
+    @Test
+    fun qrCodecRejectsProfileUriWithCorruptPayload() {
+        val decoded = ProfileQrCodec.decode("omnitak://profile?d=NOTVALIDBASE64!!!")
+        assertNull("Corrupt payload must decode to null", decoded)
+    }
+
+    // ── isProfileUri checks ───────────────────────────────────────────────
+
+    @Test
+    fun isProfileUriReturnsFalseForNull() {
+        assertFalse(ProfileQrCodec.isProfileUri(null))
+    }
+
+    @Test
+    fun isProfileUriReturnsTrueForValidUri() {
+        val profile = ConfigProfile(name = "Test", team = "Green")
+        val uriString = ProfileQrCodec.encode(profile)
+        // Parse the URI string to an android.net.Uri for the check.
+        // On JVM, Uri.parse works without robolectric for simple strings
+        // because Android's Uri class is partly JVM-compatible.
+        // If this fails on pure JVM, the test will throw — acceptable since
+        // the real test coverage comes from the encode/decode tests above.
+        val uri = runCatching { android.net.Uri.parse(uriString) }.getOrNull()
+        if (uri != null) {
+            assertTrue(ProfileQrCodec.isProfileUri(uri))
+        }
+        // If Uri.parse throws on JVM (stubs), we skip this particular assertion.
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfileTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/ConfigProfileTest.kt
@@ -8,6 +8,9 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPOutputStream
+import java.util.Base64
 
 /**
  * Unit tests for [ConfigProfile] serialization, [ProfileQrCodec] round-trip,
@@ -39,14 +42,13 @@ class ConfigProfileTest {
                     port = 8089,
                     protocol = "tls",
                     useTLS = true,
-                    username = "operator",
-                    // No password field in ProfileServer — by design.
+                    // No username / password field in ProfileServer — by design (PII + secret).
                 )
             ),
             enrollmentPointer = EnrollmentPointer(
                 host = "tak.example.com",
                 enrollmentPort = 8446,
-                username = "operator",
+                // No username — PII excluded per security contract.
                 trustSelfSigned = true,
             ),
             mapProvider = MapProvider.TOPO_HINT.name,
@@ -66,7 +68,7 @@ class ConfigProfileTest {
         assertEquals(1, decoded.servers.size)
         assertEquals("tak.example.com", decoded.servers[0].host)
         assertEquals(8089, decoded.servers[0].port)
-        assertEquals("operator", decoded.servers[0].username)
+        // username is intentionally excluded from ProfileServer (PII).
         assertNotNull(decoded.enrollmentPointer)
         assertEquals(8446, decoded.enrollmentPointer!!.enrollmentPort)
     }
@@ -120,9 +122,9 @@ class ConfigProfileTest {
         )
         val profileServer = ProfileServer.fromServer(server)
 
-        // Secrets must be excluded.
-        assertEquals("operator", profileServer.username)
-        // No password field in ProfileServer — verified at class definition level.
+        // Secrets + PII must be excluded.
+        // No username field in ProfileServer — verified at class definition level.
+        // No password field in ProfileServer — by design.
         assertEquals("abc", profileServer.id)
         assertEquals("tak.example.com", profileServer.host)
         assertEquals(8089, profileServer.port)
@@ -138,12 +140,13 @@ class ConfigProfileTest {
             port = 8089,
             protocol = "tls",
             useTLS = true,
-            username = "operator",
+            // username not included — PII excluded from ProfileServer.
         )
         val server = ProfileServer.toServer(ps)
 
         assertEquals("tak.mil", server.host)
-        assertEquals("operator", server.username)
+        // username is null — not propagated from profile (PII excluded).
+        assertNull("username must not be set on import", server.username)
         // Secrets must be null — the teammate enrolls their own cert.
         assertNull("password must not be set on import", server.password)
         assertNull("certificatePassword must not be set on import", server.certificatePassword)
@@ -166,6 +169,7 @@ class ConfigProfileTest {
                     port = 8089,
                     protocol = "tls",
                     useTLS = true,
+                    // No username — PII excluded from ProfileServer.
                 )
             ),
             coordFormat = CoordFormat.MGRS.name,
@@ -210,10 +214,10 @@ class ConfigProfileTest {
                     port = 8089,
                     protocol = "tls",
                     useTLS = true,
-                    username = "operator$i",
+                    // No username — PII excluded from ProfileServer.
                 )
             },
-            enrollmentPointer = EnrollmentPointer("tak1.example.com", 8446, username = "operator1"),
+            enrollmentPointer = EnrollmentPointer("tak1.example.com", 8446),
         )
         val uriString = ProfileQrCodec.encode(profile)
         assertTrue(
@@ -245,6 +249,80 @@ class ConfigProfileTest {
     @Test
     fun isProfileUriReturnsFalseForNull() {
         assertFalse(ProfileQrCodec.isProfileUri(null))
+    }
+
+    // ── Gzip-bomb guard ─────────────────────────────────────────────────────
+
+    /**
+     * A hostile QR can embed a gzip stream that decompresses to many megabytes
+     * (gzip bomb). [ProfileQrCodec.decode] must reject payloads that decompress
+     * beyond the 64 KiB cap rather than OOM the app.
+     */
+    @Test
+    fun qrCodecRejectsOversizedPayload() {
+        // Build a gzip stream whose decompressed size is > 64 KiB (just under
+        // 1 MB of repeating bytes) and encode it as a fake profile URI.
+        val bigData = ByteArray(1_024 * 1_024) { 0x41 } // 1 MB of 'A'
+        val bos = ByteArrayOutputStream()
+        GZIPOutputStream(bos).use { it.write(bigData) }
+        val b64 = Base64.getUrlEncoder().withoutPadding().encodeToString(bos.toByteArray())
+        val uriStr = "omnitak://profile?d=$b64"
+
+        // decode() wraps in runCatching and returns null on any error —
+        // the gzip-bomb guard throws inside gunzip, which is caught.
+        val decoded = ProfileQrCodec.decode(uriStr)
+        assertNull("Oversized QR payload must decode to null (gzip-bomb guard)", decoded)
+    }
+
+    // ── No-secrets regression test ───────────────────────────────────────────
+
+    /**
+     * Asserts that [ConfigProfileStore.snapshotCurrent] (via [ProfileQrCodec.encode])
+     * produces a QR payload that contains NO password, cert passphrase, cert blob,
+     * or username (PII). This locks the security contract in code.
+     */
+    @Test
+    fun snapshotCurrentQrContainsNoSecrets() {
+        // Build a TAKServer carrying every secret field.
+        val server = TAKServer(
+            id = "srv-secret-test",
+            name = "Secure HQ",
+            host = "tak.mil",
+            port = 8089,
+            protocol = "tls",
+            useTLS = true,
+            username = "operator42",
+            password = "hunter2",
+            certificatePassword = "certPass123",
+            certificateName = "client.p12",
+        )
+
+        // Simulate what snapshotCurrent builds: ProfileServer.fromServer strips secrets.
+        val profileServer = ProfileServer.fromServer(server)
+        val enrollmentPointer = EnrollmentPointer(
+            host = server.host,
+            enrollmentPort = 8446,
+            // username intentionally omitted per Fix 11.
+        )
+        val profile = ConfigProfile(
+            id = "sec-test",
+            name = "Security Regression",
+            servers = listOf(profileServer),
+            enrollmentPointer = enrollmentPointer,
+        )
+
+        val uriStr = ProfileQrCodec.encode(profile)
+
+        // Decode and re-serialize to get the raw JSON for content inspection.
+        val decoded = ProfileQrCodec.decode(uriStr)
+        assertNotNull("Profile must decode successfully", decoded)
+        val rawJson = Json { encodeDefaults = true }
+            .encodeToString(ConfigProfile.serializer(), decoded!!)
+
+        assertFalse("QR must not contain password 'hunter2'", rawJson.contains("hunter2"))
+        assertFalse("QR must not contain cert password 'certPass123'", rawJson.contains("certPass123"))
+        assertFalse("QR must not contain cert blob 'client.p12'", rawJson.contains("client.p12"))
+        assertFalse("QR must not contain username 'operator42'", rawJson.contains("operator42"))
     }
 
     @Test

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreFrameCodecTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreFrameCodecTest.kt
@@ -135,6 +135,48 @@ class MeshCoreFrameCodecTest {
         assertEquals(100, MeshCoreFrameCodec.batteryMvToPercent(4300))
     }
 
+    // ---- DECODE: device info -------------------------------------------
+
+    @Test fun `decode device info 0x0D minimal frame`() {
+        // [0]=0x0D [1]=fwCode [2]=maxContactsHalf [3]=maxChannels
+        val pkt = byteArrayOf(0x0D, 0x02, 0x20, 0x04) // fwCode=2, contacts=64, channels=4
+        val d = MeshCoreFrameCodec.decode(pkt)
+        assertTrue("Expected DeviceInfo, got: $d", d is MeshCoreFrameCodec.Decoded.DeviceInfo)
+        d as MeshCoreFrameCodec.Decoded.DeviceInfo
+        assertEquals(2, d.fwCode)
+        assertEquals(64, d.maxContacts)
+        assertEquals(4, d.maxChannels)
+        assertEquals("", d.manufacturer) // short frame — no manufacturer
+        assertEquals("", d.version)
+    }
+
+    @Test fun `decode device info 0x0D full frame parses manufacturer and version`() {
+        // Full layout: [0]=code [1]=fwCode [2]=maxContactsHalf [3]=maxChannels
+        // [20..59]=manufacturer(40B) [60..79]=version(20B) => need at least 80 bytes
+        val pkt = ByteArray(80)
+        pkt[0] = 0x0D
+        pkt[1] = 0x03 // fwCode
+        pkt[2] = 0x10 // maxContacts/2 = 16 → 32 contacts
+        pkt[3] = 0x08 // maxChannels
+        val mfg = "TestMaker".toByteArray(StandardCharsets.UTF_8)
+        val ver = "1.16.0".toByteArray(StandardCharsets.UTF_8)
+        System.arraycopy(mfg, 0, pkt, 20, mfg.size)
+        System.arraycopy(ver, 0, pkt, 60, ver.size)
+        val d = MeshCoreFrameCodec.decode(pkt)
+        assertTrue(d is MeshCoreFrameCodec.Decoded.DeviceInfo)
+        d as MeshCoreFrameCodec.Decoded.DeviceInfo
+        assertEquals(3, d.fwCode)
+        assertEquals(32, d.maxContacts)
+        assertEquals(8, d.maxChannels)
+        assertEquals("TestMaker", d.manufacturer)
+        assertEquals("1.16.0", d.version)
+    }
+
+    @Test fun `decode device info 0x0D too short returns unhandled`() {
+        val d = MeshCoreFrameCodec.decode(byteArrayOf(0x0D, 0x01))
+        assertTrue("Expected Unhandled, got: $d", d is MeshCoreFrameCodec.Decoded.Unhandled)
+    }
+
     // ---- DECODE: contact/advert ----------------------------------------
 
     /**
@@ -181,8 +223,8 @@ class MeshCoreFrameCodecTest {
         d as MeshCoreFrameCodec.Decoded.Contact
         assertEquals(false, d.isRepeater)
         assertEquals("ALPHA", d.node.longName)
-        // node id = first 4 bytes BE of pubkey: 01 02 03 04
-        assertEquals(0x01020304L, d.node.id)
+        // node id = first 6 bytes BE of pubkey: 01 02 03 04 05 06
+        assertEquals(0x010203040506L, d.node.id)
         val pos = d.node.position
         assertNotNull("advert with non-zero lat/lon must produce a position", pos)
         assertEquals(47.6588, pos!!.lat, 1e-6)
@@ -293,9 +335,12 @@ class MeshCoreFrameCodecTest {
 
     // ---- pubkey helpers -------------------------------------------------
 
-    @Test fun `nodeId from pubkey is first 4 bytes big-endian`() {
-        assertEquals(0xDEADBEEFL, MeshCoreFrameCodec.nodeIdFromPubKey("deadbeef0011"))
+    @Test fun `nodeId from pubkey is first 6 bytes big-endian`() {
+        // deadbeef0011 = 6 bytes → 0xDEADBEEF0011L
+        assertEquals(0xDEADBEEF0011L, MeshCoreFrameCodec.nodeIdFromPubKey("deadbeef0011"))
+        // Short pubkey returns 0
         assertEquals(0L, MeshCoreFrameCodec.nodeIdFromPubKey("aa")) // too short
+        assertEquals(0L, MeshCoreFrameCodec.nodeIdFromPubKey("deadbeef")) // 4 bytes = still short
     }
 
     @Test fun `pubkey prefix bytes`() {

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreFrameCodecTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreFrameCodecTest.kt
@@ -1,0 +1,311 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Unit tests for [MeshCoreFrameCodec] — the MeshCore companion BLE
+ * protocol encode/decode, ported from the TAK-MeshCore ATAK plugin's
+ * `BtConnectionManager.java`. Builds frames byte-for-byte to the
+ * reference layout and verifies round-trips. No Android deps.
+ */
+class MeshCoreFrameCodecTest {
+
+    // ---- ENCODE ---------------------------------------------------------
+
+    @Test fun `app_start has code at 0 and app id at offset 8`() {
+        val out = MeshCoreFrameCodec.buildAppStart("meshcore-flutter")
+        assertEquals(0x01.toByte(), out[0])
+        // bytes 1..7 reserved-zero
+        for (i in 1..7) assertEquals("byte $i must be 0", 0.toByte(), out[i])
+        val id = String(out, 8, out.size - 8, StandardCharsets.UTF_8)
+        assertEquals("meshcore-flutter", id)
+    }
+
+    @Test fun `get_next_message is single 0x0A byte`() {
+        assertTrue(MeshCoreFrameCodec.buildGetNextMessage().contentEquals(byteArrayOf(0x0A)))
+    }
+
+    @Test fun `device_query is 0x16 0x03`() {
+        assertTrue(MeshCoreFrameCodec.buildDeviceQuery().contentEquals(byteArrayOf(0x16, 0x03)))
+    }
+
+    @Test fun `get_battery is single 0x14 byte`() {
+        assertTrue(MeshCoreFrameCodec.buildGetBattery().contentEquals(byteArrayOf(0x14)))
+    }
+
+    @Test fun `send_self_advert is single 0x07 byte`() {
+        assertTrue(MeshCoreFrameCodec.buildSendSelfAdvert().contentEquals(byteArrayOf(0x07)))
+    }
+
+    @Test fun `set_advert_latlon encodes E6 little-endian lat lon alt`() {
+        val lat = 47.6588
+        val lon = -117.4260
+        val out = MeshCoreFrameCodec.buildSetAdvertLatLon(lat, lon, 600.0)
+        assertNotNull(out)
+        out!!
+        assertEquals("13-byte frame", 13, out.size)
+        assertEquals(0x0E.toByte(), out[0])
+        val bb = ByteBuffer.wrap(out).order(ByteOrder.LITTLE_ENDIAN)
+        assertEquals(Math.round(lat * 1_000_000.0).toInt(), bb.getInt(1))
+        assertEquals(Math.round(lon * 1_000_000.0).toInt(), bb.getInt(5))
+        assertEquals(600, bb.getInt(9))
+    }
+
+    @Test fun `set_advert_latlon rejects out of range`() {
+        assertNull(MeshCoreFrameCodec.buildSetAdvertLatLon(91.0, 0.0))
+        assertNull(MeshCoreFrameCodec.buildSetAdvertLatLon(0.0, 181.0))
+        assertNull(MeshCoreFrameCodec.buildSetAdvertLatLon(Double.NaN, 0.0))
+    }
+
+    @Test fun `send_txt_msg frames code type attempt ts prefix text`() {
+        val pub = "1a2b3c4d5e6f0011" // 8 bytes hex; first 6 used as prefix
+        val out = MeshCoreFrameCodec.buildSendTxtMsg(pub, "hi", nowSec = 0x01020304)
+        assertNotNull(out)
+        out!!
+        assertEquals(0x02.toByte(), out[0]) // CMD_SEND_TXT_MSG
+        assertEquals(0x00.toByte(), out[1]) // TXT_TYPE_PLAIN
+        assertEquals(0x00.toByte(), out[2]) // attempt
+        val ts = ByteBuffer.wrap(out, 3, 4).order(ByteOrder.LITTLE_ENDIAN).int
+        assertEquals(0x01020304, ts)
+        // prefix is first 6 bytes of the pubkey
+        val expectedPrefix = byteArrayOf(0x1a, 0x2b, 0x3c, 0x4d, 0x5e, 0x6f)
+        val gotPrefix = out.copyOfRange(7, 13)
+        assertTrue(expectedPrefix.contentEquals(gotPrefix))
+        val text = String(out, 13, out.size - 13, StandardCharsets.UTF_8)
+        assertEquals("hi", text)
+    }
+
+    @Test fun `send_txt_msg rejects short pubkey`() {
+        assertNull(MeshCoreFrameCodec.buildSendTxtMsg("abcd", "x"))
+    }
+
+    // ---- DECODE: control codes -----------------------------------------
+
+    @Test fun `decode messages_waiting`() {
+        assertEquals(
+            MeshCoreFrameCodec.Decoded.MessagesWaiting,
+            MeshCoreFrameCodec.decode(byteArrayOf(0x83.toByte())),
+        )
+    }
+
+    @Test fun `decode no_more_messages`() {
+        assertEquals(
+            MeshCoreFrameCodec.Decoded.NoMoreMessages,
+            MeshCoreFrameCodec.decode(byteArrayOf(0x0A)),
+        )
+    }
+
+    @Test fun `decode empty or null returns null`() {
+        assertNull(MeshCoreFrameCodec.decode(null))
+        assertNull(MeshCoreFrameCodec.decode(ByteArray(0)))
+    }
+
+    // ---- DECODE: battery -----------------------------------------------
+
+    @Test fun `decode battery resp 0x0C`() {
+        // 4000 mV = 0x0FA0 -> LE [A0, 0F]
+        val pkt = byteArrayOf(0x0C, 0xA0.toByte(), 0x0F)
+        val d = MeshCoreFrameCodec.decode(pkt)
+        assertTrue(d is MeshCoreFrameCodec.Decoded.Battery)
+        d as MeshCoreFrameCodec.Decoded.Battery
+        assertEquals(4000, d.milliVolts)
+        // (4000-3300)/(4200-3300) = 700/900 ~= 78%
+        assertEquals(78, d.percent)
+    }
+
+    @Test fun `decode stats core battery 0x18`() {
+        // type=0x00, 3700 mV = 0x0E74 -> LE [74,0E]
+        val pkt = byteArrayOf(0x18, 0x00, 0x74, 0x0E)
+        val d = MeshCoreFrameCodec.decode(pkt)
+        assertTrue(d is MeshCoreFrameCodec.Decoded.Battery)
+        d as MeshCoreFrameCodec.Decoded.Battery
+        assertEquals(3700, d.milliVolts)
+    }
+
+    @Test fun `battery mv to percent clamps`() {
+        assertEquals(-1, MeshCoreFrameCodec.batteryMvToPercent(0))
+        assertEquals(0, MeshCoreFrameCodec.batteryMvToPercent(3000))
+        assertEquals(100, MeshCoreFrameCodec.batteryMvToPercent(4300))
+    }
+
+    // ---- DECODE: contact/advert ----------------------------------------
+
+    /**
+     * Build an advert/contact frame to the companion-radio upstream layout:
+     *  [0]=code [1..32]=pubkey [33]=advType [100..131]=name(null-padded)
+     *  [132..135]=ts(LE) [136..139]=latE6(LE) [140..143]=lonE6(LE).
+     */
+    private fun buildAdvertFrame(
+        code: Byte,
+        pubKey: ByteArray,
+        advType: Int,
+        name: String,
+        tsSec: Int,
+        latE6: Int,
+        lonE6: Int,
+        size: Int = 144,
+    ): ByteArray {
+        val pkt = ByteArray(size)
+        pkt[0] = code
+        System.arraycopy(pubKey, 0, pkt, 1, minOf(32, pubKey.size))
+        pkt[33] = advType.toByte()
+        val nameBytes = name.toByteArray(StandardCharsets.UTF_8)
+        System.arraycopy(nameBytes, 0, pkt, 100, minOf(32, nameBytes.size))
+        val bb = ByteBuffer.wrap(pkt).order(ByteOrder.LITTLE_ENDIAN)
+        bb.putInt(132, tsSec)
+        bb.putInt(136, latE6)
+        bb.putInt(140, lonE6)
+        return pkt
+    }
+
+    @Test fun `decode advert with position yields contact node`() {
+        val pub = ByteArray(32) { (it + 1).toByte() } // 01 02 03 04 ...
+        val frame = buildAdvertFrame(
+            code = 0x80.toByte(),
+            pubKey = pub,
+            advType = 0x01, // not repeater
+            name = "ALPHA",
+            tsSec = 1_700_000_000,
+            latE6 = 47_658_800,
+            lonE6 = -117_426_000,
+        )
+        val d = MeshCoreFrameCodec.decode(frame)
+        assertTrue(d is MeshCoreFrameCodec.Decoded.Contact)
+        d as MeshCoreFrameCodec.Decoded.Contact
+        assertEquals(false, d.isRepeater)
+        assertEquals("ALPHA", d.node.longName)
+        // node id = first 4 bytes BE of pubkey: 01 02 03 04
+        assertEquals(0x01020304L, d.node.id)
+        val pos = d.node.position
+        assertNotNull("advert with non-zero lat/lon must produce a position", pos)
+        assertEquals(47.6588, pos!!.lat, 1e-6)
+        assertEquals(-117.426, pos.lon, 1e-6)
+        assertEquals(1_700_000_000L, d.node.lastHeardEpoch)
+    }
+
+    @Test fun `decode advert with zero position has no position`() {
+        val pub = ByteArray(32) { 0x10.toByte() }
+        val frame = buildAdvertFrame(
+            code = 0x80.toByte(),
+            pubKey = pub,
+            advType = 0x01,
+            name = "NOFIX",
+            tsSec = 1_700_000_000,
+            latE6 = 0,
+            lonE6 = 0,
+        )
+        val d = MeshCoreFrameCodec.decode(frame) as MeshCoreFrameCodec.Decoded.Contact
+        assertNull("zero lat/lon must not produce a position", d.node.position)
+    }
+
+    @Test fun `decode repeater advert flags isRepeater`() {
+        val pub = ByteArray(32) { 0x20.toByte() }
+        val frame = buildAdvertFrame(
+            code = 0x03, // RESP_CODE_CONTACT
+            pubKey = pub,
+            advType = 0x02, // ADV_TYPE_REPEATER
+            name = "RPT-1",
+            tsSec = 1_700_000_000,
+            latE6 = 47_000_000,
+            lonE6 = -117_000_000,
+        )
+        val d = MeshCoreFrameCodec.decode(frame) as MeshCoreFrameCodec.Decoded.Contact
+        assertTrue(d.isRepeater)
+    }
+
+    @Test fun `decode advert too short returns unhandled`() {
+        val d = MeshCoreFrameCodec.decode(byteArrayOf(0x80.toByte(), 0x01, 0x02))
+        assertTrue(d is MeshCoreFrameCodec.Decoded.Unhandled)
+    }
+
+    // ---- DECODE: self-info ---------------------------------------------
+
+    @Test fun `decode self_info parses pubkey name and position`() {
+        // [0]=0x05 [4..35]=pubkey [36..39]=latE6 [40..43]=lonE6 [58..]=name
+        val name = "MYNODE"
+        val pkt = ByteArray(58 + name.length)
+        pkt[0] = 0x05
+        val pub = ByteArray(32) { (it + 0x40).toByte() }
+        System.arraycopy(pub, 0, pkt, 4, 32)
+        val bb = ByteBuffer.wrap(pkt).order(ByteOrder.LITTLE_ENDIAN)
+        bb.putInt(36, 47_658_800)
+        bb.putInt(40, -117_426_000)
+        System.arraycopy(name.toByteArray(StandardCharsets.UTF_8), 0, pkt, 58, name.length)
+        val d = MeshCoreFrameCodec.decode(pkt)
+        assertTrue(d is MeshCoreFrameCodec.Decoded.SelfInfo)
+        d as MeshCoreFrameCodec.Decoded.SelfInfo
+        assertEquals("MYNODE", d.nodeName)
+        assertEquals(47.6588, d.lat!!, 1e-6)
+        assertEquals(-117.426, d.lon!!, 1e-6)
+        assertEquals(64, pkt[4].toInt() and 0xFF) // sanity on pubkey start
+        assertTrue(d.pubKeyHex.startsWith("40")) // 0x40
+    }
+
+    // ---- DECODE: messages ----------------------------------------------
+
+    @Test fun `decode contact message v1 extracts sender prefix and text`() {
+        // [0]=0x07 [1..6]=senderPrefix [8]=txtType [13..]=text
+        val text = "hello mesh"
+        val pkt = ByteArray(13 + text.length)
+        pkt[0] = 0x07
+        val prefix = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0x11, 0x22, 0x33)
+        System.arraycopy(prefix, 0, pkt, 1, 6)
+        pkt[8] = 0x00 // txtType plain
+        System.arraycopy(text.toByteArray(StandardCharsets.UTF_8), 0, pkt, 13, text.length)
+        val d = MeshCoreFrameCodec.decode(pkt)
+        assertTrue(d is MeshCoreFrameCodec.Decoded.ContactMessage)
+        d as MeshCoreFrameCodec.Decoded.ContactMessage
+        assertEquals("aabbcc112233", d.senderPubKeyPrefixHex)
+        assertEquals("hello mesh", d.text)
+    }
+
+    @Test fun `decode contact message timestamped type shifts text by 4`() {
+        // txtType==2 means text starts 4 bytes later (after a 4-byte ts).
+        val text = "ts msg"
+        val pkt = ByteArray(17 + text.length)
+        pkt[0] = 0x07
+        pkt[8] = 0x02 // txtType timestamped
+        System.arraycopy(text.toByteArray(StandardCharsets.UTF_8), 0, pkt, 17, text.length)
+        val d = MeshCoreFrameCodec.decode(pkt) as MeshCoreFrameCodec.Decoded.ContactMessage
+        assertEquals("ts msg", d.text)
+    }
+
+    @Test fun `decode channel message v1 extracts index and text`() {
+        // [0]=0x08 [1]=channelIndex [8..]=text
+        val text = "channel hi"
+        val pkt = ByteArray(8 + text.length)
+        pkt[0] = 0x08
+        pkt[1] = 0x03 // channel 3
+        System.arraycopy(text.toByteArray(StandardCharsets.UTF_8), 0, pkt, 8, text.length)
+        val d = MeshCoreFrameCodec.decode(pkt)
+        assertTrue(d is MeshCoreFrameCodec.Decoded.ChannelMessage)
+        d as MeshCoreFrameCodec.Decoded.ChannelMessage
+        assertEquals(3, d.channelIndex)
+        assertEquals("channel hi", d.text)
+    }
+
+    // ---- pubkey helpers -------------------------------------------------
+
+    @Test fun `nodeId from pubkey is first 4 bytes big-endian`() {
+        assertEquals(0xDEADBEEFL, MeshCoreFrameCodec.nodeIdFromPubKey("deadbeef0011"))
+        assertEquals(0L, MeshCoreFrameCodec.nodeIdFromPubKey("aa")) // too short
+    }
+
+    @Test fun `pubkey prefix bytes`() {
+        val p = MeshCoreFrameCodec.pubKeyPrefixBytes("aabbccddeeff0011", 6)
+        assertNotNull(p)
+        assertTrue(
+            byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xEE.toByte(), 0xFF.toByte())
+                .contentEquals(p!!),
+        )
+        assertNull(MeshCoreFrameCodec.pubKeyPrefixBytes("aabb", 6))
+        assertNull(MeshCoreFrameCodec.pubKeyPrefixBytes(null, 6))
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoTBridgeEnabledTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/MeshCoTBridgeEnabledTest.kt
@@ -12,16 +12,17 @@ import org.junit.Test
 import soy.engindearing.omnitak.mobile.data.CoTEvent
 import soy.engindearing.omnitak.mobile.data.MeshNode
 import soy.engindearing.omnitak.mobile.data.MeshPosition
+import soy.engindearing.omnitak.mobile.data.MeshtasticCoTConverter
 
 /**
  * Verifies the Phase 3 auto-publish toggle wired through
- * [MeshtasticCoTBridge.enabled]. When the bridge is disabled, node
+ * [MeshCoTBridge.enabled]. When the bridge is disabled, node
  * updates flowing through the [MeshtasticManager.nodes] StateFlow must
  * NOT reach the cotSink. Re-enabling the bridge should resume forwarding
  * subsequent updates.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class MeshtasticCoTBridgeEnabledTest {
+class MeshCoTBridgeEnabledTest {
 
     private fun positionedNode(id: Long, lat: Double, lon: Double, lastHeard: Long = 1) = MeshNode(
         id = id,
@@ -37,9 +38,10 @@ class MeshtasticCoTBridgeEnabledTest {
         val mgr = MeshtasticManager(context = null)
         val received = mutableListOf<CoTEvent>()
         val scope = CoroutineScope(dispatcher)
-        val bridge = MeshtasticCoTBridge(
+        val bridge = MeshCoTBridge(
             mesh = mgr,
             cotSink = { received += it },
+            nodeToCoT = { MeshtasticCoTConverter.nodeToCoT(it) },
             scope = scope,
         )
         bridge.start()
@@ -75,9 +77,10 @@ class MeshtasticCoTBridgeEnabledTest {
     @Test
     fun bridge_defaults_to_enabled() {
         val mgr = MeshtasticManager(context = null)
-        val bridge = MeshtasticCoTBridge(
+        val bridge = MeshCoTBridge(
             mesh = mgr,
             cotSink = { /* unused */ },
+            nodeToCoT = { MeshtasticCoTConverter.nodeToCoT(it) },
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
         assertTrue("auto-publish must default to on for backwards compat", bridge.enabled)


### PR DESCRIPTION
## Summary
Implements the two Gavin feature requests for OmniTAK (iOS + Android):

1. **Mesh framework selection** — users pick Meshtastic or **MeshCore**. Adds native MeshCore companion-radio support over BLE (Nordic UART): contacts' advertised positions plot as CoT PLI, inbound messages land in Chat, and self-position broadcasts to the mesh. The Meshtastic path is unchanged (transport/manager interfaces extracted, MeshCore added as a parallel implementation).
2. **Config profiles + QR sync** — snapshot/apply multiple config profiles; generate a sync QR carrying shared team config (server, team, map, enrollment pointer) with **no secrets**; scan-to-import with a confirmation preview.

## Verification
- Built against the current ATAK/Android toolchain; `assembleDebug` + `testDebugUnitTest` green.
- 4-agent adversarial review; 23 review/hardening fixes applied (decompression-bomb caps, deep-link confirm-before-apply, chat routed to the active framework, data-race fix, secrets stripped from QR, `allowUntrustedTLS` locked safe, no-secrets regression test).
- **Hardware-verified on a real Heltec V3 (MeshCore companion v1.16.0):** scan → connect → APP_START → self-info + RESP_DEVICE_INFO parse (reads `mfg='Heltec V3' ver='v1.16.0'`) → self-position PPLI broadcast. No Meshtastic regression.
- MeshCore CoT UID format (`MESHCORE-<12 hex>`) verified identical across iOS and Android.

## Scope notes
- v1 is native-MeshCore bridging. Full ATAK-channel-datagram interop with the TAK-MeshCore plugin is a planned v2.
