### PR TITLE
fix(map): triggerRepaint so 2D drawings paint without a reload (#80 candidate)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/GeoJsonLayerFeeder.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/GeoJsonLayerFeeder.kt
@@ -25,7 +25,17 @@ object GeoJsonLayerFeeder {
      *  Returns false when the style/source isn't ready (caller may log). */
     fun push(map: MapLibreMap, sourceId: String, features: JSONArray): Boolean {
         val style = map.style ?: return false
-        return push(style, sourceId, features)
+        val ok = push(style, sourceId, features)
+        // Issues #77 / #80 — force a GL frame after updating source data.
+        // On some Mali/Adreno drivers (reported on Pixel 9 Pro v0.35.5)
+        // GeoJsonSource.setGeoJson on a source whose layer is baked into the
+        // style JSON does NOT schedule a repaint, so a dropped marker / new
+        // drawing stays invisible until a full style reload happens to repaint
+        // (e.g. toggling 3D Terrain). triggerRepaint forces the frame so the
+        // layer paints immediately, with no reload needed. It's a no-op when
+        // the map is already drawing, so it's safe on every push.
+        if (ok) map.triggerRepaint()
+        return ok
     }
 
     /** Same as [push] for callers that already hold the [Style]. */


### PR DESCRIPTION
## Candidate fix — NOT yet device-verified, do not merge without a device pass

mozios (Pixel 9 Pro, v0.35.5) reports drawings only appear after toggling 3D Terrain (a style reload). Root cause: `setGeoJson` on a baked-in-style source doesn't schedule a repaint on some Mali/Adreno drivers. `GeoJsonLayerFeeder.push(map,...)` now calls `map.triggerRepaint()`.

**Status (honest):**
- **#80 drawings** — this targets the repaint class; high confidence by reasoning, but I could not drive the draw-a-line flow remotely to confirm render. Needs a device pass before merge.
- **#77 markers** — NOT fixed by this. On-device test: a dropped marker still didn't paint. The marker icon path (`ContactSymbolLayer` runtime `Style.addImage`) has a separate atlas-refresh cause. #77 stays open with this diagnosis.

Draft until verified on a real Mali device (ideally a Pixel matching the report).