### PR TITLE
Map rendering parity + edge-to-edge inset fixes (mozios batch)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/DrawingHitTest.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/DrawingHitTest.kt
@@ -1,0 +1,131 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import soy.engindearing.omnitak.mobile.data.Drawing
+import soy.engindearing.omnitak.mobile.data.DrawingKind
+import kotlin.math.hypot
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Issue #76 — screen-space hit-testing for operator drawings so a tap can
+ * select a circle / line / polygon and surface edit / move / delete (parity
+ * with marker tap interactions).
+ *
+ * All geometry runs in SCREEN PIXELS: the caller projects each drawing
+ * vertex to pixels via the live map projection and hands us flat points.
+ * Keeping the math screen-space (and free of any MapLibre/Android type)
+ * makes it unit-testable on the JVM and matches how the marker hit-test in
+ * [soy.engindearing.omnitak.mobile.ui.components.TacticalMap] already works.
+ *
+ * A point hits:
+ *  - LINE: within [tolerancePx] of any segment.
+ *  - POLYGON: inside the ring, OR within [tolerancePx] of any edge (so the
+ *    thin outline is still grabbable on a near-degenerate shape).
+ *  - CIRCLE: inside the disc, OR within [tolerancePx] of the rim — stored as
+ *    [center, edge], radius = |edge - center| in pixels.
+ */
+object DrawingHitTest {
+
+    /** A drawing's vertices already projected to screen pixels. */
+    data class Projected(val id: String, val kind: DrawingKind, val points: List<Pair<Float, Float>>)
+
+    /**
+     * Return the id of the topmost drawing hit by [px],[py], or null. "Topmost"
+     * = last in [drawings] (later drawings paint over earlier ones), so we scan
+     * in reverse and take the first hit.
+     */
+    fun hitId(
+        drawings: List<Projected>,
+        px: Float,
+        py: Float,
+        tolerancePx: Float,
+    ): String? {
+        for (i in drawings.indices.reversed()) {
+            val d = drawings[i]
+            if (hits(d, px, py, tolerancePx)) return d.id
+        }
+        return null
+    }
+
+    fun hits(d: Projected, px: Float, py: Float, tolerancePx: Float): Boolean {
+        val pts = d.points
+        if (pts.isEmpty()) return false
+        return when (d.kind) {
+            DrawingKind.LINE -> nearAnySegment(pts, px, py, tolerancePx)
+            DrawingKind.POLYGON ->
+                pointInPolygon(pts, px, py) || nearAnySegment(closeRing(pts), px, py, tolerancePx)
+            DrawingKind.CIRCLE -> {
+                val (cx, cy) = pts.first()
+                val (ex, ey) = pts.getOrElse(1) { pts.first() }
+                val radius = hypot((ex - cx).toDouble(), (ey - cy).toDouble()).toFloat()
+                val dist = hypot((px - cx).toDouble(), (py - cy).toDouble()).toFloat()
+                // Inside the disc OR within tolerance of the rim.
+                dist <= radius + tolerancePx
+            }
+        }
+    }
+
+    private fun closeRing(pts: List<Pair<Float, Float>>): List<Pair<Float, Float>> =
+        if (pts.size >= 2 && pts.first() != pts.last()) pts + pts.first() else pts
+
+    private fun nearAnySegment(
+        pts: List<Pair<Float, Float>>,
+        px: Float,
+        py: Float,
+        tolerancePx: Float,
+    ): Boolean {
+        if (pts.size == 1) {
+            val (x, y) = pts.first()
+            return hypot((px - x).toDouble(), (py - y).toDouble()) <= tolerancePx
+        }
+        for (i in 0 until pts.size - 1) {
+            val (x1, y1) = pts[i]
+            val (x2, y2) = pts[i + 1]
+            if (distToSegment(px, py, x1, y1, x2, y2) <= tolerancePx) return true
+        }
+        return false
+    }
+
+    /** Shortest distance from (px,py) to the segment (x1,y1)-(x2,y2), in px. */
+    internal fun distToSegment(
+        px: Float, py: Float,
+        x1: Float, y1: Float,
+        x2: Float, y2: Float,
+    ): Float {
+        val dx = (x2 - x1).toDouble()
+        val dy = (y2 - y1).toDouble()
+        val lenSq = dx * dx + dy * dy
+        if (lenSq == 0.0) return hypot((px - x1).toDouble(), (py - y1).toDouble()).toFloat()
+        var t = ((px - x1) * dx + (py - y1) * dy) / lenSq
+        t = max(0.0, min(1.0, t))
+        val projX = x1 + t * dx
+        val projY = y1 + t * dy
+        return hypot(px - projX, py - projY).toFloat()
+    }
+
+    /** Ray-casting point-in-polygon in screen space (PNPOLY). */
+    internal fun pointInPolygon(pts: List<Pair<Float, Float>>, px: Float, py: Float): Boolean {
+        if (pts.size < 3) return false
+        var inside = false
+        var j = pts.size - 1
+        for (i in pts.indices) {
+            val xi = pts[i].first
+            val yi = pts[i].second
+            val xj = pts[j].first
+            val yj = pts[j].second
+            val intersect = ((yi > py) != (yj > py)) &&
+                (px < (xj - xi) * (py - yi) / (yj - yi) + xi)
+            if (intersect) inside = !inside
+            j = i
+        }
+        return inside
+    }
+
+    /**
+     * Issue #76 — translate every vertex of [drawing] by a geographic delta
+     * (degrees). Used by the move gesture: the operator drags the selected
+     * shape and we shift all points so the whole drawing moves rigidly.
+     */
+    fun translate(drawing: Drawing, dLatDeg: Double, dLonDeg: Double): Drawing =
+        drawing.copy(points = drawing.points.map { (lat, lon) -> (lat + dLatDeg) to (lon + dLonDeg) })
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/DrawingStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/DrawingStore.kt
@@ -18,6 +18,15 @@ class DrawingStore {
         _drawings.value = _drawings.value + drawing
     }
 
+    /**
+     * Issue #76 — replace a drawing in place (rename / recolor / move).
+     * Matched by [Drawing.id]; a no-op if the id isn't present so a stale
+     * edit (drawing deleted underneath the open sheet) can't resurrect it.
+     */
+    fun update(drawing: Drawing) {
+        _drawings.value = _drawings.value.map { if (it.id == drawing.id) drawing else it }
+    }
+
     fun remove(id: String) {
         _drawings.value = _drawings.value.filterNot { it.id == id }
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumDrawingsJson.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumDrawingsJson.kt
@@ -1,0 +1,46 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.json.JSONArray
+import org.json.JSONObject
+import soy.engindearing.omnitak.mobile.data.Drawing
+import soy.engindearing.omnitak.mobile.data.DrawingKind
+
+/**
+ * Issue #79 — build the drawings payload `window.OmniBridge.setDrawings(...)`
+ * consumes on the Cesium globe. The JS bridge (cesium_scene.html
+ * `upsertDrawing` / `setDrawings`) already renders line / polygon / circle
+ * entities; this is the Kotlin side that was missing, so operator drawings
+ * made on the 2D engine now also appear on the 3D globe (engine parity —
+ * the documented "wired into one engine, missing from the other" bug class).
+ *
+ * Coordinate order is [lon, lat] to match `Cesium.Cartesian3.fromDegrees`,
+ * which the bridge calls as `fromDegrees(c[0], c[1], 0)`.
+ */
+internal fun buildCesiumDrawingsJson(drawings: List<Drawing>): String {
+    val arr = JSONArray()
+    for (d in drawings) {
+        if (d.points.isEmpty()) continue
+        val coords = JSONArray()
+        d.points.forEach { (lat, lon) ->
+            coords.put(JSONArray().put(lon).put(lat))
+        }
+        arr.put(
+            JSONObject().apply {
+                put("uid", d.id)
+                put("kind", d.kind.jsKind)
+                put("coords", coords)
+                put("color", d.colorHex)
+                put("width", d.widthPx.toDouble())
+            },
+        )
+    }
+    return arr.toString()
+}
+
+/** Lower-case kind string the cesium_scene.html bridge switches on. */
+private val DrawingKind.jsKind: String
+    get() = when (this) {
+        DrawingKind.LINE -> "line"
+        DrawingKind.POLYGON -> "polygon"
+        DrawingKind.CIRCLE -> "circle"
+    }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
@@ -21,6 +21,7 @@ import org.json.JSONObject
 import org.maplibre.android.geometry.LatLng
 import soy.engindearing.omnitak.mobile.BuildConfig
 import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.Drawing
 
 /**
  * Photoreal Cesium 3D globe map engine, hosted in a WebView. Mirrors the
@@ -43,6 +44,10 @@ fun CesiumMapView(
     selfCallsign: String,
     onLongPress: (LatLng, Offset) -> Unit,
     onContactTap: (CoTEvent) -> Unit,
+    // Issue #79 — operator drawings (line / polygon / circle) rendered on the
+    // globe via the cesium_scene.html setDrawings bridge, so a shape made on
+    // the 2D engine doesn't vanish when the operator switches to 3D.
+    drawings: List<Drawing> = emptyList(),
     // Camera events from the scene: target, web-mercator zoom, heading
     // (degrees clockwise from north — MapLibre's bearing convention).
     // Heading rides along so the 3D→2D switch keeps the rotation (#78).
@@ -82,6 +87,7 @@ fun CesiumMapView(
     val webViewRef = remember { mutableStateOf<WebView?>(null) }
 
     val contactsState = rememberUpdatedState(contacts)
+    val drawingsState = rememberUpdatedState(drawings)
     val selfLatState = rememberUpdatedState(selfLat)
     val selfLonState = rememberUpdatedState(selfLon)
     val selfCallsignState = rememberUpdatedState(selfCallsign)
@@ -102,6 +108,16 @@ fun CesiumMapView(
             context = appContext,
         )
         wv.evaluateJavascript("window.OmniBridge.setEntities($json);", null)
+    }
+
+    // Issue #79 — push the current drawing roster to the globe. The JS bridge
+    // diffs against its own `_state.drawings` map, so this is idempotent and
+    // also removes drawings the operator deleted (#76 parity on the globe).
+    fun pushDrawings() {
+        val wv = webViewRef.value ?: return
+        if (!ready.value) return
+        val json = buildCesiumDrawingsJson(drawingsState.value)
+        wv.evaluateJavascript("window.OmniBridge.setDrawings($json);", null)
     }
 
     // #78 — seed the globe camera from the 2D engine's viewport on
@@ -142,6 +158,10 @@ fun CesiumMapView(
                                 // operator was looking (#78).
                                 seedInheritedCamera()
                                 pushEntities()
+                                // #79 — paint operator drawings on first ready
+                                // so a shape made on the 2D engine is already
+                                // on the globe when it opens.
+                                pushDrawings()
                                 // #95 — apply the persisted north-up lock on
                                 // first ready so the globe respects it without
                                 // waiting for a toggle.
@@ -200,7 +220,12 @@ fun CesiumMapView(
                 loadDataWithBaseURL("https://cesium.com/", html, "text/html", "UTF-8", null)
             }
         },
-        update = { pushEntities() },
+        update = {
+            pushEntities()
+            // #79 — recomposition delivers a fresh drawings list (add / edit /
+            // move / delete); mirror the entity push so the globe stays in sync.
+            pushDrawings()
+        },
     )
 
     // Map-control buttons → globe camera. The JS guards no-op until the

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/DrawingEditSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/DrawingEditSheet.kt
@@ -1,0 +1,174 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.OpenWith
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import soy.engindearing.omnitak.mobile.data.Drawing
+import soy.engindearing.omnitak.mobile.data.DrawingKind
+
+/**
+ * Issue #76 — edit / move / delete a placed drawing (parity with the marker
+ * edit sheet). Opens when the operator taps a circle / line / polygon on the
+ * map. A modal bottom sheet (never a side panel — the full-screen map is
+ * sacred) lets them rename, recolor, start a move (drag-to-reposition on the
+ * map), or delete the shape.
+ *
+ * "Move" dismisses the sheet and flips the caller into a drag mode; the actual
+ * translation happens on the map surface so the operator sees the shape track
+ * their finger.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DrawingEditSheet(
+    drawing: Drawing,
+    onApply: (Drawing) -> Unit,
+    onMove: () -> Unit,
+    onDelete: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    var name by remember(drawing.id) { mutableStateOf(drawing.name) }
+    var colorHex by remember(drawing.id) { mutableStateOf(drawing.colorHex) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = Color(0xFF1A1F2E),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 12.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(
+                kindTitle(drawing.kind),
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.White,
+            )
+            Text(
+                "${drawing.points.size} point${if (drawing.points.size == 1) "" else "s"}",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.White.copy(alpha = 0.7f),
+                fontFamily = FontFamily.Monospace,
+            )
+
+            // -------- Name --------
+            TextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Label (optional)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            // -------- Color --------
+            Text(
+                "Color",
+                style = MaterialTheme.typography.labelLarge,
+                color = Color(0xFF00E5FF),
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                DRAWING_PALETTE.forEach { hex ->
+                    val selected = hex.equals(colorHex, ignoreCase = true)
+                    Box(
+                        modifier = Modifier
+                            .size(34.dp)
+                            .clip(CircleShape)
+                            .background(Color(android.graphics.Color.parseColor(hex)))
+                            .border(
+                                width = if (selected) 3.dp else 1.dp,
+                                color = if (selected) Color.White else Color.White.copy(alpha = 0.4f),
+                                shape = CircleShape,
+                            )
+                            .clickable { colorHex = hex },
+                    )
+                }
+            }
+
+            // -------- Actions --------
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(
+                    onClick = {
+                        onDelete()
+                        onDismiss()
+                    },
+                ) { Text("Delete", color = Color(0xFFFF3B30)) }
+                OutlinedButton(
+                    onClick = {
+                        // Persist any pending rename / recolor before handing
+                        // off to the on-map move so edits aren't lost.
+                        onApply(drawing.copy(name = name, colorHex = colorHex))
+                        onMove()
+                        onDismiss()
+                    },
+                ) {
+                    Icon(
+                        Icons.Filled.OpenWith,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Text("  Move", color = Color(0xFF00E5FF))
+                }
+                Button(
+                    onClick = {
+                        onApply(drawing.copy(name = name, colorHex = colorHex))
+                        onDismiss()
+                    },
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFF34C759),
+                        contentColor = Color.Black,
+                    ),
+                ) { Text("Save") }
+            }
+        }
+    }
+}
+
+private fun kindTitle(kind: DrawingKind): String = when (kind) {
+    DrawingKind.LINE -> "Line"
+    DrawingKind.POLYGON -> "Polygon"
+    DrawingKind.CIRCLE -> "Circle"
+}
+
+/** Common tactical drawing colors. First entry matches the drawing default. */
+private val DRAWING_PALETTE = listOf(
+    "#4ADE80", // green (default)
+    "#FFC107", // amber
+    "#F44336", // red
+    "#2196F3", // blue
+    "#FFFFFF", // white
+)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/DrawingMoveOverlay.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/DrawingMoveOverlay.kt
@@ -1,0 +1,120 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import android.graphics.PointF
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import org.maplibre.android.maps.MapLibreMap
+import soy.engindearing.omnitak.mobile.data.Drawing
+import soy.engindearing.omnitak.mobile.domain.DrawingHitTest
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalBackground
+
+/**
+ * Issue #76 — drag-to-reposition for a selected drawing. Rendered as a
+ * Compose sibling above [TacticalMap] (same pattern as [LassoOverlay]). While
+ * [drawing] is non-null the full-screen layer captures drag gestures and
+ * translates the whole shape rigidly by the geographic delta under the
+ * finger, so the operator sees it track in real time. Done / Cancel chips
+ * exit the mode.
+ *
+ * Translation is computed from the on-screen drag delta projected to a
+ * geographic delta at the drawing's anchor (first vertex) — robust across
+ * zoom levels because we re-project the anchor each frame rather than
+ * accumulating degrees from a fixed pixel scale.
+ */
+@Composable
+fun DrawingMoveOverlay(
+    drawing: Drawing?,
+    mapboxMap: MapLibreMap?,
+    onMoved: (Drawing) -> Unit,
+    onDone: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (drawing == null) return
+    // Working copy mutated as the operator drags; committed to the store via
+    // [onMoved] on every drag delta so the rendered drawing follows the finger.
+    var working by remember(drawing.id) { mutableStateOf(drawing) }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(drawing.id, mapboxMap) {
+                    detectDragGestures(
+                        onDrag = { change, dragAmount ->
+                            change.consume()
+                            val map = mapboxMap ?: return@detectDragGestures
+                            val moved = translateByScreenDelta(map, working, dragAmount)
+                            if (moved != null) {
+                                working = moved
+                                onMoved(moved)
+                            }
+                        },
+                    )
+                },
+        )
+        Row(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 76.dp, start = 12.dp, end = 12.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(TacticalBackground.copy(alpha = 0.9f))
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                "Drag to move",
+                color = TacticalAccent,
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            TextButton(onClick = onDone) {
+                Text("Done", color = TacticalAccent)
+            }
+        }
+    }
+}
+
+/**
+ * Translate [drawing] by an on-screen pixel delta, converting to a geographic
+ * delta at the drawing's anchor vertex (so the shift matches the finger at any
+ * zoom). Returns null if the projection can't resolve.
+ */
+private fun translateByScreenDelta(
+    map: MapLibreMap,
+    drawing: Drawing,
+    dragAmount: Offset,
+): Drawing? {
+    val anchor = drawing.points.firstOrNull() ?: return null
+    val proj = map.projection
+    val anchorScreen = proj.toScreenLocation(
+        org.maplibre.android.geometry.LatLng(anchor.first, anchor.second),
+    )
+    val newAnchorLatLng = proj.fromScreenLocation(
+        PointF(anchorScreen.x + dragAmount.x, anchorScreen.y + dragAmount.y),
+    )
+    val dLat = newAnchorLatLng.latitude - anchor.first
+    val dLon = newAnchorLatLng.longitude - anchor.second
+    if (dLat == 0.0 && dLon == 0.0) return null
+    return DrawingHitTest.translate(drawing, dLat, dLon)
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -115,6 +115,11 @@ fun TacticalMap(
      *  caller can re-apply style-level content (e.g. KML vector overlays)
      *  that a setStyle wipes. */
     onStyleReady: ((org.maplibre.android.maps.MapLibreMap, Style) -> Unit)? = null,
+    /** Issue #89 — system status-bar inset height in dp. Under
+     *  enableEdgeToEdge the map draws under the status bar, so the built-in
+     *  MapLibre compass margin adds this on top of [COMPASS_TOP_MARGIN_DP]
+     *  to clear the (inset-shifted) ATAKStatusBar on tall-notch devices. */
+    topInsetDp: Float = 0f,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -200,7 +205,10 @@ fun TacticalMap(
                     // pixels; 4 dp matches MapLibre's built-in side defaults
                     // so only the top changes.
                     val density = context.resources.displayMetrics.density
-                    val compassTopPx = (COMPASS_TOP_MARGIN_DP * density + 0.5f).toInt()
+                    // Issue #89 — add the status-bar inset so the compass clears
+                    // the ATAKStatusBar after enableEdgeToEdge pushes it down.
+                    val compassTopPx =
+                        ((COMPASS_TOP_MARGIN_DP + topInsetDp) * density + 0.5f).toInt()
                     val sideMarginPx = (4 * density + 0.5f).toInt()
                     setCompassMargins(sideMarginPx, compassTopPx, sideMarginPx, sideMarginPx)
                 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -25,9 +25,13 @@ import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Straighten
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
@@ -86,9 +90,25 @@ import java.util.Locale
 private val FALLBACK_GLOBAL_VIEW = LatLng(0.0, 0.0)
 private const val FALLBACK_GLOBAL_ZOOM = 2.0
 
+// Issue #76 — screen-space tolerance for tapping a drawing's outline/rim.
+// ~24px ≈ finger-tip slack on a mid-density device; lines/rims are thin so
+// this keeps a 3px stroke comfortably grabbable.
+private const val DRAWING_TAP_TOLERANCE_PX = 24f
+
+// Issue #76 — if a contact is within this screen radius of the tap, the
+// drawing hit-test defers so the marker's edit sheet wins. Matches
+// TacticalMap.TAP_HIT_RADIUS_PX (the contact hit radius).
+private const val CONTACT_TAP_DEFER_PX = 72.0
+
 @Composable
 fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     val app = LocalContext.current.applicationContext as OmniTAKApp
+    // Issue #89 — status-bar inset in dp. enableEdgeToEdge lets content draw
+    // under the system bars; overlays anchored near the top (compass, MapLibre
+    // built-in compass) add this so they clear the shifted ATAKStatusBar.
+    val statusBarTopInsetDp = WindowInsets.statusBars
+        .asPaddingValues()
+        .calculateTopPadding()
     val active by app.serverManager.activeServer.collectAsState()
     val connState by app.serverManager.connectionState.collectAsState()
     val allServers by app.serverManager.servers.collectAsState()
@@ -181,6 +201,11 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     var drawingKind by remember { mutableStateOf<DrawingKind?>(null) }
     var drawingPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var drawingPickerOpen by remember { mutableStateOf(false) }
+    // Issue #76 — tap-to-select a placed drawing for edit/move/delete.
+    // selectedDrawingId holds the tapped shape (drives the DrawingEditSheet);
+    // movingDrawingId, when set, flips the map into drag-to-reposition mode.
+    var selectedDrawingId by remember { mutableStateOf<String?>(null) }
+    var movingDrawingId by remember { mutableStateOf<String?>(null) }
     // GAP-110 — gridEnabled, drawingsVisible, aircraftVisible, contactsVisible,
     // callsignCardVisible, followMeActive are now read from userPrefs (above)
     // so they survive relaunch.
@@ -451,6 +476,10 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             onLongPress = handleMapLongPress,
             onContactTap = handleContactTap,
             onCameraChanged = handleCameraChanged,
+            // Issue #79 — render saved drawings on the globe too (parity with
+            // the 2D engine). The in-progress draft lives only during 2D
+            // drawing input, so the globe just shows committed shapes.
+            drawings = if (drawingsVisible) drawings else emptyList(),
             initialCamera = cesiumSeed,
             // Same control ticks the 2D map uses — make +/- and "center on
             // me" drive the globe (VC 77: buttons did nothing on 3D).
@@ -538,6 +567,54 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                         drawingPoints = drawingPoints + latLng
                         true
                     }
+                    // Issue #76 — a tap that didn't hit a waypoint and isn't in
+                    // a placement mode hit-tests placed drawings so the operator
+                    // can select one to edit / move / delete. Skip while moving.
+                    movingDrawingId == null && drawingsVisible -> {
+                        val map = mapboxMap
+                        if (map == null) {
+                            false
+                        } else {
+                            val tap = map.projection.toScreenLocation(latLng)
+                            // Defer to markers: if a visible contact sits under
+                            // the tap, let the contact handler open its sheet
+                            // (markers are the more precise target and own the
+                            // single-tap → edit flow).
+                            val contactUnderTap = visibleContacts.any { c ->
+                                val p = map.projection.toScreenLocation(LatLng(c.lat, c.lon))
+                                kotlin.math.hypot(
+                                    (p.x - tap.x).toDouble(),
+                                    (p.y - tap.y).toDouble(),
+                                ) < CONTACT_TAP_DEFER_PX
+                            }
+                            val hit = if (contactUnderTap) {
+                                null
+                            } else {
+                                val projected = drawings.map { d ->
+                                    soy.engindearing.omnitak.mobile.domain.DrawingHitTest.Projected(
+                                        id = d.id,
+                                        kind = d.kind,
+                                        points = d.points.map { (lat, lon) ->
+                                            val p = map.projection.toScreenLocation(LatLng(lat, lon))
+                                            p.x to p.y
+                                        },
+                                    )
+                                }
+                                soy.engindearing.omnitak.mobile.domain.DrawingHitTest.hitId(
+                                    drawings = projected,
+                                    px = tap.x,
+                                    py = tap.y,
+                                    tolerancePx = DRAWING_TAP_TOLERANCE_PX,
+                                )
+                            }
+                            if (hit != null) {
+                                selectedDrawingId = hit
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                    }
                     else -> false
                 }
             },
@@ -587,6 +664,9 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             // Issue #95 — north-up lock + tap-to-reset support.
             northUpLocked = userPrefs.northUpLocked,
             snapNorthTrigger = snapNorthTick,
+            // Issue #89 — feed the status-bar inset so the built-in MapLibre
+            // compass margin clears the inset-shifted ATAKStatusBar.
+            topInsetDp = statusBarTopInsetDp.value,
         )
         // Plugin map overlays on the MAPLIBRE engine. The handle is the live
         // MapLibreMap (captured via onMapReady above; null briefly until the
@@ -957,6 +1037,16 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             onCancelled = { lassoMode = false },
         )
 
