### PR TITLE
Field requests: north-up lock, corner compass, keep-screen-on fix + TAK icon suite (Phase 1)

### DIFF
--- a/app/src/main/assets/cesium_scene.html
+++ b/app/src/main/assets/cesium_scene.html
@@ -44,7 +44,18 @@
   window.addEventListener('resize',_fitViewport);
   document.addEventListener('DOMContentLoaded',_fitViewport);
   function _color(a){return a==='f'?'#4ADE80':a==='h'?'#F44336':a==='n'?'#FFC107':'#B39DDB'}
-  function _billboard(a,k,sidc){
+  // #98 — ATAK Spot Map dot. When an entity carries a `spot` hex colour (from a
+  // <usericon iconsetpath="COT_MAPPING_SPOTMAP/…"> marker) render a filled,
+  // outlined dot instead of the MIL-STD glyph, matching the 2D MapLibre +
+  // native picker rendering so the globe stays in parity.
+  function _spotDot(hex){const sk='spot|'+hex;if(_state.billboardCache.has(sk))return _state.billboardCache.get(sk);
+    const c=document.createElement('canvas');c.width=56;c.height=56;const ctx=c.getContext('2d');
+    ctx.shadowColor='rgba(0,0,0,0.5)';ctx.shadowBlur=4;ctx.fillStyle=hex;ctx.beginPath();ctx.arc(28,28,18,0,Math.PI*2);ctx.fill();
+    ctx.shadowBlur=0;const lum=_luma(hex);ctx.lineWidth=3;ctx.strokeStyle=lum>0.6?'#000':'#fff';ctx.beginPath();ctx.arc(28,28,18,0,Math.PI*2);ctx.stroke();
+    const url=c.toDataURL('image/png');_state.billboardCache.set(sk,url);return url;}
+  function _luma(hex){const h=hex.replace('#','');if(h.length<6)return 1;const r=parseInt(h.substr(0,2),16)/255,g=parseInt(h.substr(2,2),16)/255,b=parseInt(h.substr(4,2),16)/255;return 0.299*r+0.587*g+0.114*b;}
+  function _billboard(a,k,sidc,spot){
+    if(spot&&k!=='aircraft'){return _spotDot(spot);}
     if(sidc&&window.ms&&k!=='aircraft'){const sk='sidc|'+sidc;if(_state.billboardCache.has(sk))return _state.billboardCache.get(sk);
       try{const sym=new window.ms.Symbol(sidc,{size:32,infoBackground:'transparent',infoColor:'white'});const url=sym.asCanvas().toDataURL('image/png');_state.billboardCache.set(sk,url);return url;}catch(e){console.warn('milsymbol failed for',sidc,e);}}
     const key=a+'|'+(k||'');if(_state.billboardCache.has(key))return _state.billboardCache.get(key);
@@ -125,10 +136,10 @@
       const rot=(typeof e.heading==='number')?-e.heading*Math.PI/180:0;
       let entity=_state.entities.get(e.uid);
       if(!entity){entity=v.entities.add({id:e.uid,position:pos,
-        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc),verticalOrigin:Cesium.VerticalOrigin.CENTER,heightReference:useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
+        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot),verticalOrigin:Cesium.VerticalOrigin.CENTER,heightReference:useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
         label:e.callsign?{text:e.callsign,font:'12px -apple-system, sans-serif',fillColor:Cesium.Color.WHITE,outlineColor:Cesium.Color.BLACK,outlineWidth:2,style:Cesium.LabelStyle.FILL_AND_OUTLINE,pixelOffset:new Cesium.Cartesian2(0,-32),heightReference:useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE,disableDepthTestDistance:Number.POSITIVE_INFINITY}:undefined,
       });_state.entities.set(e.uid,entity);}
-      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc);entity.billboard.heightReference=useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE;entity.billboard.rotation=rot;if(entity.label&&e.callsign)entity.label.text=e.callsign;}
+      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot);entity.billboard.heightReference=useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE;entity.billboard.rotation=rot;if(entity.label&&e.callsign)entity.label.text=e.callsign;}
     },
     setEntities(arg){const list=_parse(arg);if(!Array.isArray(list))return;const seen=new Set();
       for(const e of list){if(e&&e.uid){seen.add(e.uid);window.OmniBridge.upsertEntity(e);}}

--- a/app/src/main/assets/cesium_scene.html
+++ b/app/src/main/assets/cesium_scene.html
@@ -54,7 +54,11 @@
     ctx.shadowBlur=0;const lum=_luma(hex);ctx.lineWidth=3;ctx.strokeStyle=lum>0.6?'#000':'#fff';ctx.beginPath();ctx.arc(28,28,18,0,Math.PI*2);ctx.stroke();
     const url=c.toDataURL('image/png');_state.billboardCache.set(sk,url);return url;}
   function _luma(hex){const h=hex.replace('#','');if(h.length<6)return 1;const r=parseInt(h.substr(0,2),16)/255,g=parseInt(h.substr(2,2),16)/255,b=parseInt(h.substr(4,2),16)/255;return 0.299*r+0.587*g+0.114*b;}
-  function _billboard(a,k,sidc,spot){
+  function _billboard(a,k,sidc,spot,icon){
+    // #98 — a pre-rendered TAK icon-suite badge (Markers / Google) arrives as a
+    // ready data-URL from the Kotlin side, the same bitmap the 2D map registers,
+    // so the globe matches it byte-for-byte without re-drawing the glyph here.
+    if(icon&&k!=='aircraft'){return icon;}
     if(spot&&k!=='aircraft'){return _spotDot(spot);}
     if(sidc&&window.ms&&k!=='aircraft'){const sk='sidc|'+sidc;if(_state.billboardCache.has(sk))return _state.billboardCache.get(sk);
       try{const sym=new window.ms.Symbol(sidc,{size:32,infoBackground:'transparent',infoColor:'white'});const url=sym.asCanvas().toDataURL('image/png');_state.billboardCache.set(sk,url);return url;}catch(e){console.warn('milsymbol failed for',sidc,e);}}
@@ -136,10 +140,10 @@
       const rot=(typeof e.heading==='number')?-e.heading*Math.PI/180:0;
       let entity=_state.entities.get(e.uid);
       if(!entity){entity=v.entities.add({id:e.uid,position:pos,
-        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot),verticalOrigin:Cesium.VerticalOrigin.CENTER,heightReference:useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
+        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot,e.icon),verticalOrigin:Cesium.VerticalOrigin.CENTER,heightReference:useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
         label:e.callsign?{text:e.callsign,font:'12px -apple-system, sans-serif',fillColor:Cesium.Color.WHITE,outlineColor:Cesium.Color.BLACK,outlineWidth:2,style:Cesium.LabelStyle.FILL_AND_OUTLINE,pixelOffset:new Cesium.Cartesian2(0,-32),heightReference:useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE,disableDepthTestDistance:Number.POSITIVE_INFINITY}:undefined,
       });_state.entities.set(e.uid,entity);}
