### PR TITLE
feat(markers): tap self-marker reposition, triangle style, icon picker wire, settable heading

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTEvent.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTEvent.kt
@@ -83,6 +83,8 @@ data class CoTEvent(
     val colorArgb: Int? = null,
     /** TAK team name from `<__group name="Red|Orange|…"/>`. Null when absent. */
     val teamName: String? = null,
+    /** Course heading in degrees (0–360) from `<track course="…"/>`. Null when absent. */
+    val courseHeading: Double? = null,
     /** TAK team role from `<__group role="Team Member|…"/>`. Null when absent. */
     val teamRole: String? = null,
 ) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTParser.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTParser.kt
@@ -39,6 +39,7 @@ object CoTParser {
         var remarks: String? = null
         var iconsetPath: String? = null
         var colorArgb: Int? = null
+        var courseHeading: Double? = null
 
         var ev = parser.eventType
         while (ev != XmlPullParser.END_DOCUMENT) {
@@ -81,6 +82,10 @@ object CoTParser {
                     "color" -> {
                         colorArgb = parser.getAttributeValue(null, "argb")?.toIntOrNull() ?: colorArgb
                     }
+                    // Course heading from <track course="270.0" speed="0.0"/>
+                    "track" -> {
+                        courseHeading = parser.getAttributeValue(null, "course")?.toDoubleOrNull() ?: courseHeading
+                    }
                 }
             }
             ev = parser.next()
@@ -104,6 +109,7 @@ object CoTParser {
             teamRole = teamRole,
             iconsetPath = iconsetPath,
             colorArgb = colorArgb,
+            courseHeading = courseHeading,
         )
     }.getOrNull()
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -138,6 +138,9 @@ data class UserPrefs(
      *  foreground. Fixes the bug where the setting was present but
      *  FLAG_KEEP_SCREEN_ON was never actually applied. Default off. */
     val keepScreenOn: Boolean = false,
+    /** When true, render the self-marker as a triangle pointing in heading
+     *  direction instead of the MIL-STD disc / puck. Rotates with compass. */
+    val selfMarkerTriangle: Boolean = false,
 )
 
 class UserPrefsStore(private val context: Context) {
@@ -180,6 +183,7 @@ class UserPrefsStore(private val context: Context) {
     // Issue #95 — north-up lock; #97 — keep-screen-on
     private val KEY_NORTH_UP_LOCKED = booleanPreferencesKey("north_up_locked")
     private val KEY_KEEP_SCREEN_ON  = booleanPreferencesKey("keep_screen_on")
+    private val KEY_SELF_MARKER_TRIANGLE = booleanPreferencesKey("selfMarkerTriangle")
 
     val prefs: Flow<UserPrefs> = context.userPrefsDataStore.data.map { p -> readFrom(p) }
 
@@ -223,6 +227,7 @@ class UserPrefsStore(private val context: Context) {
             if (next.lastCameraZoom != null) p[KEY_CAMERA_ZOOM] = next.lastCameraZoom.toString()
             p[KEY_NORTH_UP_LOCKED] = next.northUpLocked
             p[KEY_KEEP_SCREEN_ON]  = next.keepScreenOn
+            p[KEY_SELF_MARKER_TRIANGLE] = next.selfMarkerTriangle
         }
     }
 
@@ -342,6 +347,7 @@ class UserPrefsStore(private val context: Context) {
         lastCameraZoom = p[KEY_CAMERA_ZOOM]?.toDoubleOrNull(),
         northUpLocked  = p[KEY_NORTH_UP_LOCKED] ?: false,
         keepScreenOn   = p[KEY_KEEP_SCREEN_ON]  ?: false,
+        selfMarkerTriangle = p[KEY_SELF_MARKER_TRIANGLE] ?: false,
     )
 
     // ATAK / OpenTakServer canonical team names are Title Case ("Cyan",

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuilders.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/CotBuilders.kt
@@ -76,6 +76,9 @@ object CotBuilders {
             if (event.remarks.isNotBlank()) {
                 append("<remarks>").append(CotXml.escape(event.remarks)).append("</remarks>")
             }
+            event.courseHeading?.let {
+                append("<track course=\"").append(it).append("\" speed=\"0.0\"/>")
+            }
             destUids.forEach { append("<dest uid=\"").append(CotXml.escape(it)).append("\"/>") }
             append("</detail>")
         }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
@@ -85,6 +85,14 @@ internal object LocStrings {
         // Self position
         "settings.milStdSymbol" to "MIL-STD-2525 symbol",
         "settings.milStdSymbol.desc" to "Render your own pip as a friendly-combat ground frame (a-f-G-U-C) instead of the legacy tactical disc. Affects only the map; PPLI broadcast is unchanged.",
+        "settings.triangleSelfMarker" to "Triangle self-marker",
+        "settings.triangleSelfMarker.desc" to "Rotates with compass heading",
+        "marker.heading" to "Heading (°)",
+        "marker.editSelfPosition" to "Edit Self Position",
+        "marker.selfLat" to "Latitude",
+        "marker.selfLon" to "Longitude",
+        "map.manualPositionActive" to "Manual position active",
+        "map.tapToResumeGps" to "Tap to resume GPS",
 
         // Drone detection
         "settings.faaRemoteIdScanner" to "FAA Remote ID scanner",
@@ -198,6 +206,14 @@ internal object LocStrings {
 
         "settings.milStdSymbol" to "MIL-STD-2525 符號",
         "settings.milStdSymbol.desc" to "將您自身的標記繪製為友軍地面戰鬥框架（a-f-G-U-C），取代舊版戰術圓點。僅影響地圖；PPLI 廣播維持不變。",
+        "settings.triangleSelfMarker" to "三角形自我標記",
+        "settings.triangleSelfMarker.desc" to "隨羅盤方向旋轉",
+        "marker.heading" to "方向 (°)",
+        "marker.editSelfPosition" to "編輯自身位置",
+        "marker.selfLat" to "緯度",
+        "marker.selfLon" to "經度",
+        "map.manualPositionActive" to "手動定位啟用中",
+        "map.tapToResumeGps" to "點擊以恢復 GPS",
 
         "settings.faaRemoteIdScanner" to "FAA Remote ID 掃描器",
         "settings.faaRemoteId.desc" to "監聽附近無人機（DJI Mavic、Skydio、Autel）透過藍芽廣播的 FAA Remote ID。偵測到的無人機將以未知空域 UAS 目標顯示在地圖上。可接收藍芽廣播的 Remote ID 子集；WiFi 訊號廣播需搭配 gy6 感測器。藍芽掃描會消耗電池。",

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerEditSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MarkerEditSheet.kt
@@ -71,6 +71,12 @@ data class MarkerEditResult(
     /** 8-hex opaque ARGB for the CoT `<color argb>` element (Spot Map swatch).
      *  Null for MIL-STD picks, which carry their look in the symbol itself. */
     val argbHex: String? = null,
+    /** Course heading in degrees (0–360), or null if not set. */
+    val courseHeading: Double? = null,
+    /** When editingSelf, the new latitude the operator typed. */
+    val selfLatOverride: Double? = null,
+    /** When editingSelf, the new longitude the operator typed. */
+    val selfLonOverride: Double? = null,
 )
 
 /**
@@ -97,7 +103,15 @@ fun MarkerEditSheet(
     /** Issue #98 — the marker's current `usericon` iconset path (Spot Map),
      *  so an existing spot marker re-opens with its swatch highlighted. */
     initialIconsetPath: String? = null,
+    /** Current course heading in degrees for this marker. */
+    initialCourseHeading: Double? = null,
     editing: Boolean = false,
+    /** When true, shows lat/lon override fields (for self-marker repositioning). */
+    editingSelf: Boolean = false,
+    /** Initial latitude for self-position editing. */
+    initialSelfLat: Double? = null,
+    /** Initial longitude for self-position editing. */
+    initialSelfLon: Double? = null,
     onSave: (MarkerEditResult) -> Unit,
     onDelete: (() -> Unit)? = null,
     /** When non-null, renders a "Pursue with UAS" button — Map screen
@@ -135,6 +149,9 @@ fun MarkerEditSheet(
         )
     }
     var iconPickerOpen by remember { mutableStateOf(false) }
+    var headingText by remember(initialCourseHeading) { mutableStateOf(initialCourseHeading?.let { "%.0f".format(it) } ?: "") }
+    var selfLatText by remember(initialSelfLat) { mutableStateOf(initialSelfLat?.let { "%.6f".format(it) } ?: "") }
+    var selfLonText by remember(initialSelfLon) { mutableStateOf(initialSelfLon?.let { "%.6f".format(it) } ?: "") }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -257,6 +274,37 @@ fun MarkerEditSheet(
                     .height(96.dp),
             )
 
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = headingText,
+                onValueChange = { headingText = it.filter { ch -> ch.isDigit() || ch == '.' } },
+                label = { Text("Heading (°)") },
+                singleLine = true,
+                colors = tacticalFieldColors(),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            if (editingSelf) {
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = selfLatText,
+                    onValueChange = { selfLatText = it.filter { ch -> ch.isDigit() || ch == '.' || ch == '-' } },
+                    label = { Text("Latitude") },
+                    singleLine = true,
+                    colors = tacticalFieldColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = selfLonText,
+                    onValueChange = { selfLonText = it.filter { ch -> ch.isDigit() || ch == '.' || ch == '-' } },
+                    label = { Text("Longitude") },
+                    singleLine = true,
+                    colors = tacticalFieldColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
             Spacer(Modifier.height(24.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -283,6 +331,8 @@ fun MarkerEditSheet(
                 Spacer(Modifier.width(8.dp))
                 Button(
                     onClick = {
+                        val selfLat = selfLatText.toDoubleOrNull()
+                        val selfLon = selfLonText.toDoubleOrNull()
                         onSave(
                             MarkerEditResult(
                                 callsign = callsign.trim().ifEmpty { "Marker" },
@@ -292,6 +342,9 @@ fun MarkerEditSheet(
                                 cotType = cotType,
                                 iconsetPath = iconsetPath,
                                 argbHex = argbHex,
+                                courseHeading = headingText.toDoubleOrNull(),
+                                selfLatOverride = if (editingSelf) selfLat else null,
+                                selfLonOverride = if (editingSelf) selfLon else null,
                             )
                         )
                     },

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -83,6 +83,8 @@ fun TacticalMap(
      *  frame. When false, falls back to the legacy `ic_self_marker`
      *  tinted disc. Sourced from [soy.engindearing.omnitak.mobile.data.UserPrefs.useMilStdSelfSymbol]. */
     useMilStdSelfSymbol: Boolean = true,
+    /** #83 — render the self-marker as a triangle pointing in heading direction. */
+    selfMarkerTriangle: Boolean = false,
     /** TAK team name used to tint the self-marker — e.g. "Cyan", "Red",
      *  "Orange". Resolved via [TakTeamColor.forName]; unrecognised names
      *  fall back to cyan (0xFF00FFFF) to match CivTAK's default for
@@ -115,6 +117,8 @@ fun TacticalMap(
      *  caller can re-apply style-level content (e.g. KML vector overlays)
      *  that a setStyle wipes. */
     onStyleReady: ((org.maplibre.android.maps.MapLibreMap, Style) -> Unit)? = null,
+    /** #82 — called when the operator taps the self-marker. Opens reposition sheet. */
+    onSelfMarkerTap: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -136,6 +140,8 @@ fun TacticalMap(
     val currentFollowMe by rememberUpdatedState(followMeActive)
     val currentUseMilStd by rememberUpdatedState(useMilStdSelfSymbol)
     val currentTeamColor by rememberUpdatedState(selfTeamColor)
+    val currentOnSelfMarkerTap by rememberUpdatedState(onSelfMarkerTap)
+    val currentSelfMarkerTriangle by rememberUpdatedState(selfMarkerTriangle)
     // Issue #75 — whether the puck is currently rendered dimmed (stale
     // restored fix). Plain holder, not MutableState: nothing recomposes
     // off it; the effects below read/write it imperatively.
@@ -180,6 +186,7 @@ fun TacticalMap(
                         activateLocation(
                             map, style, context, currentUseMilStd, currentTeamColor,
                             seedFix = currentSelfFix, puck = puckAppearance,
+                            selfMarkerTriangle = currentSelfMarkerTriangle,
                         )
                     }
                     // Cold-start 3D: if the persisted pref has terrain on,
@@ -236,6 +243,22 @@ fun TacticalMap(
                     }
                     val cb = currentContactTap ?: return@addOnMapClickListener false
                     val tapPx = map.projection.toScreenLocation(latLng)
+                    // #82 — tap on self-marker opens reposition sheet
+                    val selfTapCb = currentOnSelfMarkerTap
+                    if (selfTapCb != null) {
+                        val fix = currentSelfFix
+                        if (fix != null) {
+                            val selfPx = map.projection.toScreenLocation(LatLng(fix.lat, fix.lon))
+                            val selfDist = kotlin.math.hypot(
+                                (selfPx.x - tapPx.x).toDouble(),
+                                (selfPx.y - tapPx.y).toDouble(),
+                            )
+                            if (selfDist < TAP_HIT_RADIUS_PX) {
+                                selfTapCb()
+                                return@addOnMapClickListener true
+                            }
+                        }
+                    }
                     var best: CoTEvent? = null
                     var bestDist = Float.MAX_VALUE
                     currentContacts.forEach { c ->
@@ -305,6 +328,7 @@ fun TacticalMap(
                     activateLocation(
                         map, style, context, currentUseMilStd, currentTeamColor,
                         seedFix = currentSelfFix, puck = puckAppearance,
+                        selfMarkerTriangle = currentSelfMarkerTriangle,
                     )
                 }
                 if (map.locationComponent.isLocationComponentActivated) {
@@ -336,6 +360,7 @@ fun TacticalMap(
                             buildPuckOptions(
                                 context, style, currentUseMilStd, currentTeamColor,
                                 dimmed = staleNow,
+                                selfMarkerTriangle = currentSelfMarkerTriangle,
                             ),
                         )
                         puckAppearance.dimmed = staleNow
@@ -468,6 +493,7 @@ fun TacticalMap(
                             buildPuckOptions(
                                 context, style, currentUseMilStd, currentTeamColor,
                                 dimmed = puckAppearance.dimmed,
+                                selfMarkerTriangle = currentSelfMarkerTriangle,
                             ),
                         )
                     }
@@ -683,6 +709,7 @@ private fun activateLocation(
     selfTeamColor: String = "Cyan",
     seedFix: SelfFix? = null,
     puck: PuckAppearance = PuckAppearance(),
+    selfMarkerTriangle: Boolean = false,
 ) {
     // Issue #75 — when the best position available at activation is a
     // restored (persisted) fix that is already old, start the puck dimmed
@@ -694,7 +721,7 @@ private fun activateLocation(
     val options = LocationComponentActivationOptions.builder(context, style)
         .useDefaultLocationEngine(true)
         .locationComponentOptions(
-            buildPuckOptions(context, style, useMilStdSelfSymbol, selfTeamColor, dimmed),
+            buildPuckOptions(context, style, useMilStdSelfSymbol, selfTeamColor, dimmed, selfMarkerTriangle),
         )
         .build()
     map.locationComponent.activateLocationComponent(options)
@@ -724,11 +751,33 @@ private fun buildPuckOptions(
     useMilStdSelfSymbol: Boolean,
     selfTeamColor: String,
     dimmed: Boolean,
+    selfMarkerTriangle: Boolean = false,
 ): LocationComponentOptions {
     // Resolve the ARGB tint from the operator's configured TAK team name
     // ("Cyan", "Red", "Orange", …). Falls back to cyan — CivTAK default
     // for unaffiliated friendlies — when the name isn't in the palette.
     val teamArgb: Int = TakTeamColor.forName(selfTeamColor) ?: 0xFF00FFFF.toInt()
+
+    // #83 — triangle self-marker overrides both MIL-STD and disc modes
+    if (selfMarkerTriangle) {
+        val triangleBmp = createTriangleBitmap(64)
+        val triangleStale = fadeBitmap(triangleBmp, STALE_MARKER_ALPHA)
+        style.addImage("omnitak-self-triangle", triangleBmp)
+        style.addImage("omnitak-self-triangle-stale", triangleStale)
+        val imgName = if (dimmed) "omnitak-self-triangle-stale" else "omnitak-self-triangle"
+        return LocationComponentOptions.builder(context)
+            .pulseEnabled(!dimmed)
+            .pulseColor(teamArgb)
+            .pulseSingleDuration(2200f)
+            .accuracyColor(teamArgb)
+            .accuracyAlpha(0.18f)
+            .enableStaleState(true)
+            .staleStateTimeout(SelfFixPersistence.STALE_AFTER_MS)
+            .bearingName(imgName)
+            .foregroundName(imgName)
+            .foregroundStaleName("omnitak-self-triangle-stale")
+            .build()
+    }
 
     // Self-position marker. When [useMilStdSelfSymbol] is true (default),
     // render with a MIL-STD-2525 friendly combat ground symbol
@@ -822,6 +871,25 @@ private fun fadeBitmap(src: android.graphics.Bitmap, alpha: Int): android.graphi
 /** Issue #75 — [argb] with its alpha channel replaced by [alpha]. */
 private fun fadeArgb(argb: Int, alpha: Int): Int =
     (argb and 0x00FFFFFF) or (alpha shl 24)
+
+/** #83 — white triangle bitmap for the triangle self-marker mode. */
+private fun createTriangleBitmap(sizePx: Int = 64): android.graphics.Bitmap {
+    val bmp = android.graphics.Bitmap.createBitmap(sizePx, sizePx, android.graphics.Bitmap.Config.ARGB_8888)
+    val canvas = android.graphics.Canvas(bmp)
+    val paint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG)
+    paint.color = android.graphics.Color.WHITE
+    val path = android.graphics.Path()
+    path.moveTo(sizePx / 2f, 0f)
+    path.lineTo(sizePx.toFloat(), sizePx.toFloat())
+    path.lineTo(0f, sizePx.toFloat())
+    path.close()
+    canvas.drawPath(path, paint)
+    paint.color = android.graphics.Color.DKGRAY
+    paint.style = android.graphics.Paint.Style.STROKE
+    paint.strokeWidth = 3f
+    canvas.drawPath(path, paint)
+    return bmp
+}
 
 /** Issue #75 — adapt a [SelfFix] for LocationComponent.forceLocationUpdate.
  *  NaN accuracy (restored fixes) is simply omitted. */

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -148,6 +148,14 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     // doesn't have to know about FEMA-specific fields.
     var femaPaletteLatLng by remember { mutableStateOf<LatLng?>(null) }
     var editingMarker by remember { mutableStateOf<CoTEvent?>(null) }
+    var selfMarkerEditOpen by remember { mutableStateOf(false) }
+    var manualSelfFix by remember { mutableStateOf<Pair<Double, Double>?>(null) }
+    val effectiveSelfFix: soy.engindearing.omnitak.mobile.data.SelfFix? = manualSelfFix?.let { (lat, lon) ->
+        soy.engindearing.omnitak.mobile.data.SelfFix(
+            lat = lat, lon = lon, altitudeM = selfFix?.altitudeM ?: 0.0,
+            speedKmh = 0.0, accuracyM = Float.NaN, timeMs = System.currentTimeMillis()
+        )
+    } ?: selfFix
     var recenterTick by remember { mutableStateOf(0) }
     var zoomInTick by remember { mutableStateOf(0) }
     var zoomOutTick by remember { mutableStateOf(0) }
@@ -571,11 +579,13 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             followMeActive = followMeActive,
             useMilStdSelfSymbol = userPrefs.useMilStdSelfSymbol,
             selfTeamColor = userPrefs.team,
+            selfMarkerTriangle = userPrefs.selfMarkerTriangle,
             // Issue #75 — feeds the puck so a restored fix renders
             // immediately on cold start (dimmed when stale) and the
             // forced foreground-resume fix lands without waiting on the
             // LocationComponent's internal engine.
-            selfFix = selfFix,
+            selfFix = effectiveSelfFix,
+            onSelfMarkerTap = { selfMarkerEditOpen = true },
             onStyleReady = { _, style ->
                 soy.engindearing.omnitak.mobile.ui.components.KmlOverlayRenderer
                     .apply(style, kmlOverlays, app.kmlOverlayStore)
@@ -1200,7 +1210,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         // (LocationProvider). Until a fix arrives we show "Acquiring
         // fix…" so users in Germany don't see San Francisco (issue #10).
         if (callsignCardVisible) {
-            val fix = selfFix
+            val fix = effectiveSelfFix
             SelfPositionCard(
                 callsign = userPrefs.callsign,
                 coordinateLabel = if (fix != null) {
@@ -1223,6 +1233,31 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                     .align(Alignment.BottomEnd)
                     .padding(end = 12.dp, bottom = 96.dp),
             )
+        }
+
+        if (manualSelfFix != null) {
+            androidx.compose.foundation.layout.Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 48.dp),
+                contentAlignment = Alignment.TopCenter,
+            ) {
+                androidx.compose.material3.Surface(
+                    modifier = Modifier
+                        .clickable { manualSelfFix = null }
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(20.dp),
+                    color = soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent.copy(alpha = 0.15f),
+                    tonalElevation = 2.dp,
+                ) {
+                    androidx.compose.material3.Text(
+                        "Manual position · tap to resume GPS",
+                        color = soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                    )
+                }
+            }
         }
 
         ToolsDrawer(
@@ -1530,6 +1565,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             // Issue #98 — re-open an existing marker on the symbol it carries.
             initialCotType = editingMarker?.type,
             initialIconsetPath = editingMarker?.iconsetPath,
+            initialCourseHeading = editingMarker?.courseHeading,
             editing = editingMarker != null,
             onSave = { result ->
                 val ll = markerSheetLatLng
@@ -1552,6 +1588,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                         // the identical dot; null for MIL-STD picks.
                         iconsetPath = result.iconsetPath,
                         colorArgb = result.argbHex?.toLong(16)?.toInt(),
+                        courseHeading = result.courseHeading ?: editingMarker?.courseHeading,
                     )
                     app.contactStore.ingest(event)
                     val verb = if (editingMarker != null) Loc.t("marker.verb.updated")
@@ -1614,6 +1651,29 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 editingMarker = null
             },
         )
+
+        if (selfMarkerEditOpen) {
+            MarkerEditSheet(
+                visible = true,
+                latLng = effectiveSelfFix?.let { org.maplibre.android.geometry.LatLng(it.lat, it.lon) },
+                initialCallsign = userPrefs.callsign,
+                initialAffiliation = soy.engindearing.omnitak.mobile.data.CoTAffiliation.FRIEND,
+                editing = true,
+                editingSelf = true,
+                initialSelfLat = effectiveSelfFix?.lat,
+                initialSelfLon = effectiveSelfFix?.lon,
+                onSave = { result ->
+                    prefScope.launch { app.userPrefsStore.update { it.copy(callsign = result.callsign) } }
+                    val newLat = result.selfLatOverride
+                    val newLon = result.selfLonOverride
+                    if (newLat != null && newLon != null) {
+                        manualSelfFix = newLat to newLon
+                    }
+                    selfMarkerEditOpen = false
+                },
+                onDismiss = { selfMarkerEditOpen = false },
+            )
+        }
 
         // "Go to Coordinate" — TWD97 (7+7 / 5+5) / MGRS / Lat-Lon entry.
         if (coordEntryOpen) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -279,6 +279,29 @@ fun SettingsScreen(
                     onCheckedChange = { v -> mutate { it.copy(useMilStdSelfSymbol = v) } },
                 )
             }
+            Spacer(Modifier.height(8.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Triangle self-marker",
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        "Rotates with compass heading",
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = prefs.selfMarkerTriangle,
+                    onCheckedChange = { v -> mutate { it.copy(selfMarkerTriangle = v) } },
+                    enabled = !prefs.useMilStdSelfSymbol,
+                )
+            }
 
             SectionHeader(Loc.t("settings.section.droneDetection"))
             Row(

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MarkerHeadingTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MarkerHeadingTest.kt
@@ -1,0 +1,87 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Test
+import org.junit.Assert.*
+import soy.engindearing.omnitak.mobile.ui.components.MarkerEditResult
+import soy.engindearing.omnitak.mobile.data.CoTAffiliation
+
+class MarkerHeadingTest {
+
+    @Test
+    fun `CoTEvent has null courseHeading by default`() {
+        val event = CoTEvent(
+            uid = "test-uid",
+            type = "a-f-G",
+            lat = 47.0,
+            lon = -122.0,
+            hae = 0.0,
+            ce = 9999.0,
+            le = 9999.0,
+            timeIso = "2026-01-01T00:00:00Z",
+            staleIso = "2026-01-01T00:05:00Z",
+            callsign = "TEST"
+        )
+        assertNull(event.courseHeading)
+    }
+
+    @Test
+    fun `CoTEvent stores courseHeading correctly`() {
+        val event = CoTEvent(
+            uid = "test-uid",
+            type = "a-f-G",
+            lat = 47.0,
+            lon = -122.0,
+            hae = 0.0,
+            ce = 9999.0,
+            le = 9999.0,
+            timeIso = "2026-01-01T00:00:00Z",
+            staleIso = "2026-01-01T00:05:00Z",
+            callsign = "TEST",
+            courseHeading = 270.0
+        )
+        assertEquals(270.0, event.courseHeading!!, 0.0)
+    }
+
+    @Test
+    fun `MarkerEditResult has null courseHeading by default`() {
+        val result = MarkerEditResult(
+            callsign = "TEST",
+            affiliation = CoTAffiliation.FRIEND,
+            altitudeMeters = null,
+            remarks = "",
+            cotType = "a-f-G",
+            iconsetPath = null,
+            argbHex = null
+        )
+        assertNull(result.courseHeading)
+    }
+
+    @Test
+    fun `CoTParser parses track course from XML`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>
+<event version="2.0" uid="ANDROID-test" type="a-f-G" time="2026-01-01T00:00:00Z" start="2026-01-01T00:00:00Z" stale="2026-01-01T00:05:00Z" how="h-e">
+  <point lat="47.0" lon="-122.0" hae="0.0" ce="9999.0" le="9999.0"/>
+  <detail>
+    <contact callsign="TEST"/>
+    <track course="270.0" speed="0.0"/>
+  </detail>
+</event>"""
+        val event = CoTParser.parse(xml)
+        assertNotNull(event)
+        assertEquals(270.0, event!!.courseHeading!!, 0.0)
+    }
+
+    @Test
+    fun `CoTParser returns null courseHeading when track element absent`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>
+<event version="2.0" uid="ANDROID-test" type="a-f-G" time="2026-01-01T00:00:00Z" start="2026-01-01T00:00:00Z" stale="2026-01-01T00:05:00Z" how="h-e">
+  <point lat="47.0" lon="-122.0" hae="0.0" ce="9999.0" le="9999.0"/>
+  <detail>
+    <contact callsign="TEST"/>
+  </detail>
+</event>"""
+        val event = CoTParser.parse(xml)
+        assertNotNull(event)
+        assertNull(event!!.courseHeading)
+    }
+}


### PR DESCRIPTION
## Summary

- **#82** — Tap self-marker to manually reposition it. Self-marker tap detected in TacticalMap; opens MarkerEditSheet in self-editing mode with editable lat/lon fields. Manual position pill overlay shown while active; tap to resume GPS.
- **#83** — Triangle self-marker option. New `selfMarkerTriangle` pref drives a programmatically-drawn upward-pointing triangle bitmap set as the MapLibre `bearingName` so it auto-rotates with compass heading. Toggle added to Settings under the MIL-STD switch (disabled when MIL-STD is active). Cesium 3D triangle styling is a follow-up.
- **#84** — Icon picker already wired via PR #98 (`MarkerIconPickerSheet` inside `MarkerEditSheet`). Verified `initialIconsetPath` and `iconsetPath` round-trip correctly through the contact-tap → `handleContactTap` → edit sheet → `onSave` flow. No further changes needed.
- **#85** — Settable CoT marker heading. `courseHeading: Double?` added to `CoTEvent`; `CoTParser` parses `<track course="…"/>` element; `CotBuilders.rebuildEvent` emits `<track>` when set; heading text field added to `MarkerEditSheet`; heading preserved on marker edit save in `MapScreen`.

## Test plan

- [ ] Tap the self-marker (blue puck) on the map → MarkerEditSheet opens with callsign pre-filled and lat/lon fields
- [ ] Change lat/lon in the sheet → manual position pill appears at top of map; self-puck moves to entered coordinates
- [ ] Tap the pill → GPS resumes, puck returns to live location
- [ ] Enable "Triangle self-marker" in Settings → self-puck becomes a rotating triangle; disable → reverts to disc/MIL-STD
- [ ] Open any contact marker → MarkerEditSheet → icon picker shows (verify PR #98)
- [ ] Set heading 270° on a marker → save → marker XML contains `<track course="270.0" speed="0.0"/>`
- [ ] Receive a CoT message with `<track course="90.0"/>` → `CoTEvent.courseHeading == 90.0`
- [ ] Unit tests pass: `./gradlew :app:testDebugUnitTest`

Closes #82, #83, #84, #85