+        // Issue #76 — drag-to-reposition the selected drawing. Rendered above
+        // the map (like the lasso) so it owns the drag while active; inert
+        // (returns immediately) when no drawing is being moved.
+        soy.engindearing.omnitak.mobile.ui.components.DrawingMoveOverlay(
+            drawing = movingDrawingId?.let { id -> drawings.firstOrNull { it.id == id } },
+            mapboxMap = mapboxMap,
+            onMoved = { moved -> app.drawingStore.update(moved) },
+            onDone = { movingDrawingId = null },
+        )
+
         // Issue #16 — selection pill. Surfaces "N selected" whenever
         // there's an active lasso selection. Tap → action sheet.
         if (lassoSelection.totalCount > 0) {
@@ -1173,7 +1263,12 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .align(Alignment.TopCenter),
+                .align(Alignment.TopCenter)
+                // Issue #89 — MainActivity uses enableEdgeToEdge, so the map
+                // (and this top chrome) draws under the system status bar.
+                // Pad by the status-bar inset so the ATAKStatusBar clears the
+                // clock / notch on every device instead of being occluded.
+                .statusBarsPadding(),
         ) {
             ATAKStatusBar(
                 serverName = headerLabel,
@@ -1291,7 +1386,11 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             },
             modifier = Modifier
                 .align(Alignment.TopStart)
-                .padding(start = 12.dp, top = 72.dp),
+                // Issue #89 — the ATAKStatusBar shifts down by the status-bar
+                // inset under enableEdgeToEdge, so the compass (which sits just
+                // below it) must shift by the same amount or it overlaps the
+                // bar on tall-notch devices.
+                .padding(start = 12.dp, top = 72.dp + statusBarTopInsetDp),
         )
 
         // Map control stack — zoom in / zoom out / center-on-me — at the
