### PR TITLE
Self-marker parity: broadcast manual position + Cesium triangle/tap

### DIFF
--- a/app/src/main/assets/cesium_scene.html
+++ b/app/src/main/assets/cesium_scene.html
@@ -54,7 +54,20 @@
     ctx.shadowBlur=0;const lum=_luma(hex);ctx.lineWidth=3;ctx.strokeStyle=lum>0.6?'#000':'#fff';ctx.beginPath();ctx.arc(28,28,18,0,Math.PI*2);ctx.stroke();
     const url=c.toDataURL('image/png');_state.billboardCache.set(sk,url);return url;}
   function _luma(hex){const h=hex.replace('#','');if(h.length<6)return 1;const r=parseInt(h.substr(0,2),16)/255,g=parseInt(h.substr(2,2),16)/255,b=parseInt(h.substr(4,2),16)/255;return 0.299*r+0.587*g+0.114*b;}
-  function _billboard(a,k,sidc,spot,icon){
+  // #83 — triangle self-marker glyph, parity with the 2D puck's triangle
+  // style. Points "up" (toward 0/north in the bitmap); the billboard is then
+  // rotated by the device heading (e.heading) just like the 2D RenderMode.
+  // COMPASS puck, so the apex tracks where the operator faces.
+  function _selfTriangle(){const sk='selftri';if(_state.billboardCache.has(sk))return _state.billboardCache.get(sk);
+    const c=document.createElement('canvas');c.width=56;c.height=56;const ctx=c.getContext('2d');
+    const color=_color('f');ctx.lineWidth=4;ctx.strokeStyle=color;ctx.fillStyle=color+'88';
+    ctx.shadowColor='rgba(0,0,0,0.5)';ctx.shadowBlur=4;
+    ctx.beginPath();ctx.moveTo(28,6);ctx.lineTo(48,50);ctx.lineTo(28,40);ctx.lineTo(8,50);ctx.closePath();ctx.fill();ctx.stroke();
+    const url=c.toDataURL('image/png');_state.billboardCache.set(sk,url);return url;}
+  function _billboard(a,k,sidc,spot,icon,triangle){
+    // #83 — operator's own triangle self-marker beats every other glyph
+    // branch when the triangle style pref is on.
+    if(triangle){return _selfTriangle();}
     // #98 — a pre-rendered TAK icon-suite badge (Markers / Google) arrives as a
     // ready data-URL from the Kotlin side, the same bitmap the 2D map registers,
     // so the globe matches it byte-for-byte without re-drawing the glyph here.
@@ -140,10 +153,10 @@
       const rot=(typeof e.heading==='number')?-e.heading*Math.PI/180:0;
       let entity=_state.entities.get(e.uid);
       if(!entity){entity=v.entities.add({id:e.uid,position:pos,
-        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot,e.icon),verticalOrigin:Cesium.VerticalOrigin.CENTER,heightReference:useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
+        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot,e.icon,e.triangle),verticalOrigin:Cesium.VerticalOrigin.CENTER,heightReference:useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
         label:e.callsign?{text:e.callsign,font:'12px -apple-system, sans-serif',fillColor:Cesium.Color.WHITE,outlineColor:Cesium.Color.BLACK,outlineWidth:2,style:Cesium.LabelStyle.FILL_AND_OUTLINE,pixelOffset:new Cesium.Cartesian2(0,-32),heightReference:useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE,disableDepthTestDistance:Number.POSITIVE_INFINITY}:undefined,
       });_state.entities.set(e.uid,entity);}
