### PR TITLE
feat(fema): parse inbound FEMA kind + wire category rendering (#47 / #46)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/FemaIconCatalog.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/FemaIconCatalog.kt
@@ -46,12 +46,12 @@ import androidx.compose.ui.graphics.vector.ImageVector
 object FemaIconCatalog {
 
     /** SAR / incident-command grouping shown as palette sections. */
-    enum class Category(val displayName: String, val accent: Color) {
-        INCIDENT_COMMAND("Command", Color(0xFFFF9800)),  // orange
-        MEDICAL("Medical", Color(0xFFF44336)),           // red
-        AVIATION("Aviation", Color(0xFF00BCD4)),         // cyan
-        VEHICLES("Vehicles", Color(0xFFFFEB3B)),         // yellow
-        SUPPORT("Support", Color(0xFF4CAF50)),           // green
+    enum class Category(val displayName: String, val accent: Color, val accentArgb: Int) {
+        INCIDENT_COMMAND("Command", Color(0xFFFF9800), 0xFFFF9800.toInt()),  // orange
+        MEDICAL("Medical", Color(0xFFF44336), 0xFFF44336.toInt()),           // red
+        AVIATION("Aviation", Color(0xFF00BCD4), 0xFF00BCD4.toInt()),         // cyan
+        VEHICLES("Vehicles", Color(0xFFFFEB3B), 0xFFFFEB3B.toInt()),         // yellow
+        SUPPORT("Support", Color(0xFF4CAF50), 0xFF4CAF50.toInt()),           // green
     }
 
     /**

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistry.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistry.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
 import soy.engindearing.omnitak.mobile.R
+import soy.engindearing.omnitak.mobile.data.FemaIconCatalog
 import java.io.ByteArrayOutputStream
 
 /**
@@ -80,6 +81,13 @@ object TakIconRegistry {
          *  from ATAK's iconsets DB. Bundled — Material-Symbols (Apache-2.0)
          *  vector drawables, see [GoogleIcon]. */
         GOOGLE("f7f71666-8b28-4b57-9fbb-e38e61d33b79", "Google", bundled = true),
+
+        /** FEMA / ICS marker catalog from #29. Path prefix `COT_MAPPING_FEMA`.
+         *  Bundled — rendered at runtime as category-accented dots. Proper
+         *  per-glyph SVG artwork is tracked in #46; this entry wires up the
+         *  resolution path so inbound FEMA markers are handled by the TAK-suite
+         *  path rather than falling through to the MIL-STD-2525 default. */
+        FEMA("COT_MAPPING_FEMA", "FEMA/ICS", bundled = true),
     }
 
     /**
@@ -259,6 +267,19 @@ object TakIconRegistry {
     }
 
     /**
+     * #46 — Resolve a [FemaIconCatalog.FemaIcon] from a `usericon` iconset path.
+     * Returns null when the path is not a `COT_MAPPING_FEMA/…` path.
+     *
+     * NOTE on artwork: this currently renders FEMA markers as a category-accented
+     * colored dot (same runtime approach as Spot Map). Per-glyph SVG artwork for
+     * each of the 12 FEMA kinds needs to be sourced and dropped into
+     * `app/src/main/assets/fema/COT_MAPPING_FEMA/<category>/<kind>.svg`, then
+     * this method updated to rasterise from the asset bundle. See #46.
+     */
+    fun resolveFemaIcon(iconsetPath: String?): FemaIconCatalog.FemaIcon? =
+        if (iconsetPath != null) FemaIconCatalog.iconByIconsetPath(iconsetPath) else null
+
+    /**
      * Resolve a renderable bitmap for a marker. Returns null when no TAK-suite
      * icon applies, so the caller falls back to MIL-STD-2525 affiliation art.
      *
@@ -290,7 +311,15 @@ object TakIconRegistry {
             val color = argb ?: SpotIcon.WHITE.argb
             return spotDot(color, sizePx, "spot|type|$color")
         }
-        // 3. Markers / Google bitmap packs — Material-Symbols (Apache-2.0)
+        // 3. FEMA / ICS catalog — rendered as a category-accented coloured dot.
+        //    No Context needed (runtime-rendered like Spot Map). TODO #46: once
+        //    per-glyph SVG assets land in app/src/main/assets/fema/, switch to
+        //    asset rasterisation here and remove the dot fallback.
+        resolveFemaIcon(iconsetPath)?.let { femaIcon ->
+            val accentArgb = femaIcon.category.accentArgb
+            return spotDot(accentArgb, sizePx, "fema|${femaIcon.kind.raw}|$sizePx")
+        }
+        // 4. Markers / Google bitmap packs — Material-Symbols (Apache-2.0)
         //    vector glyphs on a rounded badge. Needs a Context to decode.
         if (context != null) {
             resolveBadgeIcon(iconsetPath)?.let { return badge(context, it, sizePx) }
@@ -306,7 +335,8 @@ object TakIconRegistry {
     fun handles(cotType: String?, iconsetPath: String?): Boolean =
         (iconsetPath != null && SpotIcon.fromIconsetPath(iconsetPath) != null) ||
             cotType == SpotIcon.COT_TYPE ||
-            resolveBadgeIcon(iconsetPath) != null
+            resolveBadgeIcon(iconsetPath) != null ||
+            resolveFemaIcon(iconsetPath) != null
 
     /** Convenience: the rendered glyph for a selectable Spot Map icon (picker
      *  swatches, current-symbol rows). */
@@ -328,6 +358,9 @@ object TakIconRegistry {
                 return "takicon-spot-${argb ?: spot.argb}"
             }
             resolveBadgeIcon(iconsetPath)?.let { return "takicon-${it.pack.name.lowercase()}-${it.token}" }
+            // #46/#47: FEMA iconset paths get a stable per-kind key so each of the
+            // 12 kinds is registered as a distinct image in the MapLibre style.
+            resolveFemaIcon(iconsetPath)?.let { return "takicon-fema-${it.kind.raw}" }
         }
         if (cotType == SpotIcon.COT_TYPE) return "takicon-spot-${argb ?: SpotIcon.WHITE.argb}"
         return null

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/CoTParserFemaTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/CoTParserFemaTest.kt
@@ -1,0 +1,252 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #47 — Inbound CoT carrying a FEMA `<usericon iconsetpath="COT_MAPPING_FEMA/…">`
+ * must parse into a [CoTEvent] with a non-null [CoTEvent.iconsetPath] that
+ * round-trips through [FemaIconCatalog.iconByIconsetPath] to the correct
+ * [FemaIconCatalog.FemaIcon].
+ *
+ * Context: #29 added outbound FEMA CoT authoring. Inbound parse of FEMA
+ * iconsetpath was deferred — [CoTParser] already reads `<usericon>` for Spot
+ * Map markers, but the acceptance test for the FEMA catalog lookup
+ * (FemaIconCatalog.iconByIconsetPath) on a received event was missing. These
+ * tests lock that contract so a peer (iOS or another Android operator) dropping
+ * a FEMA marker renders the correct FEMA kind on the receiver.
+ *
+ * The python listener fixture shape used in the issue description:
+ *
+ *   <event version="2.0" uid="…" type="a-f-G-I-U-T" …>
+ *     <point lat="…" lon="…" hae="0" ce="9999999" le="9999999"/>
+ *     <detail>
+ *       <contact callsign="CP-1"/>
+ *       <usericon iconsetpath="COT_MAPPING_FEMA/incidentCommand/command_post"/>
+ *     </detail>
+ *   </event>
+ */
+class CoTParserFemaTest {
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private fun femaCoT(
+        uid: String,
+        cotType: String,
+        iconsetPath: String,
+        callsign: String = "TEST",
+    ): String = """
+        <event version="2.0" uid="$uid" type="$cotType"
+               time="2026-01-01T00:00:00Z" start="2026-01-01T00:00:00Z"
+               stale="2026-01-02T00:00:00Z" how="h-g-i-g-o">
+          <point lat="47.6588" lon="-117.4260" hae="0" ce="9999999" le="9999999"/>
+          <detail>
+            <contact callsign="$callsign"/>
+            <usericon iconsetpath="$iconsetPath"/>
+          </detail>
+        </event>
+    """.trimIndent()
+
+    // ── #47: parser surfaces iconsetPath on inbound FEMA CoT ─────────────────
+
+    @Test
+    fun `inbound FEMA command-post CoT parses to non-null iconsetPath`() {
+        val icon = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.COMMAND_POST)!!
+        val xml = femaCoT("fema-cp-1", icon.cotType, icon.iconsetPath, "CP-1")
+
+        val event = CoTParser.parse(xml)
+
+        assertNotNull("parser returned null for well-formed FEMA CoT", event)
+        assertNotNull(
+            "iconsetPath must be non-null on a FEMA inbound event",
+            event!!.iconsetPath,
+        )
+        assertEquals(
+            "parsed iconsetPath must match the emitted path byte-for-byte",
+            icon.iconsetPath,
+            event.iconsetPath,
+        )
+    }
+
+    @Test
+    fun `inbound FEMA iconsetPath round-trips through FemaIconCatalog to the correct kind`() {
+        val icon = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.COMMAND_POST)!!
+        val xml = femaCoT("fema-cp-2", icon.cotType, icon.iconsetPath)
+
+        val event = CoTParser.parse(xml)!!
+
+        val resolved = FemaIconCatalog.iconByIconsetPath(event.iconsetPath!!)
+        assertNotNull(
+            "iconByIconsetPath must resolve a received FEMA iconsetpath to a FemaIcon",
+            resolved,
+        )
+        assertEquals(
+            "resolved kind must match the emitted kind",
+            FemaIconCatalog.Kind.COMMAND_POST,
+            resolved!!.kind,
+        )
+    }
+
+    @Test
+    fun `every FEMA kind round-trips from inbound CoT through the catalog`() {
+        // All 12 FEMA kinds emitted by a peer must parse back to the same kind.
+        // This covers the full iOS ↔ Android matrix.
+        for (kind in FemaIconCatalog.Kind.entries) {
+            val icon = FemaIconCatalog.iconFor(kind)!!
+            val xml = femaCoT("fema-${kind.raw}", icon.cotType, icon.iconsetPath, kind.raw)
+
+            val event = CoTParser.parse(xml)
+            assertNotNull("parser returned null for FEMA kind $kind", event)
+
+            val resolved = FemaIconCatalog.iconByIconsetPath(event!!.iconsetPath!!)
+            assertNotNull(
+                "iconByIconsetPath returned null for kind $kind (path=${icon.iconsetPath})",
+                resolved,
+            )
+            assertEquals(
+                "wrong kind resolved for $kind",
+                kind,
+                resolved!!.kind,
+            )
+        }
+    }
+
+    @Test
+    fun `inbound CoT without usericon still parses with null iconsetPath`() {
+        // A peer without the FEMA bundle omits the usericon element; the event
+        // must still parse. This preserves the fallback path.
+        val xml = """
+            <event version="2.0" uid="no-icon-1" type="a-f-G-I-U-T"
+                   time="2026-01-01T00:00:00Z" start="2026-01-01T00:00:00Z"
+                   stale="2026-01-02T00:00:00Z" how="h-g-i-g-o">
+              <point lat="47.0" lon="-117.0" hae="0" ce="9999999" le="9999999"/>
+              <detail><contact callsign="PLAIN"/></detail>
+            </event>
+        """.trimIndent()
+
+        val event = CoTParser.parse(xml)
+        assertNotNull(event)
+        assertNull("iconsetPath must be null when <usericon> is absent", event!!.iconsetPath)
+    }
+
+    @Test
+    fun `inbound FEMA triage-station CoT resolves to MEDICAL category`() {
+        val icon = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.TRIAGE_STATION)!!
+        val xml = femaCoT("fema-triage-1", icon.cotType, icon.iconsetPath, "Triage-1")
+
+        val event = CoTParser.parse(xml)!!
+        val resolved = FemaIconCatalog.iconByIconsetPath(event.iconsetPath!!)
+
+        assertNotNull(resolved)
+        assertEquals(FemaIconCatalog.Category.MEDICAL, resolved!!.category)
+        assertEquals(FemaIconCatalog.Kind.TRIAGE_STATION, resolved.kind)
+    }
+
+    @Test
+    fun `inbound FEMA helicopter-LZ CoT resolves to AVIATION category`() {
+        val icon = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.HELICOPTER_LZ)!!
+        val xml = femaCoT("fema-lz-1", icon.cotType, icon.iconsetPath, "LZ-1")
+
+        val event = CoTParser.parse(xml)!!
+        val resolved = FemaIconCatalog.iconByIconsetPath(event.iconsetPath!!)
+
+        assertNotNull(resolved)
+        assertEquals(FemaIconCatalog.Category.AVIATION, resolved!!.category)
+    }
+
+    @Test
+    fun `inbound FEMA CoT callsign and position are preserved alongside iconsetPath`() {
+        // Parser must not lose existing fields when reading usericon.
+        val icon = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.BASE_CAMP)!!
+        val xml = femaCoT("fema-bc-1", icon.cotType, icon.iconsetPath, "BaseCamp-Alpha")
+
+        val event = CoTParser.parse(xml)!!
+
+        assertEquals("BaseCamp-Alpha", event.callsign)
+        assertEquals(47.6588, event.lat, 0.0001)
+        assertEquals(-117.4260, event.lon, 0.0001)
+        assertEquals(icon.iconsetPath, event.iconsetPath)
+    }
+
+    @Test
+    fun `non-FEMA iconsetPath on inbound CoT returns null from FemaIconCatalog`() {
+        // A Spot Map path or Google path must not accidentally match the FEMA
+        // catalog — keeps the two resolution paths independent.
+        val xml = femaCoT(
+            uid = "spot-not-fema-1",
+            cotType = "b-m-p-s-m",
+            iconsetPath = "COT_MAPPING_SPOTMAP/red",
+            callsign = "SPOT",
+        )
+        val event = CoTParser.parse(xml)!!
+        assertNotNull(event.iconsetPath)
+        // Must NOT resolve as a FEMA icon.
+        assertNull(
+            "A Spot Map iconsetPath must not resolve via FemaIconCatalog",
+            FemaIconCatalog.iconByIconsetPath(event.iconsetPath!!),
+        )
+    }
+
+    // ── #46: TakIconRegistry.handles() covers FEMA iconset paths ─────────────
+    // These verify the ContactSymbolLayer routing gate: a received FEMA marker
+    // with a parsed iconsetPath must not fall through to the MIL-STD path.
+
+    @Test
+    fun `TakIconRegistry handles FEMA command-post iconsetPath`() {
+        val icon = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.COMMAND_POST)!!
+        assertTrue(
+            "TakIconRegistry.handles() must return true for a FEMA iconsetPath so " +
+                "ContactSymbolLayer does not fall through to MIL-STD",
+            soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry.handles(
+                icon.cotType, icon.iconsetPath,
+            ),
+        )
+    }
+
+    @Test
+    fun `TakIconRegistry handles every FEMA kind iconsetPath`() {
+        for (kind in FemaIconCatalog.Kind.entries) {
+            val icon = FemaIconCatalog.iconFor(kind)!!
+            assertTrue(
+                "TakIconRegistry.handles() must return true for FEMA kind $kind",
+                soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry.handles(
+                    icon.cotType, icon.iconsetPath,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `TakIconRegistry styleImageId returns non-null for FEMA iconsetPath`() {
+        val icon = FemaIconCatalog.iconFor(FemaIconCatalog.Kind.COMMAND_POST)!!
+        val id = soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry.styleImageId(
+            icon.cotType, icon.iconsetPath, null,
+        )
+        assertNotNull(
+            "styleImageId must be non-null for FEMA kind ${FemaIconCatalog.Kind.COMMAND_POST}",
+            id,
+        )
+        assertTrue(
+            "FEMA style image id must be prefixed with 'takicon-fema-' to avoid colliding with MIL-STD",
+            id!!.startsWith("takicon-fema-"),
+        )
+    }
+
+    @Test
+    fun `TakIconRegistry styleImageId is unique per FEMA kind`() {
+        val ids = FemaIconCatalog.Kind.entries.map { kind ->
+            val icon = FemaIconCatalog.iconFor(kind)!!
+            soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry.styleImageId(
+                icon.cotType, icon.iconsetPath, null,
+            )
+        }
+        assertEquals(
+            "each FEMA kind must produce a distinct style image id",
+            ids.size,
+            ids.toSet().size,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #29 (FEMA authoring). Two issues in one pass — they share the
same parser path and test fixture.

### #47 — Inbound CoT: parse + surface FEMA kind

`CoTParser` already reads `<usericon iconsetpath="…">` and populates
`CoTEvent.iconsetPath` (shipped with Spot Map work). The missing piece was
the acceptance test that exercises the FEMA-specific round-trip:

- Feed a FEMA-flavored CoT through the parser.
- Assert `CoTEvent.iconsetPath` is non-null and round-trips through
  `FemaIconCatalog.iconByIconsetPath()` to the correct `FemaIcon`.
- All 12 FEMA kinds covered (iOS ↔ Android parity matrix).
- Null `iconsetPath` preserved when `<usericon>` is absent.
- Non-FEMA paths (Spot Map) do not bleed into the FEMA catalog.

New test class: `CoTParserFemaTest` (12 tests, all passing).

### #46 — FEMA glyph rendering wired through TakIconRegistry

`TakIconRegistry` previously returned null for `COT_MAPPING_FEMA/…` paths
so `ContactSymbolLayer.handles()` fell through to the MIL-STD-2525
affiliation frame for received FEMA markers. Now:

- `handles()` returns true for FEMA iconset paths.
- `styleImageId()` returns `"takicon-fema-<kind>"` (no collision with
  MIL-STD or Spot Map image keys in the MapLibre style).
- `resolveBitmap()` renders a **category-accented coloured dot**:
  orange = Command, red = Medical, cyan = Aviation, yellow = Vehicles,
  green = Support. Same runtime approach as Spot Map — no asset files needed.
- `Category.accentArgb` added to `FemaIconCatalog` for JVM-accessible
  ARGB values (the existing `accent: Color` is Compose-only).

**Honest #46 status — artwork is NOT done.** Per-glyph SVG artwork for the
12 FEMA/ICS-237 kinds is not included. The category-accented dot is a
material improvement over a generic MIL-STD frame (operators can distinguish
Command vs Medical vs Aviation at a glance by colour), but it is not the
full ICS symbology the issue describes. Full artwork pass needs:

1. Source or commission 12 FEMA/ICS-237 glyphs (references in #46 body).
2. Drop SVGs in `app/src/main/assets/fema/COT_MAPPING_FEMA/<cat>/<kind>.svg`.
3. Update `TakIconRegistry.resolveBitmap()` to rasterise from the asset bundle
   instead of the dot renderer.

## Test plan

- [ ] `./gradlew :app:testDebugUnitTest` — 484 passed, 0 failed
- [ ] `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL
- [ ] On device: drop a FEMA Command Post from the palette → another client
  sends it back → the receiver shows an orange dot instead of a generic
  friendly-installation frame
- [ ] On device: peer without FEMA support still sees the `a-f-G-I-*`
  friendly-installation fallback (behavior unchanged for non-OmniTAK clients)

Closes #47
References #46 (category-accented dot rendering done; SVG artwork pending)