@@ -1755,6 +1854,26 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                     toast("Drawing ${kind.name.lowercase()} — tap to add points")
                 },
                 onDismiss = { drawingPickerOpen = false },
+            )
+        }
+
+        // Issue #76 — edit / move / delete sheet for a tapped drawing. Resolves
+        // the live drawing each recomposition so an external change (lasso
+        // delete) closes the sheet instead of editing a ghost.
+        val selectedDrawing = selectedDrawingId?.let { id -> drawings.firstOrNull { it.id == id } }
+        if (selectedDrawing != null) {
+            soy.engindearing.omnitak.mobile.ui.components.DrawingEditSheet(
+                drawing = selectedDrawing,
+                onApply = { updated -> app.drawingStore.update(updated) },
+                onMove = {
+                    movingDrawingId = selectedDrawing.id
+                    toast("Drag the ${selectedDrawing.kind.name.lowercase()} to move it")
+                },
+                onDelete = {
+                    app.drawingStore.remove(selectedDrawing.id)
+                    toast("Deleted ${selectedDrawing.kind.name.lowercase()}")
+                },
+                onDismiss = { selectedDrawingId = null },
             )
         }
 

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/DrawingHitTestTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/DrawingHitTestTest.kt
@@ -1,0 +1,114 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.Drawing
+import soy.engindearing.omnitak.mobile.data.DrawingKind
+
+/**
+ * Issue #76 — screen-space drawing hit-testing. All coordinates are pixels
+ * (the caller projects geo → screen before calling), so these are pure JVM
+ * tests with no Android map dependency.
+ */
+class DrawingHitTestTest {
+
+    private fun projected(id: String, kind: DrawingKind, pts: List<Pair<Float, Float>>) =
+        DrawingHitTest.Projected(id, kind, pts)
+
+    // ── LINE ──────────────────────────────────────────────────────────────
+
+    @Test fun tap_on_line_segment_hits() {
+        val line = projected("L", DrawingKind.LINE, listOf(0f to 0f, 100f to 0f))
+        // 5px off the midpoint of a horizontal line, tolerance 24 → hit.
+        assertTrue(DrawingHitTest.hits(line, 50f, 5f, 24f))
+    }
+
+    @Test fun tap_far_from_line_misses() {
+        val line = projected("L", DrawingKind.LINE, listOf(0f to 0f, 100f to 0f))
+        assertFalse(DrawingHitTest.hits(line, 50f, 80f, 24f))
+    }
+
+    // ── POLYGON ───────────────────────────────────────────────────────────
+
+    @Test fun tap_inside_polygon_hits() {
+        val poly = projected(
+            "P", DrawingKind.POLYGON,
+            listOf(0f to 0f, 100f to 0f, 100f to 100f, 0f to 100f),
+        )
+        assertTrue(DrawingHitTest.hits(poly, 50f, 50f, 8f))
+    }
+
+    @Test fun tap_outside_polygon_misses() {
+        val poly = projected(
+            "P", DrawingKind.POLYGON,
+            listOf(0f to 0f, 100f to 0f, 100f to 100f, 0f to 100f),
+        )
+        assertFalse(DrawingHitTest.hits(poly, 200f, 200f, 8f))
+    }
+
+    @Test fun tap_on_polygon_edge_hits_via_tolerance() {
+        val poly = projected(
+            "P", DrawingKind.POLYGON,
+            listOf(0f to 0f, 100f to 0f, 100f to 100f, 0f to 100f),
+        )
+        // Just outside the right edge but within tolerance of it.
+        assertTrue(DrawingHitTest.hits(poly, 105f, 50f, 24f))
+    }
+
+    // ── CIRCLE ────────────────────────────────────────────────────────────
+
+    @Test fun tap_inside_circle_disc_hits() {
+        // center (50,50), edge (90,50) → radius 40.
+        val circle = projected("C", DrawingKind.CIRCLE, listOf(50f to 50f, 90f to 50f))
+        assertTrue(DrawingHitTest.hits(circle, 60f, 50f, 8f))
+    }
+
+    @Test fun tap_near_circle_rim_hits() {
+        val circle = projected("C", DrawingKind.CIRCLE, listOf(50f to 50f, 90f to 50f))
+        // 5px outside the rim, tolerance 24 → hit.
+        assertTrue(DrawingHitTest.hits(circle, 95f, 50f, 24f))
+    }
+
+    @Test fun tap_far_outside_circle_misses() {
+        val circle = projected("C", DrawingKind.CIRCLE, listOf(50f to 50f, 90f to 50f))
+        assertFalse(DrawingHitTest.hits(circle, 200f, 200f, 24f))
+    }
+
+    // ── topmost selection ───────────────────────────────────────────────────
+
+    @Test fun hitId_returns_topmost_when_overlapping() {
+        // Two overlapping polygons; the later one (B) paints on top, so a tap
+        // in the overlap selects B.
+        val a = projected("A", DrawingKind.POLYGON, listOf(0f to 0f, 100f to 0f, 100f to 100f, 0f to 100f))
+        val b = projected("B", DrawingKind.POLYGON, listOf(0f to 0f, 100f to 0f, 100f to 100f, 0f to 100f))
+        assertEquals("B", DrawingHitTest.hitId(listOf(a, b), 50f, 50f, 8f))
+    }
+
+    @Test fun hitId_returns_null_when_nothing_hit() {
+        val a = projected("A", DrawingKind.LINE, listOf(0f to 0f, 10f to 0f))
+        assertNull(DrawingHitTest.hitId(listOf(a), 500f, 500f, 8f))
+    }
+
+    @Test fun empty_points_never_hit() {
+        val empty = projected("E", DrawingKind.LINE, emptyList())
+        assertFalse(DrawingHitTest.hits(empty, 0f, 0f, 100f))
+    }
+
+    // ── translate ────────────────────────────────────────────────────────
+
+    @Test fun translate_shifts_all_vertices_rigidly() {
+        val d = Drawing(
+            id = "d1",
+            kind = DrawingKind.POLYGON,
+            points = listOf(10.0 to 20.0, 11.0 to 21.0, 12.0 to 22.0),
+        )
+        val moved = DrawingHitTest.translate(d, dLatDeg = 0.5, dLonDeg = -0.25)
+        assertEquals(listOf(10.5 to 19.75, 11.5 to 20.75, 12.5 to 21.75), moved.points)
+        // id / kind preserved.
+        assertEquals("d1", moved.id)
+        assertEquals(DrawingKind.POLYGON, moved.kind)
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/DrawingStoreTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/DrawingStoreTest.kt
@@ -1,0 +1,55 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.Drawing
+import soy.engindearing.omnitak.mobile.data.DrawingKind
+
+/**
+ * Issue #76 — DrawingStore edit/delete used by the drawing edit sheet and the
+ * move overlay.
+ */
+class DrawingStoreTest {
+
+    private fun line(id: String) =
+        Drawing(id = id, kind = DrawingKind.LINE, points = listOf(0.0 to 0.0, 1.0 to 1.0))
+
+    @Test fun add_then_update_replaces_in_place() {
+        val store = DrawingStore()
+        store.add(line("d1"))
+        store.update(line("d1").copy(name = "Alpha", colorHex = "#FF0000"))
+        val list = store.drawings.value
+        assertEquals(1, list.size)
+        assertEquals("Alpha", list[0].name)
+        assertEquals("#FF0000", list[0].colorHex)
+    }
+
+    @Test fun update_preserves_order() {
+        val store = DrawingStore()
+        store.add(line("a"))
+        store.add(line("b"))
+        store.add(line("c"))
+        store.update(line("b").copy(name = "edited"))
+        val ids = store.drawings.value.map { it.id }
+        assertEquals(listOf("a", "b", "c"), ids)
+        assertEquals("edited", store.drawings.value[1].name)
+    }
+
+    @Test fun update_unknown_id_is_noop() {
+        val store = DrawingStore()
+        store.add(line("a"))
+        store.update(line("ghost").copy(name = "should-not-appear"))
+        val list = store.drawings.value
+        assertEquals(1, list.size)
+        assertEquals("a", list[0].id)
+        assertEquals("", list[0].name)
+    }
+
+    @Test fun remove_drops_only_matching_id() {
+        val store = DrawingStore()
+        store.add(line("a"))
+        store.add(line("b"))
+        store.remove("a")
+        assertEquals(listOf("b"), store.drawings.value.map { it.id })
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumDrawingsJsonTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumDrawingsJsonTest.kt
@@ -1,0 +1,82 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.Drawing
+import soy.engindearing.omnitak.mobile.data.DrawingKind
+
+/**
+ * Issue #79 — the Kotlin → Cesium drawings bridge payload. cesium_scene.html's
+ * `upsertDrawing` consumes `{uid, kind, coords:[[lon,lat]...], color, width}`
+ * with coords in [lon, lat] order (it calls Cesium.Cartesian3.fromDegrees(
+ * c[0], c[1], 0)).
+ */
+class CesiumDrawingsJsonTest {
+
+    private fun parse(json: String): JSONArray = JSONArray(json)
+
+    @Test fun `line emits lon-lat coords in order`() {
+        val line = Drawing(
+            id = "L1",
+            kind = DrawingKind.LINE,
+            points = listOf(47.65 to -117.42, 47.66 to -117.40),
+            colorHex = "#FFC107",
+            widthPx = 4f,
+        )
+        val arr = parse(buildCesiumDrawingsJson(listOf(line)))
+        assertEquals(1, arr.length())
+        val o = arr.getJSONObject(0)
+        assertEquals("L1", o.getString("uid"))
+        assertEquals("line", o.getString("kind"))
+        assertEquals("#FFC107", o.getString("color"))
+        assertEquals(4.0, o.getDouble("width"), 1e-9)
+        val coords = o.getJSONArray("coords")
+        assertEquals(2, coords.length())
+        // [lon, lat] order.
+        assertEquals(-117.42, coords.getJSONArray(0).getDouble(0), 1e-9)
+        assertEquals(47.65, coords.getJSONArray(0).getDouble(1), 1e-9)
+    }
+
+    @Test fun `polygon kind maps to polygon`() {
+        val poly = Drawing(
+            id = "P1",
+            kind = DrawingKind.POLYGON,
+            points = listOf(0.0 to 0.0, 0.0 to 1.0, 1.0 to 1.0),
+        )
+        val o = parse(buildCesiumDrawingsJson(listOf(poly))).getJSONObject(0)
+        assertEquals("polygon", o.getString("kind"))
+        assertEquals(3, o.getJSONArray("coords").length())
+    }
+
+    @Test fun `circle kind maps to circle with center and edge`() {
+        val circle = Drawing(
+            id = "C1",
+            kind = DrawingKind.CIRCLE,
+            points = listOf(47.65 to -117.42, 47.70 to -117.42),
+        )
+        val o = parse(buildCesiumDrawingsJson(listOf(circle))).getJSONObject(0)
+        assertEquals("circle", o.getString("kind"))
+        assertEquals(2, o.getJSONArray("coords").length())
+    }
+
+    @Test fun `empty-point drawings are skipped`() {
+        val empty = Drawing(id = "E", kind = DrawingKind.LINE, points = emptyList())
+        val good = Drawing(id = "G", kind = DrawingKind.LINE, points = listOf(1.0 to 2.0, 3.0 to 4.0))
+        val arr = parse(buildCesiumDrawingsJson(listOf(empty, good)))
+        assertEquals(1, arr.length())
+        assertEquals("G", arr.getJSONObject(0).getString("uid"))
+    }
+
+    @Test fun `empty list yields empty json array`() {
+        assertEquals("[]", buildCesiumDrawingsJson(emptyList()))
+    }
+
+    @Test fun `default color is carried through`() {
+        val d = Drawing(id = "D", kind = DrawingKind.LINE, points = listOf(0.0 to 0.0, 1.0 to 1.0))
+        val o = parse(buildCesiumDrawingsJson(listOf(d))).getJSONObject(0)
+        // Drawing's default colorHex.
+        assertTrue(o.getString("color").startsWith("#"))
+    }
+}


### PR DESCRIPTION
Fixes a batch of map-rendering and edge-to-edge issues reported by u/mozios on the r/ATAK tester thread. The two map engines (MapLibre 2D and the Cesium 3D globe) had drifted apart, and the top chrome ignored the system status-bar inset under `enableEdgeToEdge`.

## What changed, per issue

### #76 — Drawings cannot be edited, moved, or deleted
Placed drawings were inert. Added marker-parity interactions:
- **Tap to select** — single-tap hit-tests placed drawings (`DrawingHitTest`, pure screen-space: line = near segment, polygon = inside ring or near edge, circle = inside disc or near rim, topmost wins). The hit-test defers to markers when a contact sits under the tap, so markers stay tappable over a drawing.
- **Edit** — `DrawingEditSheet` (modal bottom sheet) renames and recolors. The full-screen map is never compressed by a side panel.
- **Move** — `DrawingMoveOverlay` drag-to-reposition translates the whole shape rigidly under the finger (same projection pattern as the lasso).
- **Delete** — from the same sheet, via `DrawingStore.remove`.
- Added `DrawingStore.update()` for in-place edits.

### #77 — Dropped markers render only on the 3D globe, not 2D
Already addressed on `main` (the 2D MapLibre path now pushes contacts via `AndroidView.update` on every recomposition with a queued `getStyle` callback, closing the ingest/style-load race). No code change needed here; re-closing with this PR.

### #79 — Drawing tools non-functional in the 3D globe
The `cesium_scene.html` bridge already implemented `setDrawings`/`upsertDrawing`, but the Kotlin `CesiumMapView` never fed it, so shapes drawn in 2D vanished on the globe. Wired a `drawings` parameter + `buildCesiumDrawingsJson` payload through to the bridge (pushed on bridge-ready and every recomposition; idempotent diff also clears deletions). Drawing *creation* on the globe continues to auto-drop to 2D (existing behavior) since the input layer is MapLibre-only.

### #80 — Drawings intermittently invisible in 2D until 3D Terrain is enabled
Already addressed on `main` (`addOnDidFinishLoadingStyleListener` re-anchors the drawing/overlay layers on every style reload, including internal MapLibre reloads). No code change needed here; re-closing with this PR.

### #89 — Top chrome ignores the system status-bar inset under enableEdgeToEdge
- Added `Modifier.statusBarsPadding()` to the `Column` mounting `ATAKStatusBar` so it clears the clock/notch.
- Shifted the floating compass down by the status-bar inset.
- Fed the inset into `TacticalMap` so the built-in MapLibre compass margin also clears the now-lower bar on tall-notch devices (the #88/#81 64dp constant assumed a typical 24dp inset).

## Test plan
- `./gradlew :app:assembleDebug` — green.
- `./gradlew :app:testDebugUnitTest` — green. Added 22 unit tests:
  - `DrawingHitTestTest` (12) — line/polygon/circle hit-testing, topmost selection, rigid translate.
  - `CesiumDrawingsJsonTest` (6) — bridge payload shape, [lon,lat] coord order, kind mapping, empty handling.
  - `DrawingStoreTest` (4) — add/update/remove semantics and order preservation.
- Manual device pass still recommended for the rendering/gesture bugs (see PR thread): tap-select + drag-move + delete on each drawing kind in 2D; drawings appearing on the Cesium globe after a 2D→3D switch; status bar / compass clearance on a notched device.

Closes #76
Closes #77
Closes #79
Closes #80
Closes #89