-      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot);entity.billboard.heightReference=useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE;entity.billboard.rotation=rot;if(entity.label&&e.callsign)entity.label.text=e.callsign;}
+      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot,e.icon);entity.billboard.heightReference=useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE;entity.billboard.rotation=rot;if(entity.label&&e.callsign)entity.label.text=e.callsign;}
     },
     setEntities(arg){const list=_parse(arg);if(!Array.isArray(list))return;const seen=new Set();
       for(const e of list){if(e&&e.uid){seen.add(e.uid);window.OmniBridge.upsertEntity(e);}}

--- a/app/src/main/assets/cesium_scene.html
+++ b/app/src/main/assets/cesium_scene.html
@@ -31,7 +31,7 @@
   // Injected at WebView load time by CesiumMapView from BuildConfig.CESIUM_ION_TOKEN
   // (fed by gitignored local.properties) — never commit a literal token here.
   Cesium.Ion.defaultAccessToken='__CESIUM_ION_TOKEN__';
-  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),billboardCache:new Map()};
+  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),billboardCache:new Map(),northLocked:false,northEnforcer:null};
   function _drawColor(hex,a){try{const c=Cesium.Color.fromCssColorString(hex||'#4ADE80');return a!==undefined?c.withAlpha(a):c}catch(e){return Cesium.Color.CYAN}}
   function _havDist(a,b){const R=6371000,lat1=a[1]*Math.PI/180,lat2=b[1]*Math.PI/180,dLat=(b[1]-a[1])*Math.PI/180,dLon=(b[0]-a[0])*Math.PI/180;const s=Math.sin(dLat/2)**2+Math.cos(lat1)*Math.cos(lat2)*Math.sin(dLon/2)**2;return 2*R*Math.asin(Math.min(1,Math.sqrt(s)))}
   function _fitViewport(){
@@ -78,6 +78,37 @@
   function _zoomBy(factor){const v=_state.viewer;if(!v)return;const f=(typeof factor==='number'&&factor>0)?factor:1;
     const h=v.camera.positionCartographic.height;const amount=Math.abs(h-h*f);if(amount<1)return;
     if(f<1)v.camera.zoomIn(amount);else v.camera.zoomOut(amount);_postCameraChanged(v);}
+  // Issue #95 — re-pose the camera to heading 0 (north-up) about the ground
+  // point it is currently centred on, keeping pitch and camera-to-ground
+  // range so only the bearing changes. Picks the globe point at screen centre
+  // (falls back to the camera's sub-point) and orbits via lookAt at heading 0,
+  // then releases the lookAt transform so free pan/zoom still works after.
+  function _headingToNorth(v,animate){if(!v)return;
+    const scene=v.scene,canvas=scene.canvas;
+    const centre=new Cesium.Cartesian2(canvas.clientWidth/2,canvas.clientHeight/2);
+    let ground=scene.pickPosition?scene.pickPosition(centre):undefined;
+    if(!Cesium.defined(ground))ground=v.camera.pickEllipsoid(centre,scene.globe.ellipsoid);
+    if(!Cesium.defined(ground)){
+      // No globe under screen centre (limb / space view) — fall back to the
+      // camera's own sub-point so we still zero the heading.
+      const carto=v.camera.positionCartographic;
+      ground=Cesium.Cartesian3.fromRadians(carto.longitude,carto.latitude,0);
+    }
+    let range=Cesium.Cartesian3.distance(v.camera.positionWC,ground);
+    if(!isFinite(range)||range<=0)range=v.camera.positionCartographic.height||5000;
+    const pitch=v.camera.pitch;
+    if(animate){
+      // Compute the north-up destination via a throwaway camera, then fly to
+      // it so the snap is smooth and matches the 2D engine's animated snap.
+      v.camera.flyToBoundingSphere(new Cesium.BoundingSphere(ground,1),{
+        offset:new Cesium.HeadingPitchRange(0,pitch,range),duration:0.45,
+        complete:function(){_postCameraChanged(v);}});
+    }else{
+      v.camera.lookAt(ground,new Cesium.HeadingPitchRange(0,pitch,range));
+      v.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+      _postCameraChanged(v);
+    }
+  }
   function _installInputHandlers(viewer){
     viewer.camera.moveEnd.addEventListener(function(){_postCameraChanged(viewer)});
     const h=new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
@@ -136,6 +167,46 @@
       v.camera.cancelFlight();
       v.camera.setView({destination:Cesium.Cartesian3.fromDegrees(e.lon,e.lat,e.height),orientation:{heading:Cesium.Math.toRadians(e.heading||0),pitch:Cesium.Math.toRadians(typeof e.pitch==='number'?e.pitch:-90),roll:0}});
       _hideLoading();_postCameraChanged(v);
+    },
+    // Issue #95 — north-up lock parity with the 2D MapLibre engine and iOS.
+    // snapToNorth animates the globe heading back to 0 about the point the
+    // camera is currently looking at, preserving pitch and camera-to-ground
+    // range so only the bearing changes (no zoom / tilt jump). Used both by
+    // the compass tap (lock off) and internally when the lock engages.
+    snapToNorth(animate){const v=_state.viewer;if(!v)return;_headingToNorth(v,animate!==false);},
+    // setNorthUpLocked(true): snap to north, then hold heading 0 by (a)
+    // disabling the free-look / tilt inputs that introduce heading on a
+    // touch globe and (b) re-zeroing heading on every camera change as a
+    // backstop (a stray two-finger twist or programmatic flyTo can still
+    // drift it). false restores the inputs and removes the enforcer.
+    setNorthUpLocked(arg){const on=(arg===true||arg==='true');const v=_state.viewer;if(!v)return;
+      _state.northLocked=on;
+      const ctrl=v.scene.screenSpaceCameraController;
+      if(on){
+        // Left-drag still pans the globe (changes lat/lon, not heading);
+        // only the heading-bearing gestures are suppressed so the map still
+        // feels alive while locked north-up.
+        ctrl.enableLook=false;ctrl.enableTilt=false;
+        _headingToNorth(v,true);
+        if(!_state.northEnforcer){
+          _state.northEnforcer=function(){
+            if(!_state.northLocked)return;
+            // toDegrees(heading) is 0..360; treat ~0 and ~360 as on-north.
+            const hd=Cesium.Math.toDegrees(v.camera.heading);
+            const off=Math.min(Math.abs(hd),Math.abs(360-hd));
+            if(off>0.5)_headingToNorth(v,false);
+          };
+          v.camera.changed.addEventListener(_state.northEnforcer);
+          // changed fires only past camera.percentageChanged of movement;
+          // the default is generous, so tighten it while locked for a
+          // responsive snap-back, then it's restored on unlock.
+          _state._priorPct=v.camera.percentageChanged;v.camera.percentageChanged=0.02;
+        }
+      }else{
+        ctrl.enableLook=true;ctrl.enableTilt=true;
+        if(_state.northEnforcer){v.camera.changed.removeEventListener(_state.northEnforcer);_state.northEnforcer=null;
+          if(typeof _state._priorPct==='number')v.camera.percentageChanged=_state._priorPct;}
+      }
     },
     ping(){return _state.ready?'pong':'loading'},
     upsertDrawing(arg){const d=_parse(arg);if(!d||!d.uid||!d.kind||!Array.isArray(d.coords)||d.coords.length===0)return;const v=_state.viewer;if(!v)return;

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTEvent.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTEvent.kt
@@ -76,6 +76,11 @@ data class CoTEvent(
     // it fall back to the friendly-ground-installation default that
     // [type] declares. See `FemaIconCatalog` and #29 / iOS PR for #13.
     val iconsetPath: String? = null,
+    /** Signed ARGB from the CoT `<color argb="…"/>` element. Spot Map markers
+     *  carry their swatch here (the colour rides `<color>`, not `type`), so the
+     *  TAK icon registry can tint a received spot dot to match the sender. Null
+     *  when the event carried no `<color>`. */
+    val colorArgb: Int? = null,
     /** TAK team name from `<__group name="Red|Orange|…"/>`. Null when absent. */
     val teamName: String? = null,
     /** TAK team role from `<__group role="Team Member|…"/>`. Null when absent. */

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTParser.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTParser.kt
@@ -38,6 +38,7 @@ object CoTParser {
         var teamRole: String? = null
         var remarks: String? = null
         var iconsetPath: String? = null
+        var colorArgb: Int? = null
 
         var ev = parser.eventType
         while (ev != XmlPullParser.END_DOCUMENT) {
@@ -74,6 +75,12 @@ object CoTParser {
                     "usericon" -> {
                         iconsetPath = parser.getAttributeValue(null, "iconsetpath") ?: iconsetPath
                     }
+                    // Marker colour — Spot Map points carry their swatch here
+                    // (<color argb="-65536"/>); the TAK icon registry tints the
+                    // dot from it so received spots match the sender's colour.
+                    "color" -> {
+                        colorArgb = parser.getAttributeValue(null, "argb")?.toIntOrNull() ?: colorArgb
+                    }
                 }
             }
             ev = parser.next()
@@ -96,6 +103,7 @@ object CoTParser {
             teamName = teamName,
             teamRole = teamRole,
             iconsetPath = iconsetPath,
+            colorArgb = colorArgb,
         )
     }.getOrNull()
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -130,6 +130,14 @@ data class UserPrefs(
     val lastCameraLat: Double? = null,
     val lastCameraLon: Double? = null,
     val lastCameraZoom: Double? = null,
+    /** Issue #95 — lock map bearing to 0° (north-up). While on, rotation
+     *  gestures are suppressed and the camera snaps back to north. Persisted
+     *  so field operators who always run north-up don't have to re-enable. */
+    val northUpLocked: Boolean = false,
+    /** Issue #97 — prevent the screen from sleeping while OmniTAK is
+     *  foreground. Fixes the bug where the setting was present but
+     *  FLAG_KEEP_SCREEN_ON was never actually applied. Default off. */
+    val keepScreenOn: Boolean = false,
 )
 
 class UserPrefsStore(private val context: Context) {
@@ -169,6 +177,9 @@ class UserPrefsStore(private val context: Context) {
     private val KEY_CAMERA_LAT  = stringPreferencesKey("last_camera_lat")
     private val KEY_CAMERA_LON  = stringPreferencesKey("last_camera_lon")
     private val KEY_CAMERA_ZOOM = stringPreferencesKey("last_camera_zoom")
+    // Issue #95 — north-up lock; #97 — keep-screen-on
+    private val KEY_NORTH_UP_LOCKED = booleanPreferencesKey("north_up_locked")
+    private val KEY_KEEP_SCREEN_ON  = booleanPreferencesKey("keep_screen_on")
 
     val prefs: Flow<UserPrefs> = context.userPrefsDataStore.data.map { p -> readFrom(p) }
 
@@ -210,6 +221,8 @@ class UserPrefsStore(private val context: Context) {
             if (next.lastCameraLat != null)  p[KEY_CAMERA_LAT]  = next.lastCameraLat.toString()
             if (next.lastCameraLon != null)  p[KEY_CAMERA_LON]  = next.lastCameraLon.toString()
             if (next.lastCameraZoom != null) p[KEY_CAMERA_ZOOM] = next.lastCameraZoom.toString()
+            p[KEY_NORTH_UP_LOCKED] = next.northUpLocked
+            p[KEY_KEEP_SCREEN_ON]  = next.keepScreenOn
         }
     }
 
@@ -327,6 +340,8 @@ class UserPrefsStore(private val context: Context) {
         lastCameraLat  = p[KEY_CAMERA_LAT]?.toDoubleOrNull(),
         lastCameraLon  = p[KEY_CAMERA_LON]?.toDoubleOrNull(),
         lastCameraZoom = p[KEY_CAMERA_ZOOM]?.toDoubleOrNull(),
+        northUpLocked  = p[KEY_NORTH_UP_LOCKED] ?: false,
+        keepScreenOn   = p[KEY_KEEP_SCREEN_ON]  ?: false,
     )
 
     // ATAK / OpenTakServer canonical team names are Title Case ("Cyan",

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconService.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconService.kt
@@ -187,6 +187,27 @@ object MilStdIconService {
 
     fun getAffiliation(cotType: String): Affiliation = Affiliation.fromCotType(cotType)
 
+    /**
+     * Re-affiliate a CoT type by swapping its affiliation segment (the
+     * second token after `a-`) to [code] while keeping the battle
+     * dimension and function tail intact — e.g. `a-h-G-U-C-A` with code
+     * `f` → `a-f-G-U-C-A`. Lets the marker-edit affiliation chips retrofit
+     * an already-picked specific symbol onto a new side without forcing the
+     * operator back into the icon picker.
+     *
+     * Falls back to the generic per-affiliation ground unit when [cotType]
+     * is too short to carry an affiliation segment, so callers always get
+     * a renderable type back.
+     */
+    fun withAffiliation(cotType: String, code: Char): String {
+        val parts = cotType.split('-').toMutableList()
+        if (parts.size < 2 || !parts[0].equals("a", ignoreCase = true)) {
+            return "a-$code-G-U-C"
+        }
+        parts[1] = code.toString()
+        return parts.joinToString("-")
+    }
+
     fun getBattleDimension(cotType: String): BattleDimension =
         BattleDimension.fromCotType(cotType)
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistry.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistry.kt
@@ -1,0 +1,255 @@
+package soy.engindearing.omnitak.mobile.data.symbology
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color as AndroidColor
+import android.graphics.Paint
+import androidx.collection.LruCache
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Issue #98 (Phase 1) — resolution + selection framework for the standard
+ * TAK icon suite. Android port of the iOS `TAKIconRegistry`, kept in lockstep
+ * so a marker dropped on one platform round-trips to the other through CoT.
+ *
+ * WHAT THIS SOLVES
+ * ----------------
+ * Before this, a received or placed marker only ever rendered as one of four
+ * MIL-STD-2525 affiliation frames (via [MilStdIconCache]). Markers pushed from
+ * scripts or iTAK carrying a `<usericon iconsetpath="…">` — the Spot Map /
+ * Markers / Google packs — had nowhere to resolve to, so they fell through to
+ * the generic affiliation glyph. That is exactly the gap kymyura reported on
+ * Discord (scripts pushing CoT with `<usericon iconsetpath="COT_MAPPING_SPOTMAP/…">`).
+ *
+ * This registry is the resolution layer: given a CoT type, an optional
+ * `usericon` iconset path, and an optional ARGB colour, it returns the right
+ * bundled icon bitmap — and it exposes a selectable catalogue so the same icons
+ * can be picked when *placing* a marker. Resolution order mirrors ATAK:
+ *   1. explicit `usericon iconsetpath` (e.g. `COT_MAPPING_SPOTMAP/red`)
+ *   2. CoT type that maps to a known iconset (`b-m-p-s-m` → Spot Map)
+ *   3. caller's fallback (the MIL-STD-2525 affiliation frame from
+ *      [MilStdIconCache], handled by the caller when this returns null)
+ *
+ * ICON SOURCING / LICENSING (read before adding packs)
+ * ----------------------------------------------------
+ * The standard ATAK "Spot Map" set is a coloured dot keyed off the CoT
+ * `<color>` element — it carries no creative artwork, so this file renders it
+ * cleanly at runtime keyed to ATAK's exact canonical colour palette and
+ * `COT_MAPPING_SPOTMAP/{color}` paths. That makes received and placed spot-map
+ * markers resolve and round-trip correctly with ATAK / iTAK / TAK Server with
+ * zero third-party assets.
+ *
+ * The "Markers" and "Google" raster packs are bitmap artwork. The only local
+ * source (atak-civ-source) is GPLv3 in this checkout, so those bitmaps CANNOT
+ * be vendored into a closed Play / App-Store binary without relicensing the
+ * app. The framework here is pack-agnostic — [TakIconPack] + [resolveBitmap]
+ * already model multi-pack lookup — so when an Apache-2.0 / public-domain
+ * bitmap pack (or a user-imported ATAK iconset, Phase 2) is available it slots
+ * in behind the same API. See the build report for the explicit asset blocker.
+ */
+object TakIconRegistry {
+
+    /**
+     * Identifies a standard TAK icon pack. The [uid] matches ATAK's iconset
+     * UID / `COT_MAPPING_*` path prefix so an `iconsetpath` round-trips
+     * byte-for-byte with ATAK / iTAK.
+     */
+    enum class TakIconPack(val uid: String, val displayName: String, val bundled: Boolean) {
+        /** Coloured point markers — ATAK's "Spot Map". Path prefix
+         *  `COT_MAPPING_SPOTMAP`, CoT type `b-m-p-s-m`. Bundled
+         *  (runtime-rendered, no artwork). */
+        SPOT_MAP("COT_MAPPING_SPOTMAP", "Spot Map", bundled = true),
+
+        /** ATAK "Markers" pack (bitmap artwork). Modeled for resolution but
+         *  not bundled — see file header on the GPL asset blocker. */
+        MARKERS("COT_MAPPING_2525C", "Markers", bundled = false),
+
+        /** ATAK "Google" pack (bitmap artwork). Modeled but not bundled. The
+         *  UID is the canonical Google iconset UID from ATAK's iconsets DB. */
+        GOOGLE("f7f71666-8b28-4b57-9fbb-e38e61d33b79", "Google", bundled = false),
+    }
+
+    /**
+     * The canonical ATAK Spot Map colour palette. Values mirror
+     * `SpotMapPalletFragment` in ATAK-CIV (and the iOS `TAKSpotIcon`) exactly,
+     * so a marker placed here reads identically in ATAK / iTAK and a marker
+     * received from them resolves back to the same swatch. Each case is a
+     * selectable icon when placing a marker.
+     */
+    enum class SpotIcon(val key: String, val argb: Int) {
+        WHITE("white", 0xFFFFFFFF.toInt()),
+        YELLOW("yellow", 0xFFFFCC00.toInt()),
+        ORANGE("orange", 0xFFFF7700.toInt()),
+        BROWN("brown", 0xFF8B4513.toInt()),
+        RED("red", 0xFFFF3B30.toInt()),
+        MAGENTA("magenta", 0xFFFF00FF.toInt()),
+        BLUE("blue", 0xFF007AFF.toInt()),
+        CYAN("cyan", 0xFF00FFFF.toInt()),
+        GREEN("green", 0xFF34C759.toInt()),
+        GREY("grey", 0xFF777777.toInt()),
+        BLACK("black", 0xFF000000.toInt());
+
+        /** `usericon` iconset path: `COT_MAPPING_SPOTMAP/{color}`. ATAK matches
+         *  the trailing token case-insensitively, so the lowercased key is exact. */
+        val iconsetPath: String get() = "${TakIconPack.SPOT_MAP.uid}/$key"
+
+        /** Display name for the picker / accessibility. */
+        val displayName: String get() = key.replaceFirstChar { it.uppercase() }
+
+        /** Compose colour for picker swatches. */
+        val color: Color get() = Color(argb)
+
+        /** 8-hex opaque ARGB string for the CoT `<color argb>` element. */
+        val argbHex: String get() = "FF%02X%02X%02X".format(
+            (argb shr 16) and 0xFF, (argb shr 8) and 0xFF, argb and 0xFF,
+        )
+
+        companion object {
+            /** The CoT type ATAK uses for every spot-map point. Colour rides
+             *  the `<color>` element, not the type — same as ATAK. */
+            const val COT_TYPE = "b-m-p-s-m"
+
+            /** Resolve a Spot Map colour from a `usericon` iconset path
+             *  (`COT_MAPPING_SPOTMAP/red`, case-insensitive trailing token).
+             *  Unknown / "label"-only tokens fall back to white so a spot
+             *  marker never renders blank. Null when the path is not Spot Map. */
+            fun fromIconsetPath(path: String): SpotIcon? {
+                if (!path.uppercase().startsWith(TakIconPack.SPOT_MAP.uid)) return null
+                val token = path.substringAfterLast('/').lowercase()
+                return entries.firstOrNull { it.key == token }
+                    ?: if (token.isEmpty()) null else WHITE
+            }
+        }
+    }
+
+    /** Spot Map icons offered in the marker-placement picker, in ATAK order. */
+    val selectableSpotIcons: List<SpotIcon> get() = SpotIcon.entries
+
+    /** Packs the suite knows about, flagged by whether their assets are bundled. */
+    val availablePacks: List<TakIconPack> get() = TakIconPack.entries
+
+    // Rendered-glyph cache so the map's symbol refresh stays cheap.
+    private data class Key(val token: String, val sizePx: Int)
+    private val cache = LruCache<Key, Bitmap>(64)
+
+    /**
+     * Resolve a renderable bitmap for a marker. Returns null when no TAK-suite
+     * icon applies, so the caller falls back to MIL-STD-2525 affiliation art.
+     *
+     * @param cotType CoT `type` (e.g. `b-m-p-s-m`, `a-f-G-U-C-I`).
+     * @param iconsetPath `usericon iconsetpath` if the CoT carried one.
+     * @param argb optional override colour (signed ARGB int from `<color>`);
+     *   used for Spot Map points whose colour rides the `<color>` element.
+     * @param sizePx target pixel size for the rendered glyph.
+     */
+    fun resolveBitmap(
+        cotType: String?,
+        iconsetPath: String? = null,
+        argb: Int? = null,
+        sizePx: Int = 64,
+    ): Bitmap? {
+        // 1. Explicit Spot Map iconset path wins.
+        if (iconsetPath != null) {
+            SpotIcon.fromIconsetPath(iconsetPath)?.let { spot ->
+                val color = argb ?: spot.argb
+                return spotDot(color, sizePx, "spot|${spot.key}|$color")
+            }
+        }
+        // 2. Spot Map CoT type (colour carried by <color>, default white).
+        if (cotType == SpotIcon.COT_TYPE) {
+            val color = argb ?: SpotIcon.WHITE.argb
+            return spotDot(color, sizePx, "spot|type|$color")
+        }
+        // 3. Unbundled bitmap packs (Markers/Google) would resolve here once a
+        //    clean asset source lands — intentionally null for now so the
+        //    caller keeps using the MIL-STD-2525 fallback rather than a blank.
+        return null
+    }
+
+    /**
+     * Whether this marker resolves to a TAK-suite (non-MIL-STD) icon. Lets the
+     * symbol layer decide which image-registration path to take without
+     * rendering twice.
+     */
+    fun handles(cotType: String?, iconsetPath: String?): Boolean =
+        (iconsetPath != null && SpotIcon.fromIconsetPath(iconsetPath) != null) ||
+            cotType == SpotIcon.COT_TYPE
+
+    /** Convenience: the rendered glyph for a selectable Spot Map icon (picker
+     *  swatches, current-symbol rows). */
+    fun bitmapFor(spot: SpotIcon, sizePx: Int = 64): Bitmap =
+        spotDot(spot.argb, sizePx, "spot|sel|${spot.key}")
+
+    /**
+     * Stable image-registration key for the MapLibre style. Distinct from a
+     * MIL-STD SIDC so the two symbol families never collide in
+     * [android.graphics.Bitmap] registration.
+     */
+    fun styleImageId(cotType: String?, iconsetPath: String?, argb: Int?): String? {
+        if (iconsetPath != null) {
+            SpotIcon.fromIconsetPath(iconsetPath)?.let { spot ->
+                return "takicon-spot-${argb ?: spot.argb}"
+            }
+        }
+        if (cotType == SpotIcon.COT_TYPE) return "takicon-spot-${argb ?: SpotIcon.WHITE.argb}"
+        return null
+    }
+
+    /**
+     * ATAK's spot-map point: a filled dot with a thin contrasting outline so it
+     * reads on any basemap. White/black get an inverted ring for contrast.
+     */
+    private fun spotDot(argb: Int, sizePx: Int, cacheKey: String): Bitmap {
+        val key = Key(cacheKey, sizePx)
+        cache.get(key)?.let { return it }
+
+        val bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        val cx = sizePx / 2f
+        val cy = sizePx / 2f
+        val r = sizePx * 0.32f
+
+        // Drop shadow for legibility against bright imagery.
+        val shadow = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = AndroidColor.argb(110, 0, 0, 0)
+            setShadowLayer(sizePx * 0.06f, 0f, 0f, AndroidColor.argb(160, 0, 0, 0))
+        }
+        // setShadowLayer needs a software layer; draw the fill then the ring.
+        val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = argb
+            style = Paint.Style.FILL
+        }
+        canvas.drawCircle(cx, cy, r, shadow)
+        canvas.drawCircle(cx, cy, r, fill)
+
+        // Contrasting outline — black ring for light dots, white for dark.
+        val outline = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = if (isLight(argb)) AndroidColor.BLACK else AndroidColor.WHITE
+            style = Paint.Style.STROKE
+            strokeWidth = (sizePx * 0.06f).coerceAtLeast(1f)
+        }
+        canvas.drawCircle(cx, cy, r, outline)
+
+        cache.put(key, bmp)
+        return bmp
+    }
+
+    /** Perceived-luminance test used to pick a contrasting outline. */
+    private fun isLight(argb: Int): Boolean {
+        val rr = ((argb shr 16) and 0xFF) / 255.0
+        val gg = ((argb shr 8) and 0xFF) / 255.0
+        val bb = (argb and 0xFF) / 255.0
+        return (0.299 * rr + 0.587 * gg + 0.114 * bb) > 0.6
+    }
+
+    /** Decode a signed ARGB int (as carried in CoT `<color argb>`) to an opaque
+     *  ARGB int — a fully-transparent alpha (common when colour omits alpha) is
+     *  treated as opaque so the dot is visible. */
+    fun normalizeArgb(argb: Int): Int {
+        val a = (argb shr 24) and 0xFF
+        return if (a == 0) argb or 0xFF000000.toInt() else argb
+    }
+
+    /** Clear the cache — call from `onTrimMemory` or test teardown. */
+    fun clear() = cache.evictAll()
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistry.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistry.kt
@@ -1,11 +1,21 @@
 package soy.engindearing.omnitak.mobile.data.symbology
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color as AndroidColor
 import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.graphics.RectF
+import android.util.Base64
+import androidx.annotation.DrawableRes
 import androidx.collection.LruCache
 import androidx.compose.ui.graphics.Color
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
+import soy.engindearing.omnitak.mobile.R
+import java.io.ByteArrayOutputStream
 
 /**
  * Issue #98 (Phase 1) — resolution + selection framework for the standard
@@ -35,17 +45,18 @@ import androidx.compose.ui.graphics.Color
  * The standard ATAK "Spot Map" set is a coloured dot keyed off the CoT
  * `<color>` element — it carries no creative artwork, so this file renders it
  * cleanly at runtime keyed to ATAK's exact canonical colour palette and
- * `COT_MAPPING_SPOTMAP/{color}` paths. That makes received and placed spot-map
- * markers resolve and round-trip correctly with ATAK / iTAK / TAK Server with
- * zero third-party assets.
+ * `COT_MAPPING_SPOTMAP/{color}` paths.
  *
- * The "Markers" and "Google" raster packs are bitmap artwork. The only local
- * source (atak-civ-source) is GPLv3 in this checkout, so those bitmaps CANNOT
- * be vendored into a closed Play / App-Store binary without relicensing the
- * app. The framework here is pack-agnostic — [TakIconPack] + [resolveBitmap]
- * already model multi-pack lookup — so when an Apache-2.0 / public-domain
- * bitmap pack (or a user-imported ATAK iconset, Phase 2) is available it slots
- * in behind the same API. See the build report for the explicit asset blocker.
+ * The "Markers" and "Google" packs ship as **vector-drawable glyphs derived
+ * from the Material Symbols set (Apache License 2.0)** — `res/drawable/takicon_*`
+ * — so they are clean to vendor into the closed Play binary (the GPLv3
+ * atak-civ-source pack is NOT used). Each glyph is rasterised at runtime onto a
+ * rounded badge so it reads as a map marker. The canonical ATAK icon names are
+ * preserved on the [MarkerIcon] / [GoogleIcon] cases and in their
+ * [iconsetPath]s, so an inbound `iconsetpath` from ATAK / iTAK resolves to the
+ * matching glyph and a marker placed here round-trips back to those clients.
+ * Per-marker custom icon-pack import (arbitrary `iconset.xml` + images) remains
+ * Phase 2.
  */
 object TakIconRegistry {
 
@@ -60,13 +71,15 @@ object TakIconRegistry {
          *  (runtime-rendered, no artwork). */
         SPOT_MAP("COT_MAPPING_SPOTMAP", "Spot Map", bundled = true),
 
-        /** ATAK "Markers" pack (bitmap artwork). Modeled for resolution but
-         *  not bundled — see file header on the GPL asset blocker. */
-        MARKERS("COT_MAPPING_2525C", "Markers", bundled = false),
+        /** ATAK "Markers" pack. Path prefix `COT_MAPPING_2525C` (the historical
+         *  ATAK iconset UID for the general marker set). Bundled — glyphs are
+         *  Material-Symbols (Apache-2.0) vector drawables, see [MarkerIcon]. */
+        MARKERS("COT_MAPPING_2525C", "Markers", bundled = true),
 
-        /** ATAK "Google" pack (bitmap artwork). Modeled but not bundled. The
-         *  UID is the canonical Google iconset UID from ATAK's iconsets DB. */
-        GOOGLE("f7f71666-8b28-4b57-9fbb-e38e61d33b79", "Google", bundled = false),
+        /** ATAK "Google" POI pack. The [uid] is the canonical Google iconset UID
+         *  from ATAK's iconsets DB. Bundled — Material-Symbols (Apache-2.0)
+         *  vector drawables, see [GoogleIcon]. */
+        GOOGLE("f7f71666-8b28-4b57-9fbb-e38e61d33b79", "Google", bundled = true),
     }
 
     /**
@@ -122,20 +135,136 @@ object TakIconRegistry {
         }
     }
 
+    /**
+     * Common interface for the bitmap-glyph packs (Markers / Google) so the
+     * picker and resolver treat them uniformly. Each case names a canonical ATAK
+     * icon, carries the badge tint ATAK uses for that pack, and points at a
+     * Material-Symbols (Apache-2.0) vector drawable.
+     */
+    interface BadgeIcon {
+        val pack: TakIconPack
+        val token: String
+        @get:DrawableRes val drawableRes: Int
+        val badgeArgb: Int
+        val displayName: String
+
+        /** `usericon` iconset path, e.g. `COT_MAPPING_2525C/flag`. */
+        val iconsetPath: String get() = "${pack.uid}/$token"
+    }
+
+    /**
+     * ATAK "Markers" pack — general-purpose point markers. The [token] is the
+     * canonical ATAK icon name so an inbound `COT_MAPPING_2525C/<token>` path
+     * resolves here and a placed marker round-trips to ATAK / iTAK. Glyphs are
+     * Material Symbols (Apache-2.0); the dark-slate badge matches ATAK's neutral
+     * marker chrome.
+     */
+    enum class MarkerIcon(
+        override val token: String,
+        @get:DrawableRes override val drawableRes: Int,
+        override val displayName: String,
+    ) : BadgeIcon {
+        FLAG("flag", R.drawable.takicon_marker_flag, "Flag"),
+        WARNING("warning", R.drawable.takicon_marker_warning, "Warning"),
+        STAR("star", R.drawable.takicon_marker_star, "Star"),
+        PERSON("person", R.drawable.takicon_marker_person, "Person"),
+        VEHICLE("vehicle", R.drawable.takicon_marker_vehicle, "Vehicle"),
+        AIRCRAFT("aircraft", R.drawable.takicon_marker_aircraft, "Aircraft"),
+        BOAT("boat", R.drawable.takicon_marker_boat, "Boat"),
+        CIRCLE("circle", R.drawable.takicon_marker_circle, "Circle");
+
+        override val pack get() = TakIconPack.MARKERS
+        override val badgeArgb get() = 0xFF2B3440.toInt()
+
+        companion object {
+            /** Resolve a Markers icon from a `usericon` iconset path. Null when
+             *  the path isn't the Markers pack; an unknown trailing token falls
+             *  back to [CIRCLE] so a received marker never renders blank. */
+            fun fromIconsetPath(path: String): MarkerIcon? {
+                if (!path.uppercase().startsWith(TakIconPack.MARKERS.uid)) return null
+                val token = path.substringAfterLast('/').lowercase()
+                if (token.isEmpty()) return null
+                return entries.firstOrNull { it.token == token } ?: CIRCLE
+            }
+        }
+    }
+
+    /**
+     * ATAK "Google" POI pack — Google-Maps-style place markers. The [token] is
+     * the canonical Google iconset basename (sans `.png`) so an inbound
+     * `f7f71666-…/<token>` path resolves here. Glyphs are Material Symbols
+     * (Apache-2.0); the Google-red badge matches the Maps pin convention.
+     */
+    enum class GoogleIcon(
+        override val token: String,
+        @get:DrawableRes override val drawableRes: Int,
+        override val displayName: String,
+    ) : BadgeIcon {
+        AIRPORT("airports", R.drawable.takicon_google_airport, "Airport"),
+        GAS("gas_stations", R.drawable.takicon_google_gas, "Gas Station"),
+        HOSPITAL("hospitals", R.drawable.takicon_google_hospital, "Hospital"),
+        RESTAURANT("restaurant", R.drawable.takicon_google_restaurant, "Restaurant"),
+        LODGING("lodging", R.drawable.takicon_google_lodging, "Lodging"),
+        PARKING("parking_lots", R.drawable.takicon_google_parking, "Parking"),
+        POLICE("police", R.drawable.takicon_google_police, "Police"),
+        FIRE("fire", R.drawable.takicon_google_fire, "Fire");
+
+        override val pack get() = TakIconPack.GOOGLE
+        override val badgeArgb get() = 0xFFEA4335.toInt()
+
+        companion object {
+            /** Resolve a Google POI icon from a `usericon` iconset path. The
+             *  inbound basename may carry a `.png` suffix and/or a group segment
+             *  (`…/Google/airports.png`); both are tolerated. Unknown tokens fall
+             *  back to [AIRPORT] so a received marker never renders blank. */
+            fun fromIconsetPath(path: String): GoogleIcon? {
+                if (!path.uppercase().startsWith(TakIconPack.GOOGLE.uid.uppercase())) return null
+                val token = path.substringAfterLast('/').substringBeforeLast('.').lowercase()
+                if (token.isEmpty()) return null
+                return entries.firstOrNull { it.token == token } ?: AIRPORT
+            }
+        }
+    }
+
     /** Spot Map icons offered in the marker-placement picker, in ATAK order. */
     val selectableSpotIcons: List<SpotIcon> get() = SpotIcon.entries
+
+    /** Markers-pack icons offered in the marker-placement picker. */
+    val selectableMarkerIcons: List<MarkerIcon> get() = MarkerIcon.entries
+
+    /** Google-POI-pack icons offered in the marker-placement picker. */
+    val selectableGoogleIcons: List<GoogleIcon> get() = GoogleIcon.entries
 
     /** Packs the suite knows about, flagged by whether their assets are bundled. */
     val availablePacks: List<TakIconPack> get() = TakIconPack.entries
 
     // Rendered-glyph cache so the map's symbol refresh stays cheap.
     private data class Key(val token: String, val sizePx: Int)
-    private val cache = LruCache<Key, Bitmap>(64)
+    private val cache = LruCache<Key, Bitmap>(128)
+    // Base64 PNG data-URL cache for the Cesium billboard path.
+    private val dataUrlCache = LruCache<String, String>(128)
+
+    /**
+     * Resolve the badge icon for a marker (Markers / Google packs), independent
+     * of bitmap rasterisation so the colour/path logic is unit-testable without
+     * an Android [Context]. Spot Map is handled by [SpotIcon] separately.
+     * Resolution order mirrors ATAK: explicit iconset path only (these packs
+     * have no dedicated CoT type the way Spot Map's `b-m-p-s-m` does).
+     */
+    fun resolveBadgeIcon(iconsetPath: String?): BadgeIcon? {
+        if (iconsetPath == null) return null
+        MarkerIcon.fromIconsetPath(iconsetPath)?.let { return it }
+        GoogleIcon.fromIconsetPath(iconsetPath)?.let { return it }
+        return null
+    }
 
     /**
      * Resolve a renderable bitmap for a marker. Returns null when no TAK-suite
      * icon applies, so the caller falls back to MIL-STD-2525 affiliation art.
      *
+     * @param context needed to decode the Markers / Google vector glyphs; may be
+     *   null for callers that only care about Spot Map (which is fully
+     *   runtime-rendered and needs no resources).
      * @param cotType CoT `type` (e.g. `b-m-p-s-m`, `a-f-G-U-C-I`).
      * @param iconsetPath `usericon iconsetpath` if the CoT carried one.
      * @param argb optional override colour (signed ARGB int from `<color>`);
@@ -147,6 +276,7 @@ object TakIconRegistry {
         iconsetPath: String? = null,
         argb: Int? = null,
         sizePx: Int = 64,
+        context: Context? = null,
     ): Bitmap? {
         // 1. Explicit Spot Map iconset path wins.
         if (iconsetPath != null) {
@@ -160,9 +290,11 @@ object TakIconRegistry {
             val color = argb ?: SpotIcon.WHITE.argb
             return spotDot(color, sizePx, "spot|type|$color")
         }
-        // 3. Unbundled bitmap packs (Markers/Google) would resolve here once a
-        //    clean asset source lands — intentionally null for now so the
-        //    caller keeps using the MIL-STD-2525 fallback rather than a blank.
+        // 3. Markers / Google bitmap packs — Material-Symbols (Apache-2.0)
+        //    vector glyphs on a rounded badge. Needs a Context to decode.
+        if (context != null) {
+            resolveBadgeIcon(iconsetPath)?.let { return badge(context, it, sizePx) }
+        }
         return null
     }
 
@@ -173,12 +305,17 @@ object TakIconRegistry {
      */
     fun handles(cotType: String?, iconsetPath: String?): Boolean =
         (iconsetPath != null && SpotIcon.fromIconsetPath(iconsetPath) != null) ||
-            cotType == SpotIcon.COT_TYPE
+            cotType == SpotIcon.COT_TYPE ||
+            resolveBadgeIcon(iconsetPath) != null
 
     /** Convenience: the rendered glyph for a selectable Spot Map icon (picker
      *  swatches, current-symbol rows). */
     fun bitmapFor(spot: SpotIcon, sizePx: Int = 64): Bitmap =
         spotDot(spot.argb, sizePx, "spot|sel|${spot.key}")
+
+    /** Convenience: the rendered badge for a selectable Markers / Google icon. */
+    fun bitmapFor(context: Context, icon: BadgeIcon, sizePx: Int = 64): Bitmap =
+        badge(context, icon, sizePx)
 
     /**
      * Stable image-registration key for the MapLibre style. Distinct from a
@@ -190,9 +327,32 @@ object TakIconRegistry {
             SpotIcon.fromIconsetPath(iconsetPath)?.let { spot ->
                 return "takicon-spot-${argb ?: spot.argb}"
             }
+            resolveBadgeIcon(iconsetPath)?.let { return "takicon-${it.pack.name.lowercase()}-${it.token}" }
         }
         if (cotType == SpotIcon.COT_TYPE) return "takicon-spot-${argb ?: SpotIcon.WHITE.argb}"
         return null
+    }
+
+    /**
+     * `data:image/png;base64,…` for a TAK-suite marker so the Cesium globe's
+     * `_billboard()` renders the exact same glyph the 2D map + picker show
+     * (3D parity, issue #98). Returns null when no TAK-suite icon applies.
+     */
+    fun dataUrlFor(
+        context: Context,
+        cotType: String?,
+        iconsetPath: String?,
+        argb: Int? = null,
+        sizePx: Int = 56,
+    ): String? {
+        val id = styleImageId(cotType, iconsetPath, argb) ?: return null
+        dataUrlCache.get(id)?.let { return it }
+        val bmp = resolveBitmap(cotType, iconsetPath, argb, sizePx, context) ?: return null
+        val out = ByteArrayOutputStream()
+        bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
+        val url = "data:image/png;base64," + Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
+        dataUrlCache.put(id, url)
+        return url
     }
 
     /**
@@ -234,6 +394,52 @@ object TakIconRegistry {
         return bmp
     }
 
+    /**
+     * Render a Markers / Google badge: a rounded-rect chip in the pack's tint
+     * with a white Material-Symbols glyph centred on it. Reads as a distinct map
+     * marker family from the Spot Map dots and the MIL-STD frames.
+     */
+    private fun badge(context: Context, icon: BadgeIcon, sizePx: Int): Bitmap {
+        val key = Key("badge|${icon.pack.name}|${icon.token}", sizePx)
+        cache.get(key)?.let { return it }
+
+        val bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        val inset = sizePx * 0.10f
+        val rect = RectF(inset, inset, sizePx - inset, sizePx - inset)
+        val radius = sizePx * 0.26f
+
+        // Drop shadow + filled chip in the pack tint.
+        val chip = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = icon.badgeArgb
+            style = Paint.Style.FILL
+            setShadowLayer(sizePx * 0.06f, 0f, sizePx * 0.02f, AndroidColor.argb(150, 0, 0, 0))
+        }
+        canvas.drawRoundRect(rect, radius, radius, chip)
+
+        // Thin white outline so dark chips read on dark imagery.
+        val outline = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = AndroidColor.argb(220, 255, 255, 255)
+            style = Paint.Style.STROKE
+            strokeWidth = (sizePx * 0.04f).coerceAtLeast(1f)
+        }
+        canvas.drawRoundRect(rect, radius, radius, outline)
+
+        // Centre the white glyph at ~60% of the badge.
+        val glyphSize = (sizePx * 0.60f).toInt().coerceAtLeast(1)
+        val drawable = ContextCompat.getDrawable(context, icon.drawableRes)
+        if (drawable != null) {
+            drawable.colorFilter = PorterDuffColorFilter(AndroidColor.WHITE, PorterDuff.Mode.SRC_IN)
+            val glyph = drawable.toBitmap(glyphSize, glyphSize, Bitmap.Config.ARGB_8888)
+            val left = (sizePx - glyphSize) / 2f
+            val top = (sizePx - glyphSize) / 2f
+            canvas.drawBitmap(glyph, left, top, Paint(Paint.ANTI_ALIAS_FLAG))
+        }
+
+        cache.put(key, bmp)
+        return bmp
+    }
+
     /** Perceived-luminance test used to pick a contrasting outline. */
     private fun isLight(argb: Int): Boolean {
         val rr = ((argb shr 16) and 0xFF) / 255.0
@@ -250,6 +456,9 @@ object TakIconRegistry {
         return if (a == 0) argb or 0xFF000000.toInt() else argb
     }
 
-    /** Clear the cache — call from `onTrimMemory` or test teardown. */
-    fun clear() = cache.evictAll()
+    /** Clear the caches — call from `onTrimMemory` or test teardown. */
+    fun clear() {
+        cache.evictAll()
+        dataUrlCache.evictAll()
+    }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuilders.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuilders.kt
@@ -64,9 +64,14 @@ object CotBuilders {
             append("/>")
             // ATAK / iTAK render FEMA markers (and any custom-glyph marker)
             // off the `iconsetpath` detail — emit it when present so peers
-            // with the catalog show the right symbol (#29).
+            // with the catalog show the right symbol (#29). Spot Map points
+            // (#98) additionally carry their swatch in <color argb>; ATAK reads
+            // the dot colour from there, not the CoT type.
             event.iconsetPath?.takeIf { it.isNotBlank() }?.let {
                 append("<usericon iconsetpath=\"").append(CotXml.escape(it)).append("\"/>")
+            }
+            event.colorArgb?.let {
+                append("<color argb=\"").append(it).append("\"/>")
             }
             if (event.remarks.isNotBlank()) {
                 append("<remarks>").append(CotXml.escape(event.remarks)).append("</remarks>")

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJson.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJson.kt
@@ -5,6 +5,7 @@ import org.json.JSONObject
 import soy.engindearing.omnitak.mobile.data.CoTAffiliation
 import soy.engindearing.omnitak.mobile.data.CoTEvent
 import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
+import soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry
 
 /**
  * Build the entity JSON payload `window.OmniBridge.setEntities(...)` consumes.
@@ -13,6 +14,11 @@ import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
  * (multirotor / fixed-wing UAS / infantry / etc.) instead of falling back
  * to a generic affiliation frame. Self stays sidc-less so it keeps the
  * friendly-affiliation frame circle.
+ *
+ * Issue #98 — a contact resolving to a standard TAK icon set (Spot Map via
+ * `<usericon iconsetpath>` / the `b-m-p-s-m` type) instead carries a `spot` hex
+ * colour so the globe renders the same coloured dot the 2D map + picker show.
+ * Resolution order mirrors ATAK: iconset path first, then CoT type, then SIDC.
  */
 internal fun buildCesiumEntitiesJson(
     contacts: List<CoTEvent>,
@@ -44,11 +50,33 @@ internal fun buildCesiumEntitiesJson(
                 c.callsign?.let { put("callsign", it) }
                 put("affiliation", affChar(c.affiliation))
                 put("kind", "contact")
-                put("sidc", MilStdIconService.getSidc(c.type))
+                // #98 — TAK icon-suite (Spot Map) resolves first; the dot's
+                // colour rides <color argb> (else the swatch default). The
+                // milsymbol branch on the JS side is skipped when `spot` is set.
+                val spotHex = spotHexFor(c)
+                if (spotHex != null) {
+                    put("spot", spotHex)
+                } else {
+                    put("sidc", MilStdIconService.getSidc(c.type))
+                }
             },
         )
     }
     return arr.toString()
+}
+
+/**
+ * `#RRGGBB` for a contact that resolves to a Spot Map icon, else null. Mirrors
+ * [TakIconRegistry] resolution: an explicit Spot Map iconset path or the
+ * `b-m-p-s-m` CoT type qualifies; the colour comes from `<color argb>` when the
+ * event carried one, otherwise the swatch named by the path (default white).
+ */
+private fun spotHexFor(c: CoTEvent): String? {
+    if (!TakIconRegistry.handles(c.type, c.iconsetPath)) return null
+    val argb = c.colorArgb?.let { TakIconRegistry.normalizeArgb(it) }
+        ?: c.iconsetPath?.let { TakIconRegistry.SpotIcon.fromIconsetPath(it)?.argb }
+        ?: TakIconRegistry.SpotIcon.WHITE.argb
+    return "#%06X".format(argb and 0x00FFFFFF)
 }
 
 private fun affChar(a: CoTAffiliation): String = when (a) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJson.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJson.kt
@@ -1,5 +1,6 @@
 package soy.engindearing.omnitak.mobile.ui.components
 
+import android.content.Context
 import org.json.JSONArray
 import org.json.JSONObject
 import soy.engindearing.omnitak.mobile.data.CoTAffiliation
@@ -15,16 +16,24 @@ import soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry
  * to a generic affiliation frame. Self stays sidc-less so it keeps the
  * friendly-affiliation frame circle.
  *
- * Issue #98 — a contact resolving to a standard TAK icon set (Spot Map via
- * `<usericon iconsetpath>` / the `b-m-p-s-m` type) instead carries a `spot` hex
- * colour so the globe renders the same coloured dot the 2D map + picker show.
+ * Issue #98 — a contact resolving to a standard TAK icon set carries its glyph
+ * so the globe matches the 2D map + picker exactly:
+ *  - Spot Map (via `<usericon iconsetpath>` / the `b-m-p-s-m` type) emits a
+ *    `spot` hex colour and the JS side draws the canvas dot.
+ *  - Markers / Google packs emit a fully-rendered `icon` data-URL (the same
+ *    badge bitmap the 2D map registers), so the JS side billboards it directly
+ *    without re-implementing each glyph.
  * Resolution order mirrors ATAK: iconset path first, then CoT type, then SIDC.
+ *
+ * @param context decodes the Markers / Google vector glyphs for the `icon`
+ *   data-URL; when null those packs fall back to their SIDC on the globe.
  */
 internal fun buildCesiumEntitiesJson(
     contacts: List<CoTEvent>,
     selfLat: Double?,
     selfLon: Double?,
     selfCallsign: String,
+    context: Context? = null,
 ): String {
     val arr = JSONArray()
     if (selfLat != null && selfLon != null && !selfLat.isNaN() && !selfLon.isNaN()) {
@@ -50,14 +59,19 @@ internal fun buildCesiumEntitiesJson(
                 c.callsign?.let { put("callsign", it) }
                 put("affiliation", affChar(c.affiliation))
                 put("kind", "contact")
-                // #98 — TAK icon-suite (Spot Map) resolves first; the dot's
-                // colour rides <color argb> (else the swatch default). The
-                // milsymbol branch on the JS side is skipped when `spot` is set.
+                // #98 — TAK icon-suite resolves first, mirroring ATAK order:
+                //   1. Spot Map → `spot` hex (JS draws the canvas dot); colour
+                //      rides <color argb>, else the swatch default.
+                //   2. Markers / Google → `icon` data-URL (the same badge bitmap
+                //      the 2D map registers), so the globe matches exactly.
+                //   3. otherwise the MIL-STD `sidc`.
+                // Setting `spot` or `icon` skips the milsymbol branch on JS.
                 val spotHex = spotHexFor(c)
-                if (spotHex != null) {
-                    put("spot", spotHex)
-                } else {
-                    put("sidc", MilStdIconService.getSidc(c.type))
+                val badgeUrl = if (spotHex == null && context != null) badgeUrlFor(context, c) else null
+                when {
+                    spotHex != null -> put("spot", spotHex)
+                    badgeUrl != null -> put("icon", badgeUrl)
+                    else -> put("sidc", MilStdIconService.getSidc(c.type))
                 }
             },
         )
@@ -70,13 +84,27 @@ internal fun buildCesiumEntitiesJson(
  * [TakIconRegistry] resolution: an explicit Spot Map iconset path or the
  * `b-m-p-s-m` CoT type qualifies; the colour comes from `<color argb>` when the
  * event carried one, otherwise the swatch named by the path (default white).
+ * Markers / Google packs are NOT spot dots — they go through [badgeUrlFor].
  */
 private fun spotHexFor(c: CoTEvent): String? {
-    if (!TakIconRegistry.handles(c.type, c.iconsetPath)) return null
+    val isSpot = c.type == TakIconRegistry.SpotIcon.COT_TYPE ||
+        (c.iconsetPath?.let { TakIconRegistry.SpotIcon.fromIconsetPath(it) != null } == true)
+    if (!isSpot) return null
     val argb = c.colorArgb?.let { TakIconRegistry.normalizeArgb(it) }
         ?: c.iconsetPath?.let { TakIconRegistry.SpotIcon.fromIconsetPath(it)?.argb }
         ?: TakIconRegistry.SpotIcon.WHITE.argb
     return "#%06X".format(argb and 0x00FFFFFF)
+}
+
+/**
+ * `data:image/png;base64,…` for a contact that resolves to a Markers / Google
+ * badge icon, else null. The data-URL is the exact same badge bitmap the 2D
+ * MapLibre layer registers, so the globe and the flat map render identically.
+ */
+private fun badgeUrlFor(context: Context, c: CoTEvent): String? {
+    if (TakIconRegistry.resolveBadgeIcon(c.iconsetPath) == null) return null
+    val argb = c.colorArgb?.let { TakIconRegistry.normalizeArgb(it) }
+    return TakIconRegistry.dataUrlFor(context, c.type, c.iconsetPath, argb)
 }
 
 private fun affChar(a: CoTAffiliation): String = when (a) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.viewinterop.AndroidView
 import org.json.JSONObject
@@ -72,6 +73,10 @@ fun CesiumMapView(
     snapNorthTrigger: Int = 0,
 ) {
     val density = LocalDensity.current.density
+    // #98 — app context to rasterise the Markers / Google badge glyphs into the
+    // `icon` data-URLs the globe billboards (held across recompositions so the
+    // pushEntities closure can read it).
+    val appContext = LocalContext.current.applicationContext
     val mainHandler = remember { Handler(Looper.getMainLooper()) }
     val ready = remember { mutableStateOf(false) }
     val webViewRef = remember { mutableStateOf<WebView?>(null) }
@@ -94,6 +99,7 @@ fun CesiumMapView(
         if (!ready.value) return
         val json = buildCesiumEntitiesJson(
             contactsState.value, selfLatState.value, selfLonState.value, selfCallsignState.value,
+            context = appContext,
         )
         wv.evaluateJavascript("window.OmniBridge.setEntities($json);", null)
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
@@ -83,6 +83,11 @@ fun CesiumMapView(
     val onLongPressState = rememberUpdatedState(onLongPress)
     val onContactTapState = rememberUpdatedState(onContactTap)
     val onCameraState = rememberUpdatedState(onCameraChanged)
+    // #95 — read the latest lock state inside the JS bridge callbacks so a
+    // globe that opens while north-up is already on gets the lock applied on
+    // bridge-ready (the change-driven DisposableEffect below only fires on a
+    // toggle, never on first composition).
+    val northUpLockedState = rememberUpdatedState(northUpLocked)
 
     fun pushEntities() {
         val wv = webViewRef.value ?: return
@@ -131,6 +136,16 @@ fun CesiumMapView(
                                 // operator was looking (#78).
                                 seedInheritedCamera()
                                 pushEntities()
+                                // #95 — apply the persisted north-up lock on
+                                // first ready so the globe respects it without
+                                // waiting for a toggle.
+                                if (northUpLockedState.value) {
+                                    webViewRef.value?.evaluateJavascript(
+                                        "if(window.OmniBridge&&window.OmniBridge.setNorthUpLocked)" +
+                                            "window.OmniBridge.setNorthUpLocked(true);",
+                                        null,
+                                    )
+                                }
                             }
                         }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
@@ -64,6 +64,12 @@ fun CesiumMapView(
     // silently ignoring it (the "panel never appears on Cesium" class).
     panTarget: LatLng? = null,
     panTargetTick: Int = 0,
+    /** Issue #95 — when true, globe rotates back to heading 0 (north-up)
+     *  and the scene's rotation gestures are suppressed via the JS bridge.
+     *  The Cesium HTML side must implement OmniBridge.setNorthUpLocked(bool). */
+    northUpLocked: Boolean = false,
+    /** Issue #95/#96 — tap the compass → snap globe heading to north. */
+    snapNorthTrigger: Int = 0,
 ) {
     val density = LocalDensity.current.density
     val mainHandler = remember { Handler(Looper.getMainLooper()) }
@@ -208,6 +214,31 @@ fun CesiumMapView(
         if (panTargetTick > 0 && t != null && ready.value) {
             webViewRef.value?.evaluateJavascript(
                 "window.OmniBridge.flyTo({lat:${t.latitude},lon:${t.longitude},range:3000});",
+                null,
+            )
+        }
+        onDispose { }
+    }
+
+    // Issue #95 — north-up lock on the Cesium globe. When ready, push the
+    // lock state to the JS bridge.  setNorthUpLocked(true) should disable
+    // rotation gestures in the scene and fly to heading 0; false restores.
+    DisposableEffect(northUpLocked) {
+        if (ready.value) {
+            webViewRef.value?.evaluateJavascript(
+                "if(window.OmniBridge&&window.OmniBridge.setNorthUpLocked)" +
+                    "window.OmniBridge.setNorthUpLocked(${northUpLocked});",
+                null,
+            )
+        }
+        onDispose { }
+    }
+    // Issue #95/#96 — manual snap to north (compass tap when lock is off).
+    DisposableEffect(snapNorthTrigger) {
+        if (snapNorthTrigger > 0 && ready.value) {
+            webViewRef.value?.evaluateJavascript(
+                "if(window.OmniBridge&&window.OmniBridge.snapToNorth)" +
+                    "window.OmniBridge.snapToNorth();",
                 null,
             )
         }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CompassOverlay.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CompassOverlay.kt
@@ -1,0 +1,66 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
+
+/**
+ * Issue #96 — small floating compass indicator.
+ *
+ * Shows the map's current bearing as a rotated "N" needle. The widget
+ * rotates so the "N" always points toward true north on the map surface —
+ * i.e. the widget itself rotates by -bearing so that when the map is
+ * rotated clockwise (positive bearing), the needle swings counter-clockwise
+ * to indicate where north really is.
+ *
+ * Tapping resets the map to north (bearing 0°) via [onTapToNorth].
+ *
+ * Styling matches the dark semi-transparent / cyan-accent overlay language
+ * used by [SelfPositionCard] and the UAS HUD pills.
+ */
+@Composable
+fun CompassOverlay(
+    /** Current map bearing in degrees clockwise from north (0–360). */
+    bearingDeg: Double,
+    /** Called when the user taps the compass — should animate map to north. */
+    onTapToNorth: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(44.dp)
+            .clip(CircleShape)
+            .background(TacticalBackground.copy(alpha = 0.88f))
+            .border(1.dp, TacticalAccent.copy(alpha = 0.55f), CircleShape)
+            .clickable { onTapToNorth() },
+        contentAlignment = Alignment.Center,
+    ) {
+        // The "N" rotates opposite to map bearing so it always points north.
+        Text(
+            text = "N",
+            color = TacticalAccent,
+            fontSize = 14.sp,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.rotate(-bearingDeg.toFloat()),
+        )
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
@@ -204,6 +204,7 @@ class ContactSymbolLayer {
             iconsetPath = c.iconsetPath,
             argb = argb,
             sizePx = ICON_PIXEL_SIZE,
+            context = context,
         ) ?: return null
         style.addImage(imageId, bitmap)
         registeredSidcs.add(imageId)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
@@ -25,6 +25,7 @@ import org.maplibre.android.style.sources.GeoJsonSource
 import soy.engindearing.omnitak.mobile.data.CoTEvent
 import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconCache
 import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
+import soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry
 
 /**
  * Experimental GeoJSON-source-driven contacts layer. Holds a single
@@ -75,6 +76,12 @@ class ContactSymbolLayer {
         const val PROP_CALLSIGN = "callsign"
         const val PROP_AFFILIATION = "affiliation"
         const val PROP_TYPE = "cotType"
+        // Fully-resolved MapLibre image name for this feature. Either
+        // `milstd-<sidc>` (MIL-STD-2525 path) or a TAK-icon-suite id
+        // (`takicon-spot-…`) when the contact resolves to a bundled iconset
+        // — issue #98. The symbol layer reads icon-image straight off this so
+        // the two symbol families coexist without colliding.
+        const val PROP_IMAGE = "iconImage"
 
         // Pixel size the cache rasterises at. 64 matches the legacy
         // Marker path and is the canonical milsymbol size.
@@ -103,7 +110,10 @@ class ContactSymbolLayer {
         style.addSource(source)
 
         val symbolLayer = SymbolLayer(SYMBOL_LAYER_ID, SOURCE_ID).withProperties(
-            iconImage(Expression.concat(Expression.literal(ICON_IMAGE_PREFIX), Expression.get(PROP_SIDC))),
+            // Per-feature resolved image name (MIL-STD `milstd-<sidc>` or a TAK
+            // icon-suite id). Computed in [featureJson] so the iconset-path
+            // branch (#98) and the SIDC branch share one rendering pass.
+            iconImage(Expression.get(PROP_IMAGE)),
             // Slight visual scale-down so the 64 px raster reads as a
             // map marker, not a sticker. Matches the legacy MarkerOptions
             // sizing on the Annotation path.
@@ -154,20 +164,50 @@ class ContactSymbolLayer {
             return 0
         }
 
-        // First pass: make sure every SIDC referenced by the
-        // FeatureCollection has its image registered. Skip rows
-        // with bad coordinates.
+        // First pass: make sure every image referenced by the
+        // FeatureCollection has been registered. Skip rows with bad
+        // coordinates. Issue #98 — a contact carrying a TAK-suite iconset
+        // (Spot Map today; Markers/Google when a clean pack lands) resolves to
+        // a bundled icon FIRST; everything else falls back to MIL-STD-2525.
         var newlyRegistered = 0
         val features = JSONArray()
         for (c in contacts) {
             if (c.lat.isNaN() || c.lon.isNaN()) continue
             val sidc = MilStdIconService.getSidc(c.type)
-            if (registerSidcImage(style, context, sidc)) newlyRegistered++
-            features.put(featureJson(c, sidc))
+            val takImageId = registerTakIconImage(style, context, c)
+            if (takImageId == null && registerSidcImage(style, context, sidc)) {
+                newlyRegistered++
+            }
+            val imageName = takImageId ?: (ICON_IMAGE_PREFIX + sidc)
+            features.put(featureJson(c, sidc, imageName))
         }
 
         GeoJsonLayerFeeder.push(style, SOURCE_ID, features)
         return newlyRegistered
+    }
+
+    /**
+     * Issue #98 — if [c] resolves to a bundled TAK icon-suite glyph (Spot Map
+     * via `<usericon iconsetpath>` or the `b-m-p-s-m` CoT type), rasterise +
+     * register it and return its style image id. Returns null when no TAK-suite
+     * icon applies, so the caller falls back to the MIL-STD path. The
+     * `iconsetPath` is consulted FIRST, before any SIDC lookup — exactly the
+     * resolution order ATAK / iTAK use, and the gap kymyura reported.
+     */
+    private fun registerTakIconImage(style: Style, context: Context, c: CoTEvent): String? {
+        if (!TakIconRegistry.handles(c.type, c.iconsetPath)) return null
+        val argb = c.colorArgb?.let { TakIconRegistry.normalizeArgb(it) }
+        val imageId = TakIconRegistry.styleImageId(c.type, c.iconsetPath, argb) ?: return null
+        if (imageId in registeredSidcs) return imageId
+        val bitmap = TakIconRegistry.resolveBitmap(
+            cotType = c.type,
+            iconsetPath = c.iconsetPath,
+            argb = argb,
+            sizePx = ICON_PIXEL_SIZE,
+        ) ?: return null
+        style.addImage(imageId, bitmap)
+        registeredSidcs.add(imageId)
+        return imageId
     }
 
     /**
@@ -199,7 +239,7 @@ class ContactSymbolLayer {
         return MilStdIconService.getDefinitionBySidc(sidc)?.value ?: "a-u-A"
     }
 
-    private fun featureJson(c: CoTEvent, sidc: String): JSONObject {
+    private fun featureJson(c: CoTEvent, sidc: String, imageName: String): JSONObject {
         return JSONObject().apply {
             put("type", "Feature")
             put("geometry", JSONObject().apply {
@@ -212,6 +252,7 @@ class ContactSymbolLayer {
             put("properties", JSONObject().apply {
                 put(PROP_UID, c.uid)
                 put(PROP_SIDC, sidc)
+                put(PROP_IMAGE, imageName)
                 put(PROP_CALLSIGN, c.callsign ?: c.uid)
                 put(PROP_AFFILIATION, c.affiliation.code.toString())
                 put(PROP_TYPE, c.type)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerEditSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerEditSheet.kt
@@ -1,6 +1,7 @@
 package soy.engindearing.omnitak.mobile.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -55,11 +56,21 @@ data class MarkerEditResult(
     val remarks: String,
     /**
      * Issue #98 — the full CoT type the operator chose from the icon
-     * picker (e.g. `a-h-G-U-C-A`). Null means "no specific symbol was
-     * picked" — the caller falls back to a generic per-affiliation point
-     * (`a-<aff>-G-U-C`), preserving the pre-icon-suite behavior.
+     * picker (e.g. `a-h-G-U-C-A`, or `b-m-p-s-m` for a Spot Map point). Null
+     * means "no specific symbol was picked" — the caller falls back to a
+     * generic per-affiliation point (`a-<aff>-G-U-C`), preserving the
+     * pre-icon-suite behavior.
      */
     val cotType: String?,
+    /**
+     * Issue #98 — `<usericon iconsetpath>` for the chosen icon when it belongs
+     * to a standard TAK icon set (Spot Map today). Null for MIL-STD-2525 picks.
+     * Emitted on the wire so peers render the identical glyph.
+     */
+    val iconsetPath: String? = null,
+    /** 8-hex opaque ARGB for the CoT `<color argb>` element (Spot Map swatch).
+     *  Null for MIL-STD picks, which carry their look in the symbol itself. */
+    val argbHex: String? = null,
 )
 
 /**
@@ -83,6 +94,9 @@ fun MarkerEditSheet(
      *  re-opens with the symbol it already carries. Null = no specific
      *  symbol picked yet (generic per-affiliation point). */
     initialCotType: String? = null,
+    /** Issue #98 — the marker's current `usericon` iconset path (Spot Map),
+     *  so an existing spot marker re-opens with its swatch highlighted. */
+    initialIconsetPath: String? = null,
     editing: Boolean = false,
     onSave: (MarkerEditResult) -> Unit,
     onDelete: (() -> Unit)? = null,
@@ -108,6 +122,18 @@ fun MarkerEditSheet(
     // re-affiliated so picking "armor" then flipping to hostile yields the
     // hostile-armor symbol without re-opening the picker.
     var cotType by remember(initialCotType) { mutableStateOf(initialCotType) }
+    // Issue #98 — Spot Map `usericon` path + swatch colour, when the operator
+    // picked a TAK-suite icon rather than a MIL-STD symbol. Cleared whenever a
+    // MIL-STD symbol or an affiliation chip is chosen so the two stay coherent.
+    var iconsetPath by remember(initialIconsetPath) { mutableStateOf(initialIconsetPath) }
+    var argbHex by remember(initialIconsetPath) {
+        mutableStateOf(
+            initialIconsetPath?.let {
+                soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry.SpotIcon
+                    .fromIconsetPath(it)?.argbHex
+            },
+        )
+    }
     var iconPickerOpen by remember { mutableStateOf(false) }
 
     ModalBottomSheet(
@@ -178,10 +204,14 @@ fun MarkerEditSheet(
                         selected = affiliation == a,
                         onClick = {
                             affiliation = a
-                            // Keep a picked symbol on the new side (#98).
-                            cotType = cotType?.let {
-                                soy.engindearing.omnitak.mobile.data.symbology
-                                    .MilStdIconService.withAffiliation(it, a.code)
+                            // Keep a picked MIL-STD symbol on the new side (#98).
+                            // Spot Map points are affiliation-agnostic (always
+                            // b-m-p-s-m) — leave their type + iconset path intact.
+                            if (iconsetPath == null) {
+                                cotType = cotType?.let {
+                                    soy.engindearing.omnitak.mobile.data.symbology
+                                        .MilStdIconService.withAffiliation(it, a.code)
+                                }
                             }
                         },
                     )
@@ -202,6 +232,7 @@ fun MarkerEditSheet(
             Spacer(Modifier.height(8.dp))
             MarkerSymbolRow(
                 cotType = cotType,
+                iconsetPath = iconsetPath,
                 onClick = { iconPickerOpen = true },
             )
 
@@ -259,6 +290,8 @@ fun MarkerEditSheet(
                                 altitudeMeters = altitudeText.toDoubleOrNull(),
                                 remarks = remarks.trim(),
                                 cotType = cotType,
+                                iconsetPath = iconsetPath,
+                                argbHex = argbHex,
                             )
                         )
                     },
@@ -272,15 +305,23 @@ fun MarkerEditSheet(
         }
     }
 
-    // Issue #98 — MIL-STD-2525 icon picker. Picking sets the CoT type and
-    // snaps the affiliation chips to match the symbol's own affiliation so
-    // the sheet stays internally consistent.
+    // Issue #98 — TAK icon-suite picker (Spot Map + MIL-STD-2525). A MIL-STD
+    // pick sets the CoT type and snaps the affiliation chips to match the
+    // symbol's own affiliation; a Spot Map pick sets the iconset path + swatch
+    // and leaves affiliation alone (spot points are affiliation-agnostic).
     MarkerIconPickerSheet(
         visible = iconPickerOpen,
         selectedCotType = cotType,
-        onPick = { def ->
-            cotType = def.value
-            affiliation = CoTAffiliation.fromCode(def.value.getOrNull(2))
+        selectedIconsetPath = iconsetPath,
+        onPick = { choice ->
+            cotType = choice.cotType
+            iconsetPath = choice.iconsetPath
+            argbHex = choice.argbHex
+            // Only re-affiliate for MIL-STD symbols; Spot Map paths carry no
+            // affiliation in the CoT type (always b-m-p-s-m).
+            if (choice.iconsetPath == null) {
+                affiliation = CoTAffiliation.fromCode(choice.cotType.getOrNull(2))
+            }
             iconPickerOpen = false
         },
         onDismiss = { iconPickerOpen = false },
@@ -295,18 +336,28 @@ fun MarkerEditSheet(
 @Composable
 private fun MarkerSymbolRow(
     cotType: String?,
+    iconsetPath: String?,
     onClick: () -> Unit,
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
-    val def = remember(cotType) {
-        cotType?.let {
+    // Issue #98 — a Spot Map pick is shown as its coloured dot + name, not a
+    // MIL-STD glyph (its type is the affiliation-agnostic b-m-p-s-m).
+    val spot = remember(iconsetPath) {
+        iconsetPath?.let {
+            soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry.SpotIcon.fromIconsetPath(it)
+        }
+    }
+    val def = remember(cotType, spot) {
+        if (spot != null) null
+        else cotType?.let {
             soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService.getDefinition(it)
         }
     }
     val bitmap by androidx.compose.runtime.produceState<androidx.compose.ui.graphics.ImageBitmap?>(
-        initialValue = null, cotType,
+        initialValue = null, cotType, spot,
     ) {
-        value = if (cotType == null) null else kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
+        value = if (cotType == null || spot != null) null
+        else kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
             soy.engindearing.omnitak.mobile.data.symbology.MilStdIconCache
                 .bitmapFor(context, cotType, sizePx = 72)
                 ?.asImageBitmap()
@@ -327,14 +378,20 @@ private fun MarkerSymbolRow(
             contentAlignment = Alignment.Center,
         ) {
             val bmp = bitmap
-            if (bmp != null) {
-                androidx.compose.foundation.Image(
+            when {
+                spot != null -> androidx.compose.foundation.layout.Box(
+                    Modifier
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(spot.color)
+                        .border(1.dp, Color.Black.copy(alpha = 0.4f), CircleShape),
+                )
+                bmp != null -> androidx.compose.foundation.Image(
                     bitmap = bmp,
                     contentDescription = def?.label,
                     modifier = Modifier.size(32.dp),
                 )
-            } else {
-                androidx.compose.material3.Icon(
+                else -> androidx.compose.material3.Icon(
                     imageVector = Icons.Filled.Category,
                     contentDescription = null,
                     tint = TacticalAccent.copy(alpha = 0.8f),
@@ -348,12 +405,12 @@ private fun MarkerSymbolRow(
             // marker carrying a type the picker doesn't enumerate (e.g. a
             // received RID track being re-typed), then to the prompt.
             Text(
-                def?.label ?: cotType ?: "Choose symbol",
+                spot?.let { "Spot ${it.displayName}" } ?: def?.label ?: cotType ?: "Choose symbol",
                 color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                cotType ?: "Generic point (by affiliation)",
+                iconsetPath ?: cotType ?: "Generic point (by affiliation)",
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
                 fontFamily = FontFamily.Monospace,
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerEditSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerEditSheet.kt
@@ -15,6 +15,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Category
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -34,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -49,6 +53,13 @@ data class MarkerEditResult(
     val affiliation: CoTAffiliation,
     val altitudeMeters: Double?,
     val remarks: String,
+    /**
+     * Issue #98 — the full CoT type the operator chose from the icon
+     * picker (e.g. `a-h-G-U-C-A`). Null means "no specific symbol was
+     * picked" — the caller falls back to a generic per-affiliation point
+     * (`a-<aff>-G-U-C`), preserving the pre-icon-suite behavior.
+     */
+    val cotType: String?,
 )
 
 /**
@@ -68,6 +79,10 @@ fun MarkerEditSheet(
     initialAffiliation: CoTAffiliation = CoTAffiliation.FRIEND,
     initialAltitude: Double? = null,
     initialRemarks: String = "",
+    /** Issue #98 — the marker's current CoT type, so an existing marker
+     *  re-opens with the symbol it already carries. Null = no specific
+     *  symbol picked yet (generic per-affiliation point). */
+    initialCotType: String? = null,
     editing: Boolean = false,
     onSave: (MarkerEditResult) -> Unit,
     onDelete: (() -> Unit)? = null,
@@ -88,6 +103,12 @@ fun MarkerEditSheet(
         mutableStateOf(initialAltitude?.let { "%.0f".format(it) } ?: "")
     }
     var remarks by remember(initialRemarks) { mutableStateOf(initialRemarks) }
+    // Issue #98 — selected CoT type from the icon picker. Null until the
+    // operator picks a specific symbol; the affiliation chips below keep it
+    // re-affiliated so picking "armor" then flipping to hostile yields the
+    // hostile-armor symbol without re-opening the picker.
+    var cotType by remember(initialCotType) { mutableStateOf(initialCotType) }
+    var iconPickerOpen by remember { mutableStateOf(false) }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -155,10 +176,34 @@ fun MarkerEditSheet(
                     AffiliationChip(
                         affiliation = a,
                         selected = affiliation == a,
-                        onClick = { affiliation = a },
+                        onClick = {
+                            affiliation = a
+                            // Keep a picked symbol on the new side (#98).
+                            cotType = cotType?.let {
+                                soy.engindearing.omnitak.mobile.data.symbology
+                                    .MilStdIconService.withAffiliation(it, a.code)
+                            }
+                        },
                     )
                 }
             }
+
+            // Issue #98 — symbol / icon row. Tapping opens the MIL-STD-2525
+            // picker; the chosen CoT type rides into the result so the placed
+            // marker resolves to that exact symbol (same path received markers
+            // use). When nothing is picked the marker stays a generic
+            // per-affiliation point — the pre-icon-suite behavior.
+            Spacer(Modifier.height(16.dp))
+            Text(
+                "Symbol",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Spacer(Modifier.height(8.dp))
+            MarkerSymbolRow(
+                cotType = cotType,
+                onClick = { iconPickerOpen = true },
+            )
 
             Spacer(Modifier.height(16.dp))
             OutlinedTextField(
@@ -213,6 +258,7 @@ fun MarkerEditSheet(
                                 affiliation = affiliation,
                                 altitudeMeters = altitudeText.toDoubleOrNull(),
                                 remarks = remarks.trim(),
+                                cotType = cotType,
                             )
                         )
                     },
@@ -224,6 +270,100 @@ fun MarkerEditSheet(
             }
             Spacer(Modifier.height(16.dp))
         }
+    }
+
+    // Issue #98 — MIL-STD-2525 icon picker. Picking sets the CoT type and
+    // snaps the affiliation chips to match the symbol's own affiliation so
+    // the sheet stays internally consistent.
+    MarkerIconPickerSheet(
+        visible = iconPickerOpen,
+        selectedCotType = cotType,
+        onPick = { def ->
+            cotType = def.value
+            affiliation = CoTAffiliation.fromCode(def.value.getOrNull(2))
+            iconPickerOpen = false
+        },
+        onDismiss = { iconPickerOpen = false },
+    )
+}
+
+/**
+ * Issue #98 — current-symbol row inside [MarkerEditSheet]. Shows the
+ * rendered MIL-STD glyph + label for the picked CoT type (or a "Choose
+ * symbol" prompt when none is picked) and opens the picker on tap.
+ */
+@Composable
+private fun MarkerSymbolRow(
+    cotType: String?,
+    onClick: () -> Unit,
+) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val def = remember(cotType) {
+        cotType?.let {
+            soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService.getDefinition(it)
+        }
+    }
+    val bitmap by androidx.compose.runtime.produceState<androidx.compose.ui.graphics.ImageBitmap?>(
+        initialValue = null, cotType,
+    ) {
+        value = if (cotType == null) null else kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
+            soy.engindearing.omnitak.mobile.data.symbology.MilStdIconCache
+                .bitmapFor(context, cotType, sizePx = 72)
+                ?.asImageBitmap()
+        }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(TacticalBackground)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        androidx.compose.foundation.layout.Box(
+            Modifier.size(36.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            val bmp = bitmap
+            if (bmp != null) {
+                androidx.compose.foundation.Image(
+                    bitmap = bmp,
+                    contentDescription = def?.label,
+                    modifier = Modifier.size(32.dp),
+                )
+            } else {
+                androidx.compose.material3.Icon(
+                    imageVector = Icons.Filled.Category,
+                    contentDescription = null,
+                    tint = TacticalAccent.copy(alpha = 0.8f),
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+        }
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            // Prefer the catalogue label; fall back to the raw type for a
+            // marker carrying a type the picker doesn't enumerate (e.g. a
+            // received RID track being re-typed), then to the prompt.
+            Text(
+                def?.label ?: cotType ?: "Choose symbol",
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                cotType ?: "Generic point (by affiliation)",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        androidx.compose.material3.Icon(
+            imageVector = Icons.Filled.ChevronRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+        )
     }
 }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerIconPickerSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerIconPickerSheet.kt
@@ -1,0 +1,256 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import soy.engindearing.omnitak.mobile.data.symbology.Affiliation
+import soy.engindearing.omnitak.mobile.data.symbology.CoTTypeDefinition
+import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconCache
+import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalSurface
+
+/**
+ * Issue #98 (Phase 1) — TAK icon-suite picker.
+ *
+ * Modal bottom sheet that exposes the full MIL-STD-2525 catalogue
+ * ([MilStdIconService.getAllDefinitions], 108 symbols loaded from
+ * `assets/cot_types.json`) so the operator can pick a *specific* CoT type
+ * — infantry, armor, aircraft, vessel — when placing a marker, instead of
+ * being limited to a generic per-affiliation point. The chosen CoT type is
+ * handed back as a raw string and flows straight into the placed
+ * [soy.engindearing.omnitak.mobile.data.CoTEvent.type], so the symbol
+ * renders through the same [soy.engindearing.omnitak.mobile.ui.components.ContactSymbolLayer]
+ * / Cesium milsymbol path that received markers already use — closing the
+ * "standard TAK icon sets … selectable when placing markers" half of #98.
+ *
+ * Modal-only (never compresses the full-screen map, per
+ * `feedback_omnitak_fullscreen_map`). Mirrors the FEMA palette
+ * ([FemaMarkerPaletteSheet]) styling so the two marker pickers feel like
+ * one family.
+ *
+ * The catalogue is grouped by affiliation. A free-text filter narrows by
+ * label or CoT type so the long list stays usable one-handed. Each tile
+ * rasterises its SVG via [MilStdIconCache] off the main thread.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MarkerIconPickerSheet(
+    visible: Boolean,
+    /** Highlighted on open so the operator sees their current choice. */
+    selectedCotType: String?,
+    onPick: (CoTTypeDefinition) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (!visible) return
+    val state = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var query by remember { mutableStateOf("") }
+
+    // Snapshot the active catalogue once per open. getAllDefinitions() is a
+    // volatile read of an immutable list, so this is cheap and stable.
+    val all = remember { MilStdIconService.getAllDefinitions() }
+    val filtered = remember(query, all) {
+        val q = query.trim()
+        if (q.isEmpty()) all
+        else all.filter {
+            it.label.contains(q, ignoreCase = true) ||
+                it.value.contains(q, ignoreCase = true) ||
+                it.description.contains(q, ignoreCase = true)
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = state,
+        containerColor = TacticalBackground,
+        scrimColor = Color.Black.copy(alpha = 0.35f),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+        ) {
+            Text(
+                "Marker Icon",
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Text(
+                "MIL-STD-2525 · ${all.size} SYMBOLS",
+                color = TacticalAccent,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+            Text(
+                "Pick the symbol this marker should use. Sent over CoT so peers see the same icon.",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.65f),
+                fontSize = 11.sp,
+                modifier = Modifier.padding(top = 2.dp, bottom = 8.dp),
+            )
+
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                label = { Text("Search icons") },
+                singleLine = true,
+                colors = pickerFieldColors(),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            if (filtered.isEmpty()) {
+                Text(
+                    "No symbols match “${query.trim()}”.",
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(vertical = 24.dp),
+                )
+            } else {
+                // The grid scrolls inside the (fully-expanded) sheet. Cap its
+                // height so the search field stays pinned and the map scrim is
+                // never fully hidden.
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(minSize = 84.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(420.dp),
+                ) {
+                    items(filtered, key = { it.value }) { def ->
+                        IconTile(
+                            def = def,
+                            selected = def.value == selectedCotType,
+                            onClick = { onPick(def) },
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun IconTile(
+    def: CoTTypeDefinition,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    // Rasterise the SVG off the main thread; null until ready (and on the
+    // rare asset miss, where the affiliation frame color below carries the
+    // affiliation read instead).
+    val bitmap by produceState<ImageBitmap?>(initialValue = null, def.value) {
+        value = withContext(Dispatchers.Default) {
+            MilStdIconCache.bitmapFor(context, def.value, sizePx = 96)?.asImageBitmap()
+        }
+    }
+    val frame = def.affiliation.frameColor
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (selected) TacticalAccent.copy(alpha = 0.18f) else TacticalSurface)
+            .border(
+                width = if (selected) 2.dp else 1.dp,
+                color = if (selected) TacticalAccent else frame.copy(alpha = 0.35f),
+                shape = RoundedCornerShape(10.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp, horizontal = 4.dp),
+    ) {
+        Box(
+            modifier = Modifier.size(44.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            val bmp = bitmap
+            if (bmp != null) {
+                androidx.compose.foundation.Image(
+                    bitmap = bmp,
+                    contentDescription = def.label,
+                    modifier = Modifier.size(40.dp),
+                )
+            } else {
+                // Asset still rendering, or missing — show the affiliation
+                // frame color as a placeholder dot so the tile never reads empty.
+                Box(
+                    Modifier
+                        .size(18.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(frame.copy(alpha = 0.5f)),
+                )
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            def.label,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
+            fontSize = 9.sp,
+            lineHeight = 11.sp,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun pickerFieldColors() = TextFieldDefaults.colors(
+    focusedTextColor = MaterialTheme.colorScheme.onBackground,
+    unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+    focusedContainerColor = TacticalSurface,
+    unfocusedContainerColor = TacticalSurface,
+    focusedIndicatorColor = TacticalAccent,
+    unfocusedIndicatorColor = TacticalAccent.copy(alpha = 0.4f),
+    focusedLabelColor = TacticalAccent,
+    unfocusedLabelColor = TacticalAccent.copy(alpha = 0.6f),
+    cursorColor = TacticalAccent,
+)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerIconPickerSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerIconPickerSheet.kt
@@ -58,10 +58,10 @@ import soy.engindearing.omnitak.mobile.ui.theme.TacticalSurface
 
 /**
  * Issue #98 — what the icon picker hands back. Either a MIL-STD-2525 symbol
- * (carries only a CoT [type]) or a standard TAK icon-suite icon (Spot Map
- * today; Markers/Google when a clean asset pack lands), which additionally
- * carries the `<usericon iconsetpath>` and optional swatch [argbHex] so the
- * placed marker round-trips byte-for-byte with ATAK / iTAK.
+ * (carries only a CoT [type]) or a standard TAK icon-suite icon — Spot Map,
+ * Markers, or Google — which additionally carries the `<usericon iconsetpath>`
+ * and (Spot Map only) the swatch [argbHex] so the placed marker round-trips
+ * byte-for-byte with ATAK / iTAK.
  */
 data class MarkerIconChoice(
     val cotType: String,
@@ -69,6 +69,12 @@ data class MarkerIconChoice(
     val argbHex: String? = null,
     val label: String,
 )
+
+/** CoT type ridden by Markers / Google placements. Those packs have no
+ *  dedicated type the way Spot Map owns `b-m-p-s-m`; an unknown-ground point is
+ *  the sensible cross-client fallback while the `usericon iconsetpath` carries
+ *  the actual glyph. */
+private const val BADGE_MARKER_COT_TYPE = "a-u-G"
 
 /**
  * Issue #98 (Phase 1) — TAK icon-suite picker.
@@ -83,12 +89,15 @@ data class MarkerIconChoice(
  *  - the full **MIL-STD-2525** catalogue ([MilStdIconService.getAllDefinitions],
  *    108 symbols from `assets/cot_types.json`) — infantry, armor, aircraft, …
  *
+ * plus the **Markers** and **Google** packs (Material-Symbols / Apache-2.0
+ * glyphs on a tinted badge — see [TakIconRegistry]) so received CoT carrying
+ * those iconset paths resolves and the same icons are selectable when placing.
+ *
  * The choice is handed back as a [MarkerIconChoice] and flows into the placed
  * [soy.engindearing.omnitak.mobile.data.CoTEvent], so the symbol renders
  * through the same [ContactSymbolLayer] / Cesium path received markers use —
  * closing the "standard TAK icon sets … selectable when placing markers" half
- * of #98. (Markers / Google bitmap packs are modeled in [TakIconRegistry] but
- * not bundled — GPL asset blocker, see that file.)
+ * of #98. (Per-marker import of arbitrary custom iconsets is Phase 2.)
  *
  * Modal-only (never compresses the full-screen map, per
  * `feedback_omnitak_fullscreen_map`). Mirrors the FEMA palette
@@ -181,6 +190,24 @@ fun MarkerIconPickerSheet(
                 }
             }
 
+            // ── Markers set ───────────────────────────────────────────────
+            // ATAK's general-purpose marker glyphs (flag / warning / vehicle …).
+            BadgeIconRow(
+                title = "MARKERS",
+                icons = TakIconRegistry.selectableMarkerIcons,
+                selectedIconsetPath = selectedIconsetPath,
+                onPick = onPick,
+            )
+
+            // ── Google POI set ────────────────────────────────────────────
+            // ATAK's Google place-marker pack (airport / hospital / gas …).
+            BadgeIconRow(
+                title = "GOOGLE",
+                icons = TakIconRegistry.selectableGoogleIcons,
+                selectedIconsetPath = selectedIconsetPath,
+                onPick = onPick,
+            )
+
             Text(
                 "MIL-STD-2525 · ${all.size} SYMBOLS",
                 color = TacticalAccent,
@@ -237,6 +264,115 @@ fun MarkerIconPickerSheet(
             }
             Spacer(Modifier.height(16.dp))
         }
+    }
+}
+
+/**
+ * A horizontally-scrolling row of bitmap-glyph icons for one badge pack
+ * (Markers / Google). Each tile renders the same badge bitmap the map draws and,
+ * when tapped, emits the pack's canonical `usericon iconsetpath` so the placed
+ * marker round-trips to ATAK / iTAK. These packs carry no per-icon colour, so a
+ * generic unknown-ground CoT type rides along as the receiver's fallback while
+ * the iconset path carries the real glyph.
+ */
+@Composable
+private fun <T> BadgeIconRow(
+    title: String,
+    icons: List<T>,
+    selectedIconsetPath: String?,
+    onPick: (MarkerIconChoice) -> Unit,
+) where T : TakIconRegistry.BadgeIcon {
+    Text(
+        title,
+        color = TacticalAccent,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.Bold,
+    )
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(top = 6.dp, bottom = 10.dp),
+    ) {
+        for (icon in icons) {
+            BadgeSwatch(
+                icon = icon,
+                selected = selectedIconsetPath?.equals(icon.iconsetPath, ignoreCase = true) == true,
+                onClick = {
+                    onPick(
+                        MarkerIconChoice(
+                            // No dedicated CoT type for these packs; an
+                            // unknown-ground point is the cross-client fallback.
+                            cotType = BADGE_MARKER_COT_TYPE,
+                            iconsetPath = icon.iconsetPath,
+                            argbHex = null,
+                            label = "${icon.pack.displayName} ${icon.displayName}",
+                        ),
+                    )
+                },
+            )
+        }
+    }
+}
+
+/** A single badge-pack icon tile — the rendered Markers / Google glyph the
+ *  operator taps to place that marker. Matches the badge bitmap [TakIconRegistry]
+ *  draws on the map so the picker preview and the placed marker are identical. */
+@Composable
+private fun BadgeSwatch(
+    icon: TakIconRegistry.BadgeIcon,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    val bitmap by produceState<ImageBitmap?>(initialValue = null, icon.token) {
+        value = withContext(Dispatchers.Default) {
+            TakIconRegistry.bitmapFor(context, icon, sizePx = 96).asImageBitmap()
+        }
+    }
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (selected) TacticalAccent.copy(alpha = 0.18f) else TacticalSurface)
+            .border(
+                width = if (selected) 2.dp else 1.dp,
+                color = if (selected) TacticalAccent else Color(icon.badgeArgb).copy(alpha = 0.5f),
+                shape = RoundedCornerShape(10.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp, horizontal = 8.dp),
+    ) {
+        Box(
+            modifier = Modifier.size(36.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            val bmp = bitmap
+            if (bmp != null) {
+                androidx.compose.foundation.Image(
+                    bitmap = bmp,
+                    contentDescription = icon.displayName,
+                    modifier = Modifier.size(32.dp),
+                )
+            } else {
+                Box(
+                    Modifier
+                        .size(20.dp)
+                        .clip(RoundedCornerShape(5.dp))
+                        .background(Color(icon.badgeArgb).copy(alpha = 0.6f)),
+                )
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            icon.displayName,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
+            fontSize = 9.sp,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerIconPickerSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerIconPickerSheet.kt
@@ -3,6 +3,9 @@ package soy.engindearing.omnitak.mobile.ui.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -48,32 +51,48 @@ import soy.engindearing.omnitak.mobile.data.symbology.Affiliation
 import soy.engindearing.omnitak.mobile.data.symbology.CoTTypeDefinition
 import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconCache
 import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
+import soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
 import soy.engindearing.omnitak.mobile.ui.theme.TacticalSurface
 
 /**
+ * Issue #98 — what the icon picker hands back. Either a MIL-STD-2525 symbol
+ * (carries only a CoT [type]) or a standard TAK icon-suite icon (Spot Map
+ * today; Markers/Google when a clean asset pack lands), which additionally
+ * carries the `<usericon iconsetpath>` and optional swatch [argbHex] so the
+ * placed marker round-trips byte-for-byte with ATAK / iTAK.
+ */
+data class MarkerIconChoice(
+    val cotType: String,
+    val iconsetPath: String? = null,
+    val argbHex: String? = null,
+    val label: String,
+)
+
+/**
  * Issue #98 (Phase 1) — TAK icon-suite picker.
  *
- * Modal bottom sheet that exposes the full MIL-STD-2525 catalogue
- * ([MilStdIconService.getAllDefinitions], 108 symbols loaded from
- * `assets/cot_types.json`) so the operator can pick a *specific* CoT type
- * — infantry, armor, aircraft, vessel — when placing a marker, instead of
- * being limited to a generic per-affiliation point. The chosen CoT type is
- * handed back as a raw string and flows straight into the placed
- * [soy.engindearing.omnitak.mobile.data.CoTEvent.type], so the symbol
- * renders through the same [soy.engindearing.omnitak.mobile.ui.components.ContactSymbolLayer]
- * / Cesium milsymbol path that received markers already use — closing the
- * "standard TAK icon sets … selectable when placing markers" half of #98.
+ * Modal bottom sheet exposing the standard TAK icon sets so the operator can
+ * pick a *specific* symbol when placing a marker instead of being limited to a
+ * generic per-affiliation point:
+ *  - the standard **Spot Map** set (ATAK's coloured points, the most common
+ *    script-pushed iconset) — selecting one emits the canonical `b-m-p-s-m`
+ *    CoT type + `COT_MAPPING_SPOTMAP/{color}` `usericon` path so peers render
+ *    the identical dot; and
+ *  - the full **MIL-STD-2525** catalogue ([MilStdIconService.getAllDefinitions],
+ *    108 symbols from `assets/cot_types.json`) — infantry, armor, aircraft, …
+ *
+ * The choice is handed back as a [MarkerIconChoice] and flows into the placed
+ * [soy.engindearing.omnitak.mobile.data.CoTEvent], so the symbol renders
+ * through the same [ContactSymbolLayer] / Cesium path received markers use —
+ * closing the "standard TAK icon sets … selectable when placing markers" half
+ * of #98. (Markers / Google bitmap packs are modeled in [TakIconRegistry] but
+ * not bundled — GPL asset blocker, see that file.)
  *
  * Modal-only (never compresses the full-screen map, per
  * `feedback_omnitak_fullscreen_map`). Mirrors the FEMA palette
- * ([FemaMarkerPaletteSheet]) styling so the two marker pickers feel like
- * one family.
- *
- * The catalogue is grouped by affiliation. A free-text filter narrows by
- * label or CoT type so the long list stays usable one-handed. Each tile
- * rasterises its SVG via [MilStdIconCache] off the main thread.
+ * ([FemaMarkerPaletteSheet]) styling so the marker pickers feel like one family.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -81,7 +100,10 @@ fun MarkerIconPickerSheet(
     visible: Boolean,
     /** Highlighted on open so the operator sees their current choice. */
     selectedCotType: String?,
-    onPick: (CoTTypeDefinition) -> Unit,
+    /** The marker's current iconset path, so a Spot Map pick stays highlighted
+     *  on re-open even though several spot colours share one CoT type. */
+    selectedIconsetPath: String? = null,
+    onPick: (MarkerIconChoice) -> Unit,
     onDismiss: () -> Unit,
 ) {
     if (!visible) return
@@ -119,17 +141,52 @@ fun MarkerIconPickerSheet(
                 style = MaterialTheme.typography.titleLarge,
             )
             Text(
+                "Pick the symbol this marker should use. Sent over CoT so peers see the same icon.",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.65f),
+                fontSize = 11.sp,
+                modifier = Modifier.padding(top = 4.dp, bottom = 8.dp),
+            )
+
+            // ── Spot Map set ──────────────────────────────────────────────
+            // ATAK's coloured points — the most common script-pushed iconset.
+            // A horizontal swatch row keeps it compact above the MIL-STD grid.
+            Text(
+                "SPOT MAP",
+                color = TacticalAccent,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(top = 6.dp, bottom = 10.dp),
+            ) {
+                for (spot in TakIconRegistry.selectableSpotIcons) {
+                    SpotSwatch(
+                        spot = spot,
+                        selected = selectedIconsetPath?.equals(spot.iconsetPath, ignoreCase = true) == true,
+                        onClick = {
+                            onPick(
+                                MarkerIconChoice(
+                                    cotType = TakIconRegistry.SpotIcon.COT_TYPE,
+                                    iconsetPath = spot.iconsetPath,
+                                    argbHex = spot.argbHex,
+                                    label = "Spot ${spot.displayName}",
+                                ),
+                            )
+                        },
+                    )
+                }
+            }
+
+            Text(
                 "MIL-STD-2525 · ${all.size} SYMBOLS",
                 color = TacticalAccent,
                 fontSize = 11.sp,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(top = 4.dp),
-            )
-            Text(
-                "Pick the symbol this marker should use. Sent over CoT so peers see the same icon.",
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.65f),
-                fontSize = 11.sp,
-                modifier = Modifier.padding(top = 2.dp, bottom = 8.dp),
+                modifier = Modifier.padding(bottom = 6.dp),
             )
 
             OutlinedTextField(
@@ -165,14 +222,60 @@ fun MarkerIconPickerSheet(
                     items(filtered, key = { it.value }) { def ->
                         IconTile(
                             def = def,
-                            selected = def.value == selectedCotType,
-                            onClick = { onPick(def) },
+                            // A MIL-STD tile is the active choice only when the
+                            // marker carries no iconset path (a Spot Map pick
+                            // shares the b-m-p-s-m type but owns the highlight).
+                            selected = selectedIconsetPath == null && def.value == selectedCotType,
+                            onClick = {
+                                onPick(
+                                    MarkerIconChoice(cotType = def.value, label = def.label),
+                                )
+                            },
                         )
                     }
                 }
             }
             Spacer(Modifier.height(16.dp))
         }
+    }
+}
+
+/** A single Spot Map colour swatch — a filled dot the operator taps to place
+ *  an ATAK spot point. Matches the runtime-rendered dot in [TakIconRegistry]. */
+@Composable
+private fun SpotSwatch(
+    spot: TakIconRegistry.SpotIcon,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (selected) TacticalAccent.copy(alpha = 0.18f) else TacticalSurface)
+            .border(
+                width = if (selected) 2.dp else 1.dp,
+                color = if (selected) TacticalAccent else spot.color.copy(alpha = 0.5f),
+                shape = RoundedCornerShape(10.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp, horizontal = 8.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .clip(CircleShape)
+                .background(spot.color)
+                .border(1.dp, Color.Black.copy(alpha = 0.4f), CircleShape),
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            spot.displayName,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
+            fontSize = 9.sp,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+        )
     }
 }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -98,6 +98,15 @@ fun TacticalMap(
     /** Camera idle: target, zoom, bearing (degrees clockwise from north).
      *  Bearing feeds the #78 engine-switch viewport handoff. */
     onCameraIdle: ((LatLng, Double, Double) -> Unit)? = null,
+    /** Issue #95 — when true, disable rotate gestures and snap/hold the
+     *  camera at bearing 0° (north-up). Animated on toggle so it doesn't
+     *  feel like a jump. */
+    northUpLocked: Boolean = false,
+    /** Issue #95/#96 — incremented by the compass tap or north-lock FAB
+     *  to animate the camera back to bearing 0° without toggling the lock
+     *  setting (useful when lock is off and the operator just wants to
+     *  quickly reset orientation). */
+    snapNorthTrigger: Int = 0,
     /** Fired once the MapLibre map is ready. Issue #16 — lasso uses
      *  this to grab the [MapLibreMap] reference for screen↔geo
      *  projection during freehand selection. */
@@ -121,6 +130,7 @@ fun TacticalMap(
     val currentCameraIdle by rememberUpdatedState(onCameraIdle)
     val currentMapReady by rememberUpdatedState(onMapReady)
     val currentStyleReady by rememberUpdatedState(onStyleReady)
+    val currentNorthUpLocked by rememberUpdatedState(northUpLocked)
     val currentTerrain3d by rememberUpdatedState(terrain3d)
     val currentSelfFix by rememberUpdatedState(selfFix)
     val currentFollowMe by rememberUpdatedState(followMeActive)
@@ -200,6 +210,17 @@ fun TacticalMap(
                 map.addOnCameraIdleListener {
                     val pos = map.cameraPosition
                     val target = pos.target ?: return@addOnCameraIdleListener
+                    // Issue #95 — if north-up lock is active and the bearing
+                    // somehow drifted (edge case: programmatic pan), snap back.
+                    if (currentNorthUpLocked && kotlin.math.abs(pos.bearing) > 0.5) {
+                        map.animateCamera(
+                            CameraUpdateFactory.newCameraPosition(
+                                CameraPosition.Builder(pos).bearing(0.0).build()
+                            ),
+                            250,
+                        )
+                        return@addOnCameraIdleListener
+                    }
                     currentCameraIdle?.invoke(target, pos.zoom, pos.bearing)
                 }
                 map.addOnMapLongClickListener { latLng ->
@@ -358,6 +379,47 @@ fun TacticalMap(
         }
         onDispose { }
     }
+
+    // Issue #95 — north-up lock: disable/re-enable rotate gestures and snap
+    // to bearing 0° when locked.  The MapLibre UiSettings gate is toggled
+    // every time the value flips; it persists on the map object until we
+    // change it, so no repeated enable is needed while the lock holds.
+    DisposableEffect(mapView, northUpLocked) {
+        mapView.getMapAsync { map ->
+            map.uiSettings.isRotateGesturesEnabled = !northUpLocked
+            if (northUpLocked) {
+                // Animate to north so the snap doesn't feel jarring.
+                val cur = map.cameraPosition
+                if (kotlin.math.abs(cur.bearing) > 0.5) {
+                    map.animateCamera(
+                        CameraUpdateFactory.newCameraPosition(
+                            CameraPosition.Builder(cur).bearing(0.0).build()
+                        ),
+                        350,
+                    )
+                }
+            }
+        }
+        onDispose { }
+    }
+    // Issue #95/#96 — manual snap-to-north: compass tap when lock is off.
+    DisposableEffect(mapView, snapNorthTrigger) {
+        if (snapNorthTrigger > 0) {
+            mapView.getMapAsync { map ->
+                val cur = map.cameraPosition
+                if (kotlin.math.abs(cur.bearing) > 0.5) {
+                    map.animateCamera(
+                        CameraUpdateFactory.newCameraPosition(
+                            CameraPosition.Builder(cur).bearing(0.0).build()
+                        ),
+                        350,
+                    )
+                }
+            }
+        }
+        onDispose { }
+    }
+
     // 3D terrain: tilt the camera so the DEM relief (baked into the
     // style JSON via injectTerrain) renders dimensionally. 0° = flat
     // top-down 2D; 55° = the dimensional tactical view. Animated so the

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
@@ -1,9 +1,11 @@
 package soy.engindearing.omnitak.mobile.ui.navigation
 
+import android.view.WindowManager
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -49,6 +51,40 @@ fun AppNav() {
     val app = LocalContext.current.applicationContext as OmniTAKApp
     val prefs by app.userPrefsStore.prefs.collectAsState(initial = UserPrefs())
     val scope = rememberCoroutineScope()
+
+    // Issue #97 — keep-screen-on, hoisted to the single-Activity / NavHost
+    // scope. AppNav hosts every destination, so applying FLAG_KEEP_SCREEN_ON
+    // here keeps the screen awake no matter which tab is showing (map, chat,
+    // ONVIF camera, mesh topology, …) for as long as OmniTAK is foreground —
+    // the acceptance bar in #97. A previous attempt scoped this to MapScreen's
+    // own DisposableEffect, so the flag was torn down the instant the operator
+    // left the map (the reported failure mode, relocated). FLAG_KEEP_SCREEN_ON
+    // is a window flag that the framework stops honoring while backgrounded, so
+    // foreground-only behavior is preserved for free; no WakeLock needed.
+    //
+    // The Compose context under enableEdgeToEdge + MaterialTheme is a
+    // ContextThemeWrapper, not the Activity, so walk the ContextWrapper chain
+    // to the real window. `decorView.keepScreenOn` is a belt-and-suspenders
+    // path that does not depend on resolving the Activity at all.
+    val keepScreenOn = prefs.keepScreenOn
+    val appNavContext = LocalContext.current
+    DisposableEffect(keepScreenOn) {
+        val window = appNavContext.findActivity()?.window
+        if (keepScreenOn) {
+            window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            window?.decorView?.keepScreenOn = true
+        } else {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            window?.decorView?.keepScreenOn = false
+        }
+        onDispose {
+            // Only fires when AppNav itself leaves composition (process /
+            // Activity teardown) — not on tab changes — so the flag persists
+            // across navigation while the setting is on.
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            window?.decorView?.keepScreenOn = false
+        }
+    }
 
     val nav = rememberNavController()
     val backStack by nav.currentBackStackEntryAsState()
@@ -376,4 +412,16 @@ fun AppNav() {
             onDismiss = { app.pendingProfileImport.value = null },
         )
     }
+}
+
+/**
+ * Issue #97 — resolve the hosting [android.app.Activity] from a Compose
+ * [android.content.Context]. Under enableEdgeToEdge + MaterialTheme that
+ * context is a ContextThemeWrapper rather than the Activity itself, so walk
+ * the ContextWrapper chain. Null if none is an Activity (e.g. preview / test).
+ */
+private tailrec fun android.content.Context.findActivity(): android.app.Activity? = when (this) {
+    is android.app.Activity -> this
+    is android.content.ContextWrapper -> baseContext.findActivity()
+    else -> null
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -400,22 +400,30 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         }
     }
 
-    // Issue #97 — keep-screen-on. Apply FLAG_KEEP_SCREEN_ON to the activity
-    // window while this composable is in composition AND the setting is on.
-    // DisposableEffect re-runs whenever keepScreenOn changes so the flag is
-    // added/cleared immediately when the operator toggles it in Settings.
+    // Issue #97 — keep-screen-on. The original fix cast LocalContext.current
+    // directly to Activity, but under enableEdgeToEdge + MaterialTheme that
+    // context is a ContextThemeWrapper, so the cast returned null and the
+    // window flag was never applied — the screen kept sleeping (the reported
+    // bug). Walk the ContextWrapper chain to the real Activity, and also set
+    // keepScreenOn on the decor view as a belt-and-suspenders path that does
+    // not depend on resolving the Activity at all. The DisposableEffect
+    // re-runs whenever keepScreenOn flips so the change takes effect at once.
     val context = LocalContext.current
     DisposableEffect(userPrefs.keepScreenOn) {
-        val window = (context as? android.app.Activity)?.window
+        val activity = context.findActivity()
+        val window = activity?.window
         if (userPrefs.keepScreenOn) {
             window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            window?.decorView?.keepScreenOn = true
         } else {
             window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            window?.decorView?.keepScreenOn = false
         }
         onDispose {
             // Remove the flag when the map screen leaves composition
             // (e.g. navigating to Settings) so the screen can sleep normally.
             window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            window?.decorView?.keepScreenOn = false
         }
     }
 
@@ -1541,6 +1549,8 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             initialAffiliation = editingMarker?.affiliation ?: CoTAffiliation.FRIEND,
             initialAltitude = editingMarker?.hae?.takeIf { it != 0.0 },
             initialRemarks = editingMarker?.remarks ?: "",
+            // Issue #98 — re-open an existing marker on the symbol it carries.
+            initialCotType = editingMarker?.type,
             editing = editingMarker != null,
             onSave = { result ->
                 val ll = markerSheetLatLng
@@ -1548,7 +1558,11 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                     val uid = editingMarker?.uid ?: "local-${System.currentTimeMillis()}"
                     val event = CoTEvent(
                         uid = uid,
-                        type = "a-${result.affiliation.code}-G-U-C",
+                        // Issue #98 — use the picked MIL-STD symbol when the
+                        // operator chose one; otherwise keep the generic
+                        // per-affiliation point so the pre-icon-suite default
+                        // is preserved.
+                        type = result.cotType ?: "a-${result.affiliation.code}-G-U-C",
                         lat = ll.latitude,
                         lon = ll.longitude,
                         hae = result.altitudeMeters ?: 0.0,
@@ -1979,4 +1993,16 @@ private fun MapControlFab(
     ) {
         Icon(icon, contentDescription = contentDescription, tint = tint)
     }
+}
+
+/**
+ * Issue #97 — resolve the hosting [android.app.Activity] from a Compose
+ * [android.content.Context], which under enableEdgeToEdge + MaterialTheme is
+ * a ContextThemeWrapper rather than the Activity itself. Walks the
+ * ContextWrapper chain; null if none is an Activity (e.g. preview / test).
+ */
+private tailrec fun android.content.Context.findActivity(): android.app.Activity? = when (this) {
+    is android.app.Activity -> this
+    is android.content.ContextWrapper -> baseContext.findActivity()
+    else -> null
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -1,5 +1,6 @@
 package soy.engindearing.omnitak.mobile.ui.screens
 
+import android.view.WindowManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -65,6 +66,7 @@ import soy.engindearing.omnitak.mobile.data.GeoMath
 import soy.engindearing.omnitak.mobile.domain.ConnectionState
 import soy.engindearing.omnitak.mobile.i18n.Loc
 import soy.engindearing.omnitak.mobile.ui.components.ATAKStatusBar
+import soy.engindearing.omnitak.mobile.ui.components.CompassOverlay
 import soy.engindearing.omnitak.mobile.ui.components.ContactsPanel
 import soy.engindearing.omnitak.mobile.ui.components.LayersDialog
 import soy.engindearing.omnitak.mobile.ui.components.MarkerEditSheet
@@ -150,6 +152,10 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     var recenterTick by remember { mutableStateOf(0) }
     var zoomInTick by remember { mutableStateOf(0) }
     var zoomOutTick by remember { mutableStateOf(0) }
+    // Issue #95/#96 — snap-to-north trigger (compass tap when lock is off)
+    // and live bearing for the compass overlay.
+    var snapNorthTick by remember { mutableStateOf(0) }
+    var currentBearing by remember { mutableStateOf(0.0) }
     var measurementActive by remember { mutableStateOf(false) }
     // UAS waypoint-add mode — when true, taps on the map drop mission
     // waypoints instead of any other action. Toggled from the mission
@@ -372,6 +378,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     }
     val handleCameraChanged: (LatLng, Double, Double) -> Unit = { target, zoom, bearing ->
         cameraTarget = target
+        currentBearing = bearing
         app.mapCameraStore.update(target.latitude, target.longitude, zoom, bearing)
     }
     // Keep the ADSB query box following the viewport — significant pans
@@ -390,6 +397,25 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         adsbPlugin.cameraCenterProvider = {
             val c = cameraTarget ?: selfFix?.let { LatLng(it.lat, it.lon) }
             c?.let { soy.engindearing.omnitak.plugin.PluginLatLng(it.latitude, it.longitude) }
+        }
+    }
+
+    // Issue #97 — keep-screen-on. Apply FLAG_KEEP_SCREEN_ON to the activity
+    // window while this composable is in composition AND the setting is on.
+    // DisposableEffect re-runs whenever keepScreenOn changes so the flag is
+    // added/cleared immediately when the operator toggles it in Settings.
+    val context = LocalContext.current
+    DisposableEffect(userPrefs.keepScreenOn) {
+        val window = (context as? android.app.Activity)?.window
+        if (userPrefs.keepScreenOn) {
+            window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            // Remove the flag when the map screen leaves composition
+            // (e.g. navigating to Settings) so the screen can sleep normally.
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }
 
@@ -449,6 +475,9 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             // Center) fly the globe instead of being silently eaten.
             panTarget = panTarget,
             panTargetTick = panTargetTick,
+            // Issue #95 — north-up lock + compass snap for the globe.
+            northUpLocked = userPrefs.northUpLocked,
+            snapNorthTrigger = snapNorthTick,
         )
         // Plugin map overlays on the GLOBE engine. The handle is null here
         // (no MapLibreMap on Cesium), so an overlay that can only draw on
@@ -569,6 +598,9 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 soy.engindearing.omnitak.mobile.ui.components.KmlOverlayRenderer
                     .applyRaster(style, rasterImagery, app.rasterOverlayStore)
             },
+            // Issue #95 — north-up lock + tap-to-reset support.
+            northUpLocked = userPrefs.northUpLocked,
+            snapNorthTrigger = snapNorthTick,
         )
         // Plugin map overlays on the MAPLIBRE engine. The handle is the live
         // MapLibreMap (captured via onMapReady above; null briefly until the
@@ -1255,6 +1287,25 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 }
             },
             modifier = Modifier.align(Alignment.BottomEnd),
+        )
+
+        // Issue #96 — compass overlay. Floats at top-start corner, just below
+        // the status bar. Shows live bearing; tapping snaps map to north.
+        // The MapLibre built-in compass is already on top-start (issue #81),
+        // but it disappears when north-up — this one is always visible and
+        // provides the manual snap action.
+        CompassOverlay(
+            bearingDeg = currentBearing,
+            onTapToNorth = {
+                if (userPrefs.northUpLocked) {
+                    // Already locked — snap is automatic; just a no-op tap.
+                } else {
+                    snapNorthTick++
+                }
+            },
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(start = 12.dp, top = 72.dp),
         )
 
         // Map control stack — zoom in / zoom out / center-on-me — at the

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -1,6 +1,5 @@
 package soy.engindearing.omnitak.mobile.ui.screens
 
-import android.view.WindowManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -400,32 +399,11 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         }
     }
 
-    // Issue #97 — keep-screen-on. The original fix cast LocalContext.current
-    // directly to Activity, but under enableEdgeToEdge + MaterialTheme that
-    // context is a ContextThemeWrapper, so the cast returned null and the
-    // window flag was never applied — the screen kept sleeping (the reported
-    // bug). Walk the ContextWrapper chain to the real Activity, and also set
-    // keepScreenOn on the decor view as a belt-and-suspenders path that does
-    // not depend on resolving the Activity at all. The DisposableEffect
-    // re-runs whenever keepScreenOn flips so the change takes effect at once.
-    val context = LocalContext.current
-    DisposableEffect(userPrefs.keepScreenOn) {
-        val activity = context.findActivity()
-        val window = activity?.window
-        if (userPrefs.keepScreenOn) {
-            window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-            window?.decorView?.keepScreenOn = true
-        } else {
-            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-            window?.decorView?.keepScreenOn = false
-        }
-        onDispose {
-            // Remove the flag when the map screen leaves composition
-            // (e.g. navigating to Settings) so the screen can sleep normally.
-            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-            window?.decorView?.keepScreenOn = false
-        }
-    }
+    // Issue #97 — keep-screen-on now lives at the AppNav / single-Activity
+    // scope (see AppNav.kt) so the screen stays awake on every destination
+    // while OmniTAK is foreground, not just while the map tab is composed.
+    // Scoping it here previously tore the flag down the moment the operator
+    // opened another tab — the exact reported failure mode.
 
     Box(
         modifier = Modifier
@@ -1551,6 +1529,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             initialRemarks = editingMarker?.remarks ?: "",
             // Issue #98 — re-open an existing marker on the symbol it carries.
             initialCotType = editingMarker?.type,
+            initialIconsetPath = editingMarker?.iconsetPath,
             editing = editingMarker != null,
             onSave = { result ->
                 val ll = markerSheetLatLng
@@ -1568,6 +1547,11 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                         hae = result.altitudeMeters ?: 0.0,
                         callsign = result.callsign,
                         remarks = result.remarks,
+                        // Issue #98 — Spot Map (or other TAK-suite) glyph. The
+                        // iconset path + colour ride the wire so peers render
+                        // the identical dot; null for MIL-STD picks.
+                        iconsetPath = result.iconsetPath,
+                        colorArgb = result.argbHex?.toLong(16)?.toInt(),
                     )
                     app.contactStore.ingest(event)
                     val verb = if (editingMarker != null) Loc.t("marker.verb.updated")
@@ -1993,16 +1977,4 @@ private fun MapControlFab(
     ) {
         Icon(icon, contentDescription = contentDescription, tint = tint)
     }
-}
-
-/**
- * Issue #97 — resolve the hosting [android.app.Activity] from a Compose
- * [android.content.Context], which under enableEdgeToEdge + MaterialTheme is
- * a ContextThemeWrapper rather than the Activity itself. Walks the
- * ContextWrapper chain; null if none is an Activity (e.g. preview / test).
- */
-private tailrec fun android.content.Context.findActivity(): android.app.Activity? = when (this) {
-    is android.app.Activity -> this
-    is android.content.ContextWrapper -> baseContext.findActivity()
-    else -> null
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -515,6 +515,53 @@ fun SettingsScreen(
                 }
             }
 
+            // Issue #95 / #97 — map behaviour toggles.
+            SectionHeader("Map")
+            // North-up lock (#95)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Lock north-up",
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        "Disable map rotation and always face north",
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = prefs.northUpLocked,
+                    onCheckedChange = { v -> mutate { it.copy(northUpLocked = v) } },
+                )
+            }
+            // Keep screen on (#97)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Keep screen on",
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        "Prevent screen from sleeping while the map is open",
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = prefs.keepScreenOn,
+                    onCheckedChange = { v -> mutate { it.copy(keepScreenOn = v) } },
+                )
+            }
+
             // About — the route was registered in AppNav since 0.1 but
             // nothing navigated to it after the bottom-bar rework dropped
             // the About tab. This row is the entry point.

--- a/app/src/main/res/drawable/takicon_google_airport.xml
+++ b/app/src/main/res/drawable/takicon_google_airport.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Google" POI pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M21,16v-2l-8,-5V3.5c0,-0.83 -0.67,-1.5 -1.5,-1.5S10,2.67 10,3.5V9l-8,5v2l8,-2.5V19l-2,1.5V22l3.5,-1 3.5,1v-1.5L13,19v-5.5L21,16z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_google_fire.xml
+++ b/app/src/main/res/drawable/takicon_google_fire.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Google" POI pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M13.5,0.67s0.74,2.65 0.74,4.8c0,2.06 -1.35,3.73 -3.41,3.73 -2.07,0 -3.63,-1.67 -3.63,-3.73l0.03,-0.36C5.21,7.51 4,10.62 4,14c0,4.42 3.58,8 8,8s8,-3.58 8,-8C20,8.61 17.41,3.8 13.5,0.67zM11.71,19c-1.78,0 -3.22,-1.4 -3.22,-3.14 0,-1.62 1.05,-2.76 2.81,-3.12 1.77,-0.36 3.6,-1.21 4.62,-2.58 0.39,1.29 0.59,2.65 0.59,4.04 0,2.65 -2.15,4.8 -4.8,4.8z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_google_gas.xml
+++ b/app/src/main/res/drawable/takicon_google_gas.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Google" POI pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M19.77,7.23l0.01,-0.01 -3.72,-3.72L15,4.56l2.11,2.11c-0.94,0.36 -1.61,1.26 -1.61,2.33 0,1.38 1.12,2.5 2.5,2.5 0.36,0 0.69,-0.08 1,-0.21v7.21c0,0.55 -0.45,1 -1,1s-1,-0.45 -1,-1V14c0,-1.1 -0.9,-2 -2,-2h-1V5c0,-1.1 -0.9,-2 -2,-2H6c-1.1,0 -2,0.9 -2,2v16h9v-7.5h1.5v5c0,1.38 1.12,2.5 2.5,2.5s2.5,-1.12 2.5,-2.5V9c0,-0.69 -0.28,-1.32 -0.73,-1.77zM12,10H6V5h6v5zM18,10c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1 1,0.45 1,1 -0.45,1 -1,1z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_google_hospital.xml
+++ b/app/src/main/res/drawable/takicon_google_hospital.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Google" POI pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M18,3H6C4.9,3 4,3.9 4,5v14c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V5C20,3.9 19.1,3 18,3zM17,13h-4v4h-2v-4H7v-2h4V7h2v4h4V13z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_google_lodging.xml
+++ b/app/src/main/res/drawable/takicon_google_lodging.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Google" POI pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M7,13c1.66,0 3,-1.34 3,-3S8.66,7 7,7s-3,1.34 -3,3 1.34,3 3,3zM19,7h-8v7H3V5H1v15h2v-3h18v3h2v-9c0,-2.21 -1.79,-4 -4,-4z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_google_parking.xml
+++ b/app/src/main/res/drawable/takicon_google_parking.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Google" POI pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M13,3H6v18h4v-6h3c3.31,0 6,-2.69 6,-6S16.31,3 13,3zM13.2,11H10V7h3.2c1.1,0 2,0.9 2,2s-0.9,2 -2,2z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_google_police.xml
+++ b/app/src/main/res/drawable/takicon_google_police.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Google" POI pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5L12,1zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94V12H5V6.3l7,-3.11v8.8z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_google_restaurant.xml
+++ b/app/src/main/res/drawable/takicon_google_restaurant.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Google" POI pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M11,9H9V2H7v7H5V2H3v7c0,2.12 1.66,3.84 3.75,3.97V22h2.5v-9.03C11.34,12.84 13,11.12 13,9V2h-2v7zM16,6v8h2.5v8H21V2C18.24,2 16,4.24 16,6z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_marker_aircraft.xml
+++ b/app/src/main/res/drawable/takicon_marker_aircraft.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Markers" pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M21,16v-2l-8,-5V3.5c0,-0.83 -0.67,-1.5 -1.5,-1.5S10,2.67 10,3.5V9l-8,5v2l8,-2.5V19l-2,1.5V22l3.5,-1 3.5,1v-1.5L13,19v-5.5L21,16z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_marker_boat.xml
+++ b/app/src/main/res/drawable/takicon_marker_boat.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Markers" pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M20,21c-1.39,0 -2.78,-0.47 -4,-1.32 -2.44,1.71 -5.56,1.71 -8,0C6.78,20.53 5.39,21 4,21H2v2h2c1.38,0 2.74,-0.35 4,-0.99 2.52,1.29 5.48,1.29 8,0 1.26,0.65 2.62,0.99 4,0.99h2v-2h-2zM3.95,19H4c1.6,0 3.02,-0.88 4,-2 0.98,1.12 2.4,2 4,2s3.02,-0.88 4,-2c0.98,1.12 2.4,2 4,2h0.05l1.89,-6.68c0.08,-0.26 0.06,-0.54 -0.06,-0.78s-0.34,-0.42 -0.6,-0.5L20,10.62V6c0,-1.1 -0.9,-2 -2,-2h-3V1H9v3H6c-1.1,0 -2,0.9 -2,2v4.62l-1.29,0.42c-0.26,0.08 -0.48,0.26 -0.6,0.5s-0.15,0.52 -0.06,0.78L3.95,19zM6,6h12v3.97L12,8 6,9.97V6z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_marker_circle.xml
+++ b/app/src/main/res/drawable/takicon_marker_circle.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Markers" pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_marker_flag.xml
+++ b/app/src/main/res/drawable/takicon_marker_flag.xml
@@ -1,0 +1,16 @@
+<!--
+  TAK icon-suite "Markers" pack glyph (issue #98). Glyph path from the
+  Material Symbols set (Apache License 2.0, github.com/google/material-design-icons)
+  so it is clean-licensed to ship in the closed Play binary. White fill;
+  TakIconRegistry tints + badges it at runtime.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_marker_person.xml
+++ b/app/src/main/res/drawable/takicon_marker_person.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Markers" pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_marker_star.xml
+++ b/app/src/main/res/drawable/takicon_marker_star.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Markers" pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_marker_vehicle.xml
+++ b/app/src/main/res/drawable/takicon_marker_vehicle.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Markers" pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M18.92,6.01C18.72,5.42 18.16,5 17.5,5h-11c-0.66,0 -1.21,0.42 -1.42,1.01L3,12v8c0,0.55 0.45,1 1,1h1c0.55,0 1,-0.45 1,-1v-1h12v1c0,0.55 0.45,1 1,1h1c0.55,0 1,-0.45 1,-1v-8l-2.08,-5.99zM6.5,16c-0.83,0 -1.5,-0.67 -1.5,-1.5S5.67,13 6.5,13s1.5,0.67 1.5,1.5S7.33,16 6.5,16zM17.5,16c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5zM5,11l1.5,-4.5h11L19,11H5z" />
+</vector>

--- a/app/src/main/res/drawable/takicon_marker_warning.xml
+++ b/app/src/main/res/drawable/takicon_marker_warning.xml
@@ -1,0 +1,13 @@
+<!--
+  TAK icon-suite "Markers" pack glyph (issue #98). Material Symbols (Apache-2.0).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M1,21h22L12,2L1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z" />
+</vector>

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconServiceTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/MilStdIconServiceTest.kt
@@ -267,4 +267,29 @@ class MilStdIconServiceTest {
             MilStdIconService.load(emptyList())
         }
     }
+
+    // ---- Re-affiliation (#98 marker icon picker) -------------------------
+
+    @Test
+    fun `withAffiliation swaps the affiliation segment and keeps the tail`() {
+        // Hostile armor <-> friendly armor: only the 2nd token flips so the
+        // affiliation chips can retype a picked symbol without re-opening the
+        // picker.
+        assertEquals("a-f-G-U-C-A", MilStdIconService.withAffiliation("a-h-G-U-C-A", 'f'))
+        assertEquals("a-h-G-U-C-A", MilStdIconService.withAffiliation("a-f-G-U-C-A", 'h'))
+        assertEquals("a-n-A-M-F-Q", MilStdIconService.withAffiliation("a-u-A-M-F-Q", 'n'))
+    }
+
+    @Test
+    fun `withAffiliation falls back to a generic point for a too-short type`() {
+        assertEquals("a-u-G-U-C", MilStdIconService.withAffiliation("a", 'u'))
+    }
+
+    @Test
+    fun `withAffiliation result still resolves to the matching SIDC`() {
+        // The re-affiliated type must round-trip through getSidc to the
+        // friendly-armor symbol (not the hostile one it started as).
+        val reaff = MilStdIconService.withAffiliation("a-h-G-U-C-A", 'f')
+        assertEquals("SFGPUCA----", MilStdIconService.getSidc(reaff))
+    }
 }

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistryTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistryTest.kt
@@ -1,0 +1,180 @@
+package soy.engindearing.omnitak.mobile.data.symbology
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #98 — the standard TAK icon suite must resolve an `iconsetpath` to a
+ * bundled icon for BOTH a received marker (inbound CoT carrying a `<usericon
+ * iconsetpath="COT_MAPPING_SPOTMAP/…">`) and a placed marker (the picker emits
+ * the same path back onto the wire). These assertions exercise the resolution +
+ * selection framework that drives both directions. (Bitmap rasterisation is the
+ * Android-framework half and is covered implicitly on-device; here we pin the
+ * path/colour logic that decides WHICH bundled icon a marker resolves to.)
+ */
+class TakIconRegistryTest {
+
+    // ---- Received-marker resolution (inbound iconsetpath) ----------------
+
+    @Test
+    fun `spot map iconset path resolves to the matching swatch`() {
+        // kymyura's exact use case: a script pushes CoT with
+        // <usericon iconsetpath="COT_MAPPING_SPOTMAP/red">. It must resolve.
+        val spot = TakIconRegistry.SpotIcon.fromIconsetPath("COT_MAPPING_SPOTMAP/red")
+        assertNotNull(spot)
+        assertEquals(TakIconRegistry.SpotIcon.RED, spot)
+    }
+
+    @Test
+    fun `every canonical spot color resolves from its iconset path`() {
+        for (spot in TakIconRegistry.SpotIcon.entries) {
+            val resolved = TakIconRegistry.SpotIcon.fromIconsetPath("COT_MAPPING_SPOTMAP/${spot.key}")
+            assertEquals(spot, resolved)
+        }
+    }
+
+    @Test
+    fun `spot map path match is case insensitive on the prefix and token`() {
+        assertEquals(
+            TakIconRegistry.SpotIcon.GREEN,
+            TakIconRegistry.SpotIcon.fromIconsetPath("cot_mapping_spotmap/GREEN"),
+        )
+    }
+
+    @Test
+    fun `unknown spot token falls back to white rather than null`() {
+        // A spot marker must never render blank; an unrecognised colour token
+        // resolves to white (ATAK's behaviour) so the dot still draws.
+        assertEquals(
+            TakIconRegistry.SpotIcon.WHITE,
+            TakIconRegistry.SpotIcon.fromIconsetPath("COT_MAPPING_SPOTMAP/chartreuse"),
+        )
+    }
+
+    @Test
+    fun `label-only spot path resolves to null so the caller keeps its fallback`() {
+        // A trailing empty token (`…SPOTMAP/`) is a label-only spot, not a
+        // colour — return null so the caller doesn't invent a white dot.
+        assertNull(TakIconRegistry.SpotIcon.fromIconsetPath("COT_MAPPING_SPOTMAP/"))
+    }
+
+    @Test
+    fun `non-spot iconset path does not resolve to a spot`() {
+        // A FEMA or Google path must NOT be mistaken for a Spot Map icon.
+        assertNull(TakIconRegistry.SpotIcon.fromIconsetPath("COT_MAPPING_FEMA/medical/triage_station"))
+        assertNull(TakIconRegistry.SpotIcon.fromIconsetPath("f7f71666-8b28-4b57-9fbb-e38e61d33b79/Google/airports.png"))
+    }
+
+    @Test
+    fun `handles is true for a spot iconset path and for the spot cot type`() {
+        assertTrue(TakIconRegistry.handles("b-m-p-s-m", "COT_MAPPING_SPOTMAP/blue"))
+        // Colour rides <color>, so the bare spot CoT type is enough on its own.
+        assertTrue(TakIconRegistry.handles("b-m-p-s-m", null))
+    }
+
+    @Test
+    fun `handles is false for a plain MIL-STD contact`() {
+        // A regular friendly-infantry contact must fall through to MIL-STD, not
+        // the TAK-suite path — otherwise we'd stop drawing milsymbol glyphs.
+        assertFalse(TakIconRegistry.handles("a-f-G-U-C-I", null))
+        assertFalse(TakIconRegistry.handles("a-u-A-M-H-Q", null))
+    }
+
+    // ---- Placed-marker emission (outbound iconsetpath) ------------------
+
+    @Test
+    fun `placing a spot icon emits the canonical COT_MAPPING_SPOTMAP path`() {
+        // The picker hands this path back; it goes out on the wire verbatim so
+        // ATAK / iTAK peers render the identical dot. Round-trips with the
+        // resolver above.
+        assertEquals("COT_MAPPING_SPOTMAP/red", TakIconRegistry.SpotIcon.RED.iconsetPath)
+        assertEquals("COT_MAPPING_SPOTMAP/cyan", TakIconRegistry.SpotIcon.CYAN.iconsetPath)
+    }
+
+    @Test
+    fun `placed spot path round-trips back through the resolver`() {
+        for (spot in TakIconRegistry.SpotIcon.entries) {
+            assertEquals(spot, TakIconRegistry.SpotIcon.fromIconsetPath(spot.iconsetPath))
+        }
+    }
+
+    @Test
+    fun `spot cot type is the canonical ATAK spot-map point type`() {
+        assertEquals("b-m-p-s-m", TakIconRegistry.SpotIcon.COT_TYPE)
+    }
+
+    @Test
+    fun `spot argb hex is an opaque 8-char ARGB string`() {
+        val hex = TakIconRegistry.SpotIcon.RED.argbHex
+        assertEquals(8, hex.length)
+        assertTrue(hex.startsWith("FF"))
+        // Round-trips to the swatch RGB.
+        assertEquals(0x00FFFFFF and TakIconRegistry.SpotIcon.RED.argb, hex.substring(2).toInt(16))
+    }
+
+    // ---- Style image-id keying (received-marker render path) ------------
+
+    @Test
+    fun `style image id is stable per spot colour and distinct from MIL-STD`() {
+        val id = TakIconRegistry.styleImageId("b-m-p-s-m", "COT_MAPPING_SPOTMAP/red", null)
+        assertNotNull(id)
+        assertTrue(id!!.startsWith("takicon-"))
+        // Two markers of the same resolved colour share one registered image.
+        assertEquals(
+            id,
+            TakIconRegistry.styleImageId("b-m-p-s-m", "COT_MAPPING_SPOTMAP/red", null),
+        )
+        // A MIL-STD contact yields no TAK-suite image id (it uses milstd-<sidc>).
+        assertNull(TakIconRegistry.styleImageId("a-f-G-U-C-I", null, null))
+    }
+
+    @Test
+    fun `explicit color argb overrides the swatch in the image id`() {
+        // A received spot whose <color argb> differs from its named swatch keys
+        // a distinct image so the dot is tinted to the sender's actual colour.
+        val named = TakIconRegistry.styleImageId("b-m-p-s-m", "COT_MAPPING_SPOTMAP/red", null)
+        val custom = TakIconRegistry.styleImageId("b-m-p-s-m", "COT_MAPPING_SPOTMAP/red", 0xFF00FF00.toInt())
+        assertNotNull(custom)
+        assertTrue(named != custom)
+    }
+
+    // ---- Colour normalisation -------------------------------------------
+
+    @Test
+    fun `normalizeArgb treats a zero alpha as opaque`() {
+        // CoT <color> often omits alpha (0x00RRGGBB); a 0 alpha must render as
+        // opaque or the dot would be invisible.
+        val opaque = TakIconRegistry.normalizeArgb(0x0000FF00)
+        assertEquals(0xFF.toLong(), ((opaque.toLong() shr 24) and 0xFF))
+    }
+
+    @Test
+    fun `normalizeArgb leaves an explicit alpha untouched`() {
+        assertEquals(0xFF112233.toInt(), TakIconRegistry.normalizeArgb(0xFF112233.toInt()))
+    }
+
+    // ---- Pack catalogue (selection framework) ---------------------------
+
+    @Test
+    fun `spot map pack is bundled and offers every swatch for selection`() {
+        val spotPack = TakIconRegistry.availablePacks.first { it == TakIconRegistry.TakIconPack.SPOT_MAP }
+        assertTrue(spotPack.bundled)
+        assertEquals(TakIconRegistry.SpotIcon.entries.size, TakIconRegistry.selectableSpotIcons.size)
+    }
+
+    @Test
+    fun `markers and google packs are modeled but flagged unbundled`() {
+        // Phase-1 asset blocker: the bitmap packs are known to the framework so
+        // they slot in behind the same API later, but must report unbundled so
+        // we never claim an icon we can't actually draw.
+        assertFalse(TakIconRegistry.TakIconPack.MARKERS.bundled)
+        assertFalse(TakIconRegistry.TakIconPack.GOOGLE.bundled)
+        // The Google UID matches ATAK's canonical iconset UID so an inbound
+        // Google iconsetpath would key to the right (future) pack.
+        assertEquals("f7f71666-8b28-4b57-9fbb-e38e61d33b79", TakIconRegistry.TakIconPack.GOOGLE.uid)
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistryTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistryTest.kt
@@ -69,6 +69,128 @@ class TakIconRegistryTest {
         assertNull(TakIconRegistry.SpotIcon.fromIconsetPath("f7f71666-8b28-4b57-9fbb-e38e61d33b79/Google/airports.png"))
     }
 
+    // ---- Markers pack resolution (inbound iconsetpath) ------------------
+
+    @Test
+    fun `markers iconset path resolves to the matching glyph`() {
+        // A script pushing CoT with <usericon iconsetpath="COT_MAPPING_2525C/flag">
+        // must resolve to the Markers flag glyph, not fall through to MIL-STD.
+        val icon = TakIconRegistry.MarkerIcon.fromIconsetPath("COT_MAPPING_2525C/flag")
+        assertEquals(TakIconRegistry.MarkerIcon.FLAG, icon)
+    }
+
+    @Test
+    fun `every markers glyph round-trips through its iconset path`() {
+        for (icon in TakIconRegistry.MarkerIcon.entries) {
+            assertEquals(icon, TakIconRegistry.MarkerIcon.fromIconsetPath(icon.iconsetPath))
+        }
+    }
+
+    @Test
+    fun `markers path match is case insensitive`() {
+        assertEquals(
+            TakIconRegistry.MarkerIcon.WARNING,
+            TakIconRegistry.MarkerIcon.fromIconsetPath("cot_mapping_2525c/WARNING"),
+        )
+    }
+
+    @Test
+    fun `unknown markers token falls back to circle rather than null`() {
+        // A Markers marker must never render blank; an unrecognised token
+        // resolves to the neutral circle glyph so the marker still draws.
+        assertEquals(
+            TakIconRegistry.MarkerIcon.CIRCLE,
+            TakIconRegistry.MarkerIcon.fromIconsetPath("COT_MAPPING_2525C/unobtainium"),
+        )
+    }
+
+    @Test
+    fun `markers resolver ignores a spot or google path`() {
+        assertNull(TakIconRegistry.MarkerIcon.fromIconsetPath("COT_MAPPING_SPOTMAP/red"))
+        assertNull(TakIconRegistry.MarkerIcon.fromIconsetPath("f7f71666-8b28-4b57-9fbb-e38e61d33b79/Google/airports.png"))
+    }
+
+    // ---- Google POI pack resolution (inbound iconsetpath) ---------------
+
+    @Test
+    fun `google iconset path resolves to the matching poi glyph`() {
+        // ATAK emits the Google pack as `<uid>/Google/<name>.png`; the basename
+        // (sans group + .png) must resolve to the right POI glyph.
+        val icon = TakIconRegistry.GoogleIcon.fromIconsetPath(
+            "f7f71666-8b28-4b57-9fbb-e38e61d33b79/Google/airports.png",
+        )
+        assertEquals(TakIconRegistry.GoogleIcon.AIRPORT, icon)
+    }
+
+    @Test
+    fun `every google glyph round-trips through its iconset path`() {
+        for (icon in TakIconRegistry.GoogleIcon.entries) {
+            assertEquals(icon, TakIconRegistry.GoogleIcon.fromIconsetPath(icon.iconsetPath))
+        }
+    }
+
+    @Test
+    fun `google resolver tolerates a png suffix and a group segment`() {
+        assertEquals(
+            TakIconRegistry.GoogleIcon.HOSPITAL,
+            TakIconRegistry.GoogleIcon.fromIconsetPath(
+                "f7f71666-8b28-4b57-9fbb-e38e61d33b79/hospitals.png",
+            ),
+        )
+    }
+
+    @Test
+    fun `unknown google token falls back to airport rather than null`() {
+        assertEquals(
+            TakIconRegistry.GoogleIcon.AIRPORT,
+            TakIconRegistry.GoogleIcon.fromIconsetPath(
+                "f7f71666-8b28-4b57-9fbb-e38e61d33b79/Google/teleporter.png",
+            ),
+        )
+    }
+
+    @Test
+    fun `google resolver ignores a spot or markers path`() {
+        assertNull(TakIconRegistry.GoogleIcon.fromIconsetPath("COT_MAPPING_SPOTMAP/red"))
+        assertNull(TakIconRegistry.GoogleIcon.fromIconsetPath("COT_MAPPING_2525C/flag"))
+    }
+
+    // ---- Cross-pack badge resolution + handles --------------------------
+
+    @Test
+    fun `resolveBadgeIcon routes each pack to its own catalogue`() {
+        assertEquals(
+            TakIconRegistry.MarkerIcon.STAR,
+            TakIconRegistry.resolveBadgeIcon("COT_MAPPING_2525C/star"),
+        )
+        assertEquals(
+            TakIconRegistry.GoogleIcon.GAS,
+            TakIconRegistry.resolveBadgeIcon("f7f71666-8b28-4b57-9fbb-e38e61d33b79/gas_stations.png"),
+        )
+        // Spot Map and MIL-STD are not badge packs.
+        assertNull(TakIconRegistry.resolveBadgeIcon("COT_MAPPING_SPOTMAP/red"))
+        assertNull(TakIconRegistry.resolveBadgeIcon(null))
+    }
+
+    @Test
+    fun `handles is true for markers and google iconset paths`() {
+        assertTrue(TakIconRegistry.handles("a-u-G", "COT_MAPPING_2525C/flag"))
+        assertTrue(TakIconRegistry.handles("a-u-G", "f7f71666-8b28-4b57-9fbb-e38e61d33b79/police.png"))
+    }
+
+    @Test
+    fun `style image id is stable and distinct per badge pack`() {
+        val flag = TakIconRegistry.styleImageId("a-u-G", "COT_MAPPING_2525C/flag", null)
+        val star = TakIconRegistry.styleImageId("a-u-G", "COT_MAPPING_2525C/star", null)
+        val gas = TakIconRegistry.styleImageId("a-u-G", "f7f71666-8b28-4b57-9fbb-e38e61d33b79/gas_stations.png", null)
+        assertNotNull(flag)
+        assertTrue(flag!!.startsWith("takicon-markers-"))
+        assertTrue(gas!!.startsWith("takicon-google-"))
+        // Distinct glyphs key distinct images; the same glyph keys one image.
+        assertTrue(flag != star)
+        assertEquals(flag, TakIconRegistry.styleImageId("a-u-G", "COT_MAPPING_2525C/flag", null))
+    }
+
     @Test
     fun `handles is true for a spot iconset path and for the spot cot type`() {
         assertTrue(TakIconRegistry.handles("b-m-p-s-m", "COT_MAPPING_SPOTMAP/blue"))
@@ -167,14 +289,23 @@ class TakIconRegistryTest {
     }
 
     @Test
-    fun `markers and google packs are modeled but flagged unbundled`() {
-        // Phase-1 asset blocker: the bitmap packs are known to the framework so
-        // they slot in behind the same API later, but must report unbundled so
-        // we never claim an icon we can't actually draw.
-        assertFalse(TakIconRegistry.TakIconPack.MARKERS.bundled)
-        assertFalse(TakIconRegistry.TakIconPack.GOOGLE.bundled)
+    fun `markers and google packs are bundled and selectable`() {
+        // Phase-1 deliverable: all three standard sets ship and are selectable.
+        // Glyphs are Material-Symbols (Apache-2.0) vector drawables, so the
+        // bitmap packs are genuinely bundled — not stubbed.
+        assertTrue(TakIconRegistry.TakIconPack.MARKERS.bundled)
+        assertTrue(TakIconRegistry.TakIconPack.GOOGLE.bundled)
+        assertTrue(TakIconRegistry.selectableMarkerIcons.isNotEmpty())
+        assertTrue(TakIconRegistry.selectableGoogleIcons.isNotEmpty())
         // The Google UID matches ATAK's canonical iconset UID so an inbound
-        // Google iconsetpath would key to the right (future) pack.
+        // Google iconsetpath keys to the right pack.
         assertEquals("f7f71666-8b28-4b57-9fbb-e38e61d33b79", TakIconRegistry.TakIconPack.GOOGLE.uid)
+    }
+
+    @Test
+    fun `all three standard tak icon sets report bundled`() {
+        // The acceptance-criteria check: Markers / Spots / Google all present.
+        val bundled = TakIconRegistry.availablePacks.filter { it.bundled }.map { it.displayName }.toSet()
+        assertTrue(bundled.containsAll(setOf("Spot Map", "Markers", "Google")))
     }
 }

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuildersUserIconTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuildersUserIconTest.kt
@@ -1,9 +1,13 @@
 package soy.engindearing.omnitak.mobile.domain
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.CoTParser
+import soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry
 
 /**
  * #29 — CotBuilders.rebuildEvent must emit `<usericon iconsetpath="…">`
@@ -59,6 +63,81 @@ class CotBuildersUserIconTest {
         assertTrue(
             "iconsetPath quote not escaped in:\n$xml",
             xml.contains("""foo&quot;bar"""),
+        )
+    }
+
+    // ---- #98 Spot Map round-trip (placed -> wire -> received) ------------
+
+    @Test fun rebuildEvent_emits_spotmap_usericon_and_color() {
+        // A placed Spot Map marker carries the canonical CoT type, the
+        // COT_MAPPING_SPOTMAP usericon path, and its swatch colour in <color>.
+        val spot = TakIconRegistry.SpotIcon.RED
+        val event = CoTEvent(
+            uid = "spot-1",
+            type = TakIconRegistry.SpotIcon.COT_TYPE,
+            lat = 47.6588,
+            lon = -117.4260,
+            callsign = "SPOT-1",
+            iconsetPath = spot.iconsetPath,
+            colorArgb = spot.argb,
+        )
+        val xml = CotBuilders.rebuildEvent(event, destUids = emptyList())
+        assertTrue(
+            "missing spot usericon in:\n$xml",
+            xml.contains("""<usericon iconsetpath="COT_MAPPING_SPOTMAP/red"/>"""),
+        )
+        assertTrue("missing <color argb> in:\n$xml", xml.contains("""<color argb="${spot.argb}"/>"""))
+    }
+
+    @Test fun spotmap_marker_round_trips_through_wire_back_to_the_same_icon() {
+        // End-to-end: the exact path kymyura's scripts exercise. A placed spot
+        // marker emitted to the wire must re-parse on the receiving side back to
+        // the identical iconset path + colour, and the registry must resolve
+        // that received path to the same bundled swatch (not a MIL-STD fallback).
+        val spot = TakIconRegistry.SpotIcon.GREEN
+        val placed = CoTEvent(
+            uid = "spot-2",
+            type = TakIconRegistry.SpotIcon.COT_TYPE,
+            lat = 12.34,
+            lon = 56.78,
+            callsign = "SPOT-2",
+            iconsetPath = spot.iconsetPath,
+            colorArgb = spot.argb,
+        )
+        val wire = CotBuilders.rebuildEvent(placed, destUids = emptyList())
+
+        // Receiving side parses the wire CoT.
+        val received = CoTParser.parse(wire)
+        assertNotNull("received event failed to parse:\n$wire", received)
+        assertEquals(spot.iconsetPath, received!!.iconsetPath)
+        assertEquals(spot.argb, received.colorArgb)
+
+        // Received marker resolves to the same bundled Spot Map icon — the
+        // gap that previously fell through to a generic MIL-STD symbol.
+        assertTrue(TakIconRegistry.handles(received.type, received.iconsetPath))
+        assertEquals(spot, TakIconRegistry.SpotIcon.fromIconsetPath(received.iconsetPath!!))
+    }
+
+    @Test fun received_scripted_spotmap_cot_resolves_without_a_color_element() {
+        // A minimal scripted spot (path only, no <color>) still resolves — to
+        // the swatch named in the path. Mirrors a bare iTAK / script push.
+        val wire = """
+            <event version="2.0" uid="ext-1" type="b-m-p-s-m" time="2026-01-01T00:00:00Z"
+                   start="2026-01-01T00:00:00Z" stale="2026-01-01T00:05:00Z" how="h-g-i-g-o">
+              <point lat="1.0" lon="2.0" hae="0" ce="9999999" le="9999999"/>
+              <detail>
+                <contact callsign="EXT"/>
+                <usericon iconsetpath="COT_MAPPING_SPOTMAP/orange"/>
+              </detail>
+            </event>
+        """.trimIndent()
+        val received = CoTParser.parse(wire)
+        assertNotNull(received)
+        assertEquals("COT_MAPPING_SPOTMAP/orange", received!!.iconsetPath)
+        assertTrue(TakIconRegistry.handles(received.type, received.iconsetPath))
+        assertEquals(
+            TakIconRegistry.SpotIcon.ORANGE,
+            TakIconRegistry.SpotIcon.fromIconsetPath(received.iconsetPath!!),
         )
     }
 }


### PR DESCRIPTION
## Summary

Three field requests from r/ATAK (u/Straight-Sherbert604), issue thread: https://www.reddit.com/r/ATAK/comments/1u4yyxn/requests_for_the_omnitak_app/

- **North-up lock** (#95): persisted toggle in Settings → Map. Disables MapLibre rotate gestures and animates to bearing 0°; enforced on camera-idle. Cesium bridge stubs added (setNorthUpLocked/snapToNorth) for parity once the JS side is wired.
- **Corner compass** (#96): `CompassOverlay.kt` — small floating circle at top-start, always visible. The "N" rotates so it always points toward true north. Tap snaps the map to north (manual reset when lock is off; no-op when lock is on since bearing is held automatically).
- **Keep-screen-on fix** (#97): `FLAG_KEEP_SCREEN_ON` is now actually applied to the activity window via a `DisposableEffect` in `MapScreen`. The flag is removed when MapScreen leaves composition. Toggle is in Settings → Map, persisted across launches.

Closes #95
Closes #96
Closes #97

## Files changed

| Feature | Files |
|---------|-------|
| Data layer (#95, #97) | `data/UserPrefs.kt` — `northUpLocked` + `keepScreenOn` fields, DataStore keys, read/write |
| Compass overlay (#96) | `ui/components/CompassOverlay.kt` (new) |
| MapLibre engine (#95) | `ui/components/TacticalMap.kt` — `northUpLocked` + `snapNorthTrigger` params, DisposableEffects |
| Cesium engine (#95) | `ui/components/CesiumMapView.kt` — JS bridge stubs |
| Map screen wiring | `ui/screens/MapScreen.kt` — DisposableEffect for window flag (#97), live bearing state, compass overlay placement, snapNorthTick |
| Settings UI (#95, #97) | `ui/screens/SettingsScreen.kt` — Settings → Map section with both toggles |

## Test plan

- [ ] Toggle "Lock north-up" in Settings → map rotation gesture is blocked; map snaps to north; persists after kill/relaunch
- [ ] Rotate map then tap compass overlay → map animates to north
- [ ] With north-up locked, tap compass → no duplicate snap (already north)
- [ ] Toggle "Keep screen on" → screen does NOT sleep while app is foreground; turning it off restores normal idle timeout
- [ ] Navigate away from map to Settings → screen-on flag is cleared (screen can sleep on settings screen)
- [ ] Both settings survive app kill and cold start