-      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot,e.icon);entity.billboard.heightReference=useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE;entity.billboard.rotation=rot;if(entity.label&&e.callsign)entity.label.text=e.callsign;}
+      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot,e.icon,e.triangle);entity.billboard.heightReference=useGround?Cesium.HeightReference.CLAMP_TO_GROUND:Cesium.HeightReference.NONE;entity.billboard.rotation=rot;if(entity.label&&e.callsign)entity.label.text=e.callsign;}
     },
     setEntities(arg){const list=_parse(arg);if(!Array.isArray(list))return;const seen=new Set();
       for(const e of list){if(e&&e.uid){seen.add(e.uid);window.OmniBridge.upsertEntity(e);}}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -515,6 +515,12 @@ class OmniTAKApp : Application() {
             prefsStore = userPrefsStore,
             sendCoT = { xml -> serverManager.sendCoT(xml) },
             locationFix = fixFlow,
+            // #82 — when the operator manually repositions their self-marker,
+            // PPLI broadcasts that coordinate instead of live GPS. The override
+            // lives on LocationProvider as the shared source of truth (MapScreen
+            // writes it, the puck + card read it), so the broadcast can't drift
+            // from what's on screen.
+            manualFixProvider = { locationProvider.manualFix.value },
             batteryProvider = ::readDeviceBatteryPercent,
             sendToMesh = { event -> activeMeshManager.sendCoTOverMesh(event) },
             meshConnected = { activeMeshManager.activeConnectionState.value is ConnectionState.Connected },
@@ -533,6 +539,12 @@ class OmniTAKApp : Application() {
         broadcasterPrefsJob = null
     }
     val locationProvider: LocationProvider by lazy { LocationProvider(this) }
+    // #83 — device compass heading for the Cesium triangle self-marker, so it
+    // rotates with the operator's facing just like the 2D RenderMode.COMPASS
+    // puck. Started/stopped by MapScreen only while the globe is on screen.
+    val headingProvider: soy.engindearing.omnitak.mobile.data.DeviceHeadingProvider by lazy {
+        soy.engindearing.omnitak.mobile.data.DeviceHeadingProvider(this)
+    }
     val serverManager: ServerManager by lazy {
         ServerManager(
             store = TAKServerStore(this),

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/DeviceHeadingProvider.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/DeviceHeadingProvider.kt
@@ -1,0 +1,84 @@
+package soy.engindearing.omnitak.mobile.data
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.view.Surface
+import android.view.WindowManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Device compass heading in degrees clockwise from true/magnetic north
+ * (0..360). Backed by the rotation-vector sensor — the same source
+ * MapLibre's `RenderMode.COMPASS` uses to spin the 2D self-puck, so the
+ * Cesium globe's triangle self-marker (#83) rotates in lockstep with the
+ * 2D engine instead of being stuck pointing north.
+ *
+ * Emits null until the first sensor sample (or on a device with no
+ * rotation-vector sensor), which callers treat as "heading unknown →
+ * draw the triangle pointing north." Lifecycle is caller-owned: [start]
+ * when the globe is on screen, [stop] when it leaves so we don't keep the
+ * magnetometer powered for nothing.
+ */
+class DeviceHeadingProvider(private val context: Context) {
+
+    private val sensorManager =
+        context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+    private val rotationSensor: Sensor? =
+        sensorManager?.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+
+    private val _headingDeg = MutableStateFlow<Float?>(null)
+    val headingDeg: StateFlow<Float?> = _headingDeg.asStateFlow()
+
+    private var started = false
+    private val rotationMatrix = FloatArray(9)
+    private val orientation = FloatArray(3)
+
+    private val listener = object : SensorEventListener {
+        override fun onSensorChanged(event: SensorEvent) {
+            if (event.sensor.type != Sensor.TYPE_ROTATION_VECTOR) return
+            SensorManager.getRotationMatrixFromVector(rotationMatrix, event.values)
+            SensorManager.getOrientation(rotationMatrix, orientation)
+            // azimuth (radians, -PI..PI) → degrees clockwise from north (0..360),
+            // then corrected for the natural display rotation so the heading is
+            // referenced to the top of the screen the operator is holding.
+            val azimuthDeg = Math.toDegrees(orientation[0].toDouble()).toFloat()
+            val corrected = (azimuthDeg + displayRotationDegrees() + 360f) % 360f
+            _headingDeg.value = corrected
+        }
+
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) { /* no-op */ }
+    }
+
+    /** Start listening. No-op (returns false) when there's no sensor. */
+    fun start(): Boolean {
+        if (started) return true
+        val sm = sensorManager ?: return false
+        val sensor = rotationSensor ?: return false
+        sm.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_UI)
+        started = true
+        return true
+    }
+
+    fun stop() {
+        if (!started) return
+        sensorManager?.unregisterListener(listener)
+        started = false
+    }
+
+    @Suppress("DEPRECATION")
+    private fun displayRotationDegrees(): Float {
+        val wm = context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+            ?: return 0f
+        return when (wm.defaultDisplay?.rotation) {
+            Surface.ROTATION_90 -> 90f
+            Surface.ROTATION_180 -> 180f
+            Surface.ROTATION_270 -> 270f
+            else -> 0f
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/LocationProvider.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/LocationProvider.kt
@@ -31,6 +31,27 @@ class LocationProvider(private val context: Context) {
     private val _fix = MutableStateFlow<SelfFix?>(null)
     val fix: StateFlow<SelfFix?> = _fix.asStateFlow()
 
+    // #82 — manual self-position override. When the operator taps the
+    // self-marker and drops it somewhere (MapScreen's reposition sheet),
+    // the chosen coordinate lands here as the single source of truth for
+    // "where we say we are." Non-null means manual mode is active:
+    //  - the map puck + SelfPositionCard render this instead of GPS, and
+    //  - SelfPositionBroadcaster broadcasts THIS in PPLI so teammates and
+    //    the TAK server see the operator where they placed themselves, not
+    //    at their real GPS spot (iOS PositionBroadcastService parity).
+    // Clearing it ("resume GPS") reverts every consumer to the live fix.
+    private val _manualFix = MutableStateFlow<SelfFix?>(null)
+    val manualFix: StateFlow<SelfFix?> = _manualFix.asStateFlow()
+
+    /** #82 — enter manual mode at [fix] (set) or resume live GPS (null). */
+    fun setManualFix(fix: SelfFix?) {
+        _manualFix.value = fix
+    }
+
+    /** #82 — the position every consumer should treat as authoritative:
+     *  the manual override when active, else the live GPS fix. */
+    fun effectiveFix(): SelfFix? = _manualFix.value ?: _fix.value
+
     private val callback = object : LocationCallback() {
         override fun onLocationResult(result: LocationResult) {
             result.lastLocation?.let { offerFix(it.toSelfFix()) }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/SelfPositionBroadcaster.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/SelfPositionBroadcaster.kt
@@ -37,6 +37,14 @@ class SelfPositionBroadcaster internal constructor(
     private val updatePrefs: suspend ((UserPrefs) -> UserPrefs) -> Unit,
     private val sendCoT: suspend (String) -> Boolean,
     private val locationFix: StateFlow<SelfFix?>,
+    // #82 — manual self-position override. When non-null, PPLI broadcasts
+    // this coordinate instead of the live GPS fix so teammates / the TAK
+    // server see the operator where they manually placed themselves (the
+    // self-marker reposition flow). Returns null in normal GPS mode, which
+    // falls through to the existing live-fix → persisted-fix selection.
+    // A lambda (like meshBroadcastEnabled) so toggling manual mode on a
+    // running broadcaster takes effect on the next tick without a restart.
+    private val manualFixProvider: () -> SelfFix? = { null },
     // Issue #11 — supplies the device's real battery percentage (0..100).
     // Returns null when unknown (no Context yet, BatteryManager error, or
     // a tester-friendly default for unit tests). The previous hardcoded
@@ -71,6 +79,7 @@ class SelfPositionBroadcaster internal constructor(
         prefsStore: UserPrefsStore,
         sendCoT: suspend (String) -> Boolean,
         locationFix: StateFlow<SelfFix?>,
+        manualFixProvider: () -> SelfFix? = { null },
         batteryProvider: () -> Int? = { null },
         intervalMs: Long = DEFAULT_INTERVAL_MS,
         staleSeconds: Long = DEFAULT_STALE_SECONDS,
@@ -84,6 +93,7 @@ class SelfPositionBroadcaster internal constructor(
         updatePrefs = { mutator -> prefsStore.update(mutator) },
         sendCoT = sendCoT,
         locationFix = locationFix,
+        manualFixProvider = manualFixProvider,
         batteryProvider = batteryProvider,
         intervalMs = intervalMs,
         staleSeconds = staleSeconds,
@@ -127,7 +137,11 @@ class SelfPositionBroadcaster internal constructor(
     private suspend fun currentPrefs(): UserPrefs = prefsFlow.first()
 
     internal suspend fun broadcastOnce(prefs: UserPrefs) {
-        val fix = locationFix.value
+        // #82 — a manual self-position override wins over live GPS so PPLI
+        // reports where the operator placed themselves. It carries no real
+        // accuracy (Float.NaN → unknown CE), so peers don't read a manual
+        // drop as a precise GPS lock.
+        val fix = manualFixProvider() ?: locationFix.value
         val lat: Double
         val lon: Double
         val hae: Double

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJson.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJson.kt
@@ -34,6 +34,13 @@ internal fun buildCesiumEntitiesJson(
     selfLon: Double?,
     selfCallsign: String,
     context: Context? = null,
+    // #83 — when true the self entity carries a `triangle` flag + heading so
+    // the globe draws a heading-rotated triangle instead of the friendly
+    // affiliation circle, matching the 2D puck's triangle style.
+    selfTriangle: Boolean = false,
+    // #83 — device compass heading (deg CW from north) for the triangle.
+    // null → unknown, the triangle points north (parity with a no-fix puck).
+    selfHeadingDeg: Float? = null,
 ): String {
     val arr = JSONArray()
     if (selfLat != null && selfLon != null && !selfLat.isNaN() && !selfLon.isNaN()) {
@@ -45,6 +52,13 @@ internal fun buildCesiumEntitiesJson(
                 put("callsign", selfCallsign)
                 put("affiliation", "f")
                 put("kind", "self")
+                // #83 — triangle style + heading. The JS side draws a
+                // heading-rotated triangle for kind:self when `triangle` is set
+                // (the entity rotation already reads `heading`).
+                if (selfTriangle) {
+                    put("triangle", true)
+                    put("heading", (selfHeadingDeg ?: 0f).toDouble())
+                }
             },
         )
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumMapView.kt
@@ -44,6 +44,16 @@ fun CesiumMapView(
     selfCallsign: String,
     onLongPress: (LatLng, Offset) -> Unit,
     onContactTap: (CoTEvent) -> Unit,
+    // #82 — tap on the self entity opens the reposition sheet, parity with the
+    // 2D engine's onSelfMarkerTap. The scene already tags the self billboard
+    // `__self__` and posts that uid on tap; this routes it back to native.
+    onSelfMarkerTap: (() -> Unit)? = null,
+    // #83 — render the self entity as a heading-rotated triangle (vs the
+    // friendly circle) when the operator's triangle self-marker pref is on.
+    selfMarkerTriangle: Boolean = false,
+    // #83 — device compass heading (deg CW from north) driving the triangle's
+    // rotation; null leaves it pointing north.
+    selfHeadingDeg: Float? = null,
     // Issue #79 — operator drawings (line / polygon / circle) rendered on the
     // globe via the cesium_scene.html setDrawings bridge, so a shape made on
     // the 2D engine doesn't vanish when the operator switches to 3D.
@@ -93,6 +103,9 @@ fun CesiumMapView(
     val selfCallsignState = rememberUpdatedState(selfCallsign)
     val onLongPressState = rememberUpdatedState(onLongPress)
     val onContactTapState = rememberUpdatedState(onContactTap)
+    val onSelfMarkerTapState = rememberUpdatedState(onSelfMarkerTap)
+    val selfTriangleState = rememberUpdatedState(selfMarkerTriangle)
+    val selfHeadingState = rememberUpdatedState(selfHeadingDeg)
     val onCameraState = rememberUpdatedState(onCameraChanged)
     // #95 — read the latest lock state inside the JS bridge callbacks so a
     // globe that opens while north-up is already on gets the lock applied on
@@ -106,6 +119,8 @@ fun CesiumMapView(
         val json = buildCesiumEntitiesJson(
             contactsState.value, selfLatState.value, selfLonState.value, selfCallsignState.value,
             context = appContext,
+            selfTriangle = selfTriangleState.value,
+            selfHeadingDeg = selfHeadingState.value,
         )
         wv.evaluateJavascript("window.OmniBridge.setEntities($json);", null)
     }
@@ -186,9 +201,14 @@ fun CesiumMapView(
                                 when (event) {
                                     "tap" -> {
                                         val uid = if (o.isNull("uid")) null else o.optString("uid")
-                                        if (!uid.isNullOrEmpty() && uid != "__self__") {
-                                            contactsState.value.firstOrNull { it.uid == uid }
-                                                ?.let { onContactTapState.value(it) }
+                                        when {
+                                            // #82 — tapping the self entity opens the
+                                            // reposition sheet (parity with TacticalMap's
+                                            // onSelfMarkerTap on the 2D engine).
+                                            uid == "__self__" -> onSelfMarkerTapState.value?.invoke()
+                                            !uid.isNullOrEmpty() ->
+                                                contactsState.value.firstOrNull { it.uid == uid }
+                                                    ?.let { onContactTapState.value(it) }
                                         }
                                     }
                                     "longpress" -> {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -169,13 +169,14 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     var femaPaletteLatLng by remember { mutableStateOf<LatLng?>(null) }
     var editingMarker by remember { mutableStateOf<CoTEvent?>(null) }
     var selfMarkerEditOpen by remember { mutableStateOf(false) }
-    var manualSelfFix by remember { mutableStateOf<Pair<Double, Double>?>(null) }
-    val effectiveSelfFix: soy.engindearing.omnitak.mobile.data.SelfFix? = manualSelfFix?.let { (lat, lon) ->
-        soy.engindearing.omnitak.mobile.data.SelfFix(
-            lat = lat, lon = lon, altitudeM = selfFix?.altitudeM ?: 0.0,
-            speedKmh = 0.0, accuracyM = Float.NaN, timeMs = System.currentTimeMillis()
-        )
-    } ?: selfFix
+    // #82 — manual self-position override. Stored on LocationProvider (not
+    // local state) so it's the single source of truth: the puck + the
+    // SelfPositionCard render it AND SelfPositionBroadcaster broadcasts it in
+    // PPLI, so teammates see the operator where they placed themselves instead
+    // of at live GPS. Collecting the flow keeps the map in lockstep with what
+    // goes on the wire; null = live GPS (the "resume GPS" state).
+    val manualSelfFix by app.locationProvider.manualFix.collectAsState()
+    val effectiveSelfFix: soy.engindearing.omnitak.mobile.data.SelfFix? = manualSelfFix ?: selfFix
     var recenterTick by remember { mutableStateOf(0) }
     var zoomInTick by remember { mutableStateOf(0) }
     var zoomOutTick by remember { mutableStateOf(0) }
@@ -475,14 +476,33 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         // 3D Globe — photoreal Cesium WebView engine. Contacts (incl. dropped
         // pins) + self render as entities; long-press surfaces the same radial
         // menu the 2D/terrain engines use, tapping a contact opens its sheet.
+        // #83 — device compass heading drives the Cesium triangle self-marker's
+        // rotation (parity with the 2D RenderMode.COMPASS puck). Only run the
+        // magnetometer while the globe is up AND the triangle style is on, so
+        // the 2D engine and disc-marker users pay nothing for it.
+        val deviceHeading by app.headingProvider.headingDeg.collectAsState()
+        LaunchedEffect(userPrefs.selfMarkerTriangle) {
+            if (userPrefs.selfMarkerTriangle) app.headingProvider.start()
+            else app.headingProvider.stop()
+        }
+        DisposableEffect(Unit) {
+            onDispose { app.headingProvider.stop() }
+        }
         soy.engindearing.omnitak.mobile.ui.components.CesiumMapView(
             modifier = Modifier.fillMaxSize(),
             contacts = visibleContacts,
-            selfLat = selfFix?.lat,
-            selfLon = selfFix?.lon,
+            // #82 — show the manual override on the globe too (effectiveSelfFix),
+            // so the 3D puck and the broadcast agree with the 2D engine.
+            selfLat = effectiveSelfFix?.lat,
+            selfLon = effectiveSelfFix?.lon,
             selfCallsign = userPrefs.callsign,
             onLongPress = handleMapLongPress,
             onContactTap = handleContactTap,
+            // #82 — tap self entity on the globe opens the reposition sheet too.
+            onSelfMarkerTap = { selfMarkerEditOpen = true },
+            // #83 — triangle self-marker style + heading parity on the globe.
+            selfMarkerTriangle = userPrefs.selfMarkerTriangle,
+            selfHeadingDeg = deviceHeading,
             onCameraChanged = handleCameraChanged,
             // Issue #79 — render saved drawings on the globe too (parity with
             // the 2D engine). The in-progress draft lives only during 2D
@@ -1339,7 +1359,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             ) {
                 androidx.compose.material3.Surface(
                     modifier = Modifier
-                        .clickable { manualSelfFix = null }
+                        .clickable { app.locationProvider.setManualFix(null) }
                         .padding(horizontal = 16.dp, vertical = 4.dp),
                     shape = androidx.compose.foundation.shape.RoundedCornerShape(20.dp),
                     color = soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent.copy(alpha = 0.15f),
@@ -1766,7 +1786,20 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                     val newLat = result.selfLatOverride
                     val newLon = result.selfLonOverride
                     if (newLat != null && newLon != null) {
-                        manualSelfFix = newLat to newLon
+                        // #82 — push the manual position into LocationProvider so
+                        // the puck, the card, and the PPLI broadcast all use it.
+                        // accuracyM = NaN marks it as a manual drop (unknown CE on
+                        // the wire); altitude inherits the last GPS fix's HAE.
+                        app.locationProvider.setManualFix(
+                            soy.engindearing.omnitak.mobile.data.SelfFix(
+                                lat = newLat,
+                                lon = newLon,
+                                altitudeM = selfFix?.altitudeM ?: 0.0,
+                                speedKmh = 0.0,
+                                accuracyM = Float.NaN,
+                                timeMs = System.currentTimeMillis(),
+                            )
+                        )
                     }
                     selfMarkerEditOpen = false
                 },

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/SelfPositionBroadcasterManualFixTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/SelfPositionBroadcasterManualFixTest.kt
@@ -1,0 +1,114 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.SelfFix
+import soy.engindearing.omnitak.mobile.data.UserPrefs
+
+/**
+ * #82 — when the operator manually repositions their self-marker, PPLI must
+ * broadcast the MANUAL coordinate, not live GPS, so teammates / the TAK server
+ * see them where they placed themselves (iOS PositionBroadcastService parity).
+ * Clearing the override ("resume GPS") reverts to the live fix.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SelfPositionBroadcasterManualFixTest {
+
+    private val berlin = SelfFix(
+        lat = 52.5, lon = 13.4, altitudeM = 34.0,
+        speedKmh = 12.0, accuracyM = 5f, timeMs = 1_700_000_000_000L,
+    )
+
+    private fun broadcaster(
+        fixFlow: MutableStateFlow<SelfFix?>,
+        manualFix: MutableStateFlow<SelfFix?>,
+        sent: MutableList<String>,
+        prefs: UserPrefs = UserPrefs(selfUid = "ANDROID-test"),
+    ): SelfPositionBroadcaster = SelfPositionBroadcaster(
+        scope = CoroutineScope(Dispatchers.Unconfined),
+        prefsFlow = MutableStateFlow(prefs),
+        updatePrefs = { /* no-op */ },
+        sendCoT = { xml -> sent += xml; true },
+        locationFix = fixFlow,
+        manualFixProvider = { manualFix.value },
+    )
+
+    @Test fun broadcasts_manual_position_over_live_gps() = runTest {
+        val fixFlow = MutableStateFlow<SelfFix?>(berlin)
+        // Operator dropped themselves on a hilltop a few km away.
+        val manual = SelfFix(
+            lat = 52.55, lon = 13.45, altitudeM = 80.0,
+            speedKmh = 0.0, accuracyM = Float.NaN, timeMs = 1_700_000_500_000L,
+        )
+        val manualFlow = MutableStateFlow<SelfFix?>(manual)
+        val sent = mutableListOf<String>()
+        val prefs = UserPrefs(selfUid = "ANDROID-test")
+        broadcaster(fixFlow, manualFlow, sent, prefs).broadcastOnce(prefs)
+
+        assertTrue("expected one PPLI", sent.size == 1)
+        val xml = sent.single()
+        assertTrue("manual lat in XML, was: $xml", xml.contains("lat=\"52.55\""))
+        assertTrue("manual lon in XML, was: $xml", xml.contains("lon=\"13.45\""))
+        // The live GPS coords must NOT leak onto the wire while manual is active.
+        assertFalse("must not broadcast live GPS lat, was: $xml", xml.contains("lat=\"52.5\""))
+        assertFalse("must not broadcast live GPS lon, was: $xml", xml.contains("lon=\"13.4\""))
+    }
+
+    @Test fun manual_drop_reports_unknown_circular_error() = runTest {
+        // A manual drop carries accuracyM = NaN; the broadcaster must map that
+        // to the "unknown" CE sentinel so peers don't read it as a precise lock.
+        val fixFlow = MutableStateFlow<SelfFix?>(berlin)
+        val manual = SelfFix(
+            lat = 10.0, lon = 20.0, altitudeM = 0.0,
+            speedKmh = 0.0, accuracyM = Float.NaN, timeMs = 1L,
+        )
+        val manualFlow = MutableStateFlow<SelfFix?>(manual)
+        val sent = mutableListOf<String>()
+        val prefs = UserPrefs(selfUid = "ANDROID-test")
+        broadcaster(fixFlow, manualFlow, sent, prefs).broadcastOnce(prefs)
+
+        val xml = sent.single()
+        assertTrue("unknown CE for a manual drop, was: $xml", xml.contains("ce=\"9999999.0\""))
+    }
+
+    @Test fun reverts_to_live_gps_when_override_cleared() = runTest {
+        val fixFlow = MutableStateFlow<SelfFix?>(berlin)
+        val manualFlow = MutableStateFlow<SelfFix?>(
+            SelfFix(lat = 1.0, lon = 2.0, altitudeM = 0.0, speedKmh = 0.0, accuracyM = Float.NaN, timeMs = 1L),
+        )
+        val sent = mutableListOf<String>()
+        val prefs = UserPrefs(selfUid = "ANDROID-test")
+        val b = broadcaster(fixFlow, manualFlow, sent, prefs)
+
+        // First tick: manual active.
+        b.broadcastOnce(prefs)
+        assertTrue(sent.last().contains("lat=\"1.0\""))
+
+        // Operator taps "resume GPS" → override cleared.
+        manualFlow.value = null
+        b.broadcastOnce(prefs)
+        val resumed = sent.last()
+        assertTrue("back to live GPS lat, was: $resumed", resumed.contains("lat=\"52.5\""))
+        assertTrue("back to live GPS lon, was: $resumed", resumed.contains("lon=\"13.4\""))
+    }
+
+    @Test fun null_override_is_pure_passthrough_to_live_fix() = runTest {
+        // Sanity: with no manual override, behaviour is identical to the
+        // pre-#82 live-fix path (regression guard for the default lambda).
+        val fixFlow = MutableStateFlow<SelfFix?>(berlin)
+        val manualFlow = MutableStateFlow<SelfFix?>(null)
+        val sent = mutableListOf<String>()
+        val prefs = UserPrefs(selfUid = "ANDROID-test")
+        broadcaster(fixFlow, manualFlow, sent, prefs).broadcastOnce(prefs)
+
+        val xml = sent.single()
+        assertTrue("live lat, was: $xml", xml.contains("lat=\"52.5\""))
+        assertTrue("live lon, was: $xml", xml.contains("lon=\"13.4\""))
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJsonTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/CesiumEntityJsonTest.kt
@@ -28,6 +28,51 @@ class CesiumEntityJsonTest {
     }
 
     @Test
+    fun `self entity is not a triangle by default`() {
+        // #83 — without the triangle pref the self entity keeps the friendly
+        // affiliation frame (no triangle flag / heading), so existing globe
+        // users see no behaviour change.
+        val json = parse(buildCesiumEntitiesJson(
+            contacts = emptyList(),
+            selfLat = 47.65, selfLon = -117.42, selfCallsign = "OMNI-1",
+        ))
+        val self = json.getJSONObject(0)
+        assertFalse("no triangle flag when pref off", self.has("triangle"))
+        assertFalse("no heading when pref off", self.has("heading"))
+    }
+
+    @Test
+    fun `self entity carries triangle flag and heading when triangle style on`() {
+        // #83 — triangle self-marker parity with the 2D puck: the JS side draws
+        // a heading-rotated triangle when `triangle` is set, rotating by `heading`.
+        val json = parse(buildCesiumEntitiesJson(
+            contacts = emptyList(),
+            selfLat = 47.65, selfLon = -117.42, selfCallsign = "OMNI-1",
+            selfTriangle = true,
+            selfHeadingDeg = 137.5f,
+        ))
+        val self = json.getJSONObject(0)
+        assertEquals("self", self.getString("kind"))
+        assertTrue("triangle flag set", self.getBoolean("triangle"))
+        assertEquals(137.5, self.getDouble("heading"), 0.001)
+    }
+
+    @Test
+    fun `triangle self defaults heading to zero when device heading unknown`() {
+        // null device heading (no magnetometer / first frame) → triangle points
+        // north, matching a 2D puck with no compass fix yet.
+        val json = parse(buildCesiumEntitiesJson(
+            contacts = emptyList(),
+            selfLat = 47.65, selfLon = -117.42, selfCallsign = "OMNI-1",
+            selfTriangle = true,
+            selfHeadingDeg = null,
+        ))
+        val self = json.getJSONObject(0)
+        assertTrue("triangle flag set", self.getBoolean("triangle"))
+        assertEquals(0.0, self.getDouble("heading"), 0.001)
+    }
+
+    @Test
     fun `RID multirotor contact gets SUAPMHQ multirotor SIDC`() {
         // RemoteIdToCoTConverter emits a-u-A-M-H-Q for multirotor drones.
         // The catalogue maps it to SUAPMHQ---- which milsymbol can render


### PR DESCRIPTION
Two follow-ups left open after the self-marker work in #104 — both gaps the MapLibre 2D engine already handled but the broadcast path and the Cesium 3D globe did not. Completes follow-ups from #82/#83.

## Task 1 — PPLI broadcasts the manual self-position
#104 added "tap self-marker → reposition," but only the *displayed* puck and the SelfPositionCard honored the manual coordinate — `SelfPositionBroadcaster` kept sending **live GPS**, so teammates/the TAK server saw the operator at their real spot. iOS (`PositionBroadcastService`) broadcasts the manual coord when manual mode is active; this brings Android to parity.

- New shared source of truth: `LocationProvider.manualFix` (`StateFlow<SelfFix?>`). `MapScreen` writes it (reposition save / "resume GPS" tap), the puck + SelfPositionCard read it via `effectiveSelfFix`, and `SelfPositionBroadcaster` reads it through a `manualFixProvider` lambda — so a running broadcaster picks up the change on its next tick (no restart), and the wire can't drift from what's on screen.
- A manual drop carries `accuracyM = NaN`, which the broadcaster already maps to the unknown-CE sentinel (`9999999.0`) — so a manual position never masquerades as a precise GPS lock.
- `MapScreen`'s transient local `manualSelfFix` state is replaced by the provider flow (no duplicated state).

## Task 2 — Cesium 3D parity for the triangle + self-marker tap
The triangle self-marker style (#83) and the tap-to-reposition gesture (#82) worked only on MapLibre 2D; on the Cesium globe they were stubbed.

- **Self tap:** the scene already tagged the self billboard `__self__` and posted that uid on tap, but `CesiumMapView` explicitly dropped it. It now routes to a new `onSelfMarkerTap` callback → opens the reposition sheet in 3D too (the 2D path already called `onSelfMarkerTap`).
- **Triangle style:** the self entity carries a `triangle` flag + `heading` when the pref is on; `cesium_scene.html` draws a heading-rotated triangle glyph (reusing the billboard's existing heading rotation) instead of the friendly affiliation circle.
- **Heading source:** new `DeviceHeadingProvider` (rotation-vector sensor — the same source MapLibre's `RenderMode.COMPASS` puck uses) spins the triangle to the operator's facing. Run only while the globe is up *and* the triangle pref is on, so the 2D engine and disc-marker users pay nothing. Unknown heading → triangle points north (parity with a no-compass-fix puck).
- The globe self entity now uses the effective fix, so a manual reposition shows on 3D and agrees with the broadcast.

## Test plan
- `./gradlew :app:assembleDebug` — GREEN.
- `./gradlew :app:testDebugUnitTest` — GREEN (full suite).
- New `SelfPositionBroadcasterManualFixTest` (4 tests): manual coord wins over live GPS; manual drop → unknown CE; "resume GPS" reverts to live fix; null override is pure passthrough.
- Extended `CesiumEntityJsonTest` (+3 tests): no triangle/heading by default; triangle flag + heading present when the style is on; heading defaults to 0 when device heading is unknown.

### Needs a human visual/device pass
- The Cesium triangle glyph + its on-globe rotation, and the self-entity tap hitbox on the globe, are logic/build-verified (entity JSON + bridge wiring under unit test) but **not** yet eyeballed on a device — the WebView/Cesium render and the magnetometer-driven rotation can't be exercised in JVM unit tests.
- `DeviceHeadingProvider`'s display-rotation correction is the standard formula but worth a quick spot-check in landscape on a real device.
- Per the project's side-by-side rule, an iOS+Android composite of the 3D triangle should be captured before declaring the visual gap fully closed.