### PR TITLE
fix(connection): app-level keepalive + auto-reconnect with backoff (#102)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ReconnectPolicy.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ReconnectPolicy.kt
@@ -1,0 +1,77 @@
+package soy.engindearing.omnitak.mobile.domain
+
+/**
+ * Pure backoff + dead-socket policy for application-level auto-reconnect
+ * (issue #102). Holds no Android types and does no I/O so it is fully
+ * JVM-unit-testable — the [ServerManager] reconnect supervisor that owns
+ * the sockets delegates its timing + "should I re-dial?" decisions here.
+ *
+ * The escalation curve matches the proven [GybManager] BLE reconnect loop:
+ * the first retry after a drop is immediate so a transient Wi-Fi↔LTE swap
+ * recovers in well under the issue's ~30s target, then delays grow
+ * geometrically and cap so a server that is genuinely down doesn't get
+ * hammered (and the radio doesn't stay awake spinning).
+ *
+ *   drop → 0ms → [initialDelayMs] → ×2 → ×2 → … → capped at [maxDelayMs]
+ *
+ * A successful (re)connect calls [reset] so the next independent drop
+ * starts the curve over from immediate.
+ *
+ * Instances are single-server and confined to one reconnect coroutine, so
+ * the mutable [attempt] counter needs no synchronization.
+ */
+class ReconnectPolicy(
+    private val initialDelayMs: Long = DEFAULT_INITIAL_DELAY_MS,
+    private val maxDelayMs: Long = DEFAULT_MAX_DELAY_MS,
+) {
+    // Number of delays handed out since the last reset. 0 → the upcoming
+    // retry is the immediate one.
+    private var attempt: Int = 0
+
+    /**
+     * The delay to wait before the next reconnect attempt, then advances
+     * the curve. First call after a [reset] (or construction) returns 0
+     * (retry now); subsequent calls return [initialDelayMs], then double
+     * each time, capped at [maxDelayMs].
+     */
+    fun nextDelayMs(): Long {
+        val delay = when (attempt) {
+            0 -> 0L
+            else -> {
+                // attempt 1 → initial, 2 → initial×2, 3 → initial×4 …
+                // Compute in Double to avoid Long overflow on a long-lived
+                // loop, then clamp to the cap before converting back.
+                val raw = initialDelayMs.toDouble() * (1L shl (attempt - 1))
+                raw.coerceAtMost(maxDelayMs.toDouble()).toLong()
+            }
+        }
+        attempt++
+        return delay
+    }
+
+    /** Reset the curve after a successful connect — next drop retries now. */
+    fun reset() {
+        attempt = 0
+    }
+
+    companion object {
+        const val DEFAULT_INITIAL_DELAY_MS = 2_000L
+        const val DEFAULT_MAX_DELAY_MS = 30_000L
+
+        /**
+         * Dead-socket detection: should a server whose connection is in
+         * [state] be (re)dialed? True only when the server is still
+         * [serverEnabled] AND the socket is down ([ConnectionState.Disconnected]
+         * or [ConnectionState.Failed]). A live [ConnectionState.Connected] or an
+         * in-flight [ConnectionState.Connecting] is left alone so we never tear
+         * down a healthy socket or stack duplicate dials.
+         */
+        fun shouldReconnect(state: ConnectionState, serverEnabled: Boolean): Boolean {
+            if (!serverEnabled) return false
+            return when (state) {
+                is ConnectionState.Disconnected, is ConnectionState.Failed -> true
+                is ConnectionState.Connected, is ConnectionState.Connecting -> false
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ServerManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ServerManager.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -97,6 +98,15 @@ class ServerManager(
     private val connectionsLock = Any()
     private val stateJobs = ConcurrentHashMap<String, kotlinx.coroutines.Job>()
     private val receivedJobs = ConcurrentHashMap<String, kotlinx.coroutines.Job>()
+    // Issue #102 — per-server auto-reconnect supervisor. Watches each live
+    // connection's state and, when a previously-up socket dies in the
+    // background (Doze / app-standby / a Wi-Fi↔LTE swap kills the TLS read
+    // loop), re-dials with exponential backoff instead of waiting for the
+    // operator to foreground the app (ON_RESUME). One job + one policy per
+    // server; both are torn down by disconnect() so a deliberate
+    // disconnect / toggle-off doesn't fight an instant auto-reconnect.
+    private val reconnectJobs = ConcurrentHashMap<String, kotlinx.coroutines.Job>()
+    private val reconnectPolicies = ConcurrentHashMap<String, ReconnectPolicy>()
     // Single PLI broadcaster — self-position fans out to every connected
     // server via the broadcast path of sendCoT, so one broadcaster covers all.
     private var pliBroadcaster: SelfPositionBroadcaster? = null
@@ -125,6 +135,52 @@ class ServerManager(
                 // PLI broadcaster lives as long as ≥1 server is connected.
                 if (_connectedServerIds.value.isNotEmpty()) startPliBroadcast()
                 else stopPliBroadcast()
+            }
+        }
+        // Issue #102 — application-level keepalive: re-dial this server with
+        // exponential backoff whenever its socket drops while it's still a
+        // wanted (enabled, in-map) connection. This is what makes a
+        // backgrounded, screen-off device recover on its own instead of
+        // only on the next ON_RESUME. conn.connect() is idempotent
+        // (no-op while a connect is in flight), so re-dialing the same
+        // TAKConnection instance is safe.
+        val policy = ReconnectPolicy()
+        reconnectPolicies[server.id] = policy
+        reconnectJobs[server.id] = scope.launch {
+            // drop(1): skip the StateFlow's initial Disconnected replay — the
+            // explicit conn.connect() below performs the first dial, and
+            // consuming a nextDelayMs() here would push the first *real* drop
+            // off its intended immediate retry.
+            conn.state.drop(1).collect { state ->
+                when (state) {
+                    is ConnectionState.Connected -> policy.reset()
+                    is ConnectionState.Connecting -> { /* attempt in flight */ }
+                    is ConnectionState.Disconnected, is ConnectionState.Failed -> {
+                        // Only re-dial connections we still want: a deliberate
+                        // disconnect()/toggle-off removes the server from the
+                        // map (and cancels this job), and a disabled server
+                        // must stay down.
+                        val stillWanted = connections[server.id] === conn &&
+                            (_servers.value.firstOrNull { it.id == server.id }?.enabled ?: false)
+                        if (ReconnectPolicy.shouldReconnect(state, stillWanted)) {
+                            val wait = policy.nextDelayMs()
+                            if (wait > 0) kotlinx.coroutines.delay(wait)
+                            // Re-check after the backoff sleep: the operator
+                            // may have disconnected/disabled the server, or a
+                            // foreground ON_RESUME reconnect may already have
+                            // it Connecting/Connected, during the wait.
+                            val target = connections[server.id]
+                            val enabledNow = _servers.value
+                                .firstOrNull { it.id == server.id }?.enabled ?: false
+                            val downNow = target?.state?.value.let {
+                                it is ConnectionState.Disconnected || it is ConnectionState.Failed
+                            }
+                            if (target === conn && enabledNow && downNow) {
+                                conn.connect()
+                            }
+                        }
+                    }
+                }
             }
         }
         receivedJobs[server.id] = scope.launch {
@@ -173,8 +229,26 @@ class ServerManager(
      * Called from MainActivity's ON_RESUME hook so that coming back from
      * the background (where Android may have killed read loops after Doze /
      * app-standby) recovers without the operator tapping play. Issue #6.
+     *
+     * Issue #102 — the background auto-reconnect supervisor now also keeps
+     * sockets alive without a foreground resume, but a server can still be
+     * mid-backoff when the operator opens the app. Reset every policy so
+     * the resume forces an immediate re-dial instead of waiting out the
+     * remaining backoff, then reconcile to cover any connection that was
+     * fully removed (e.g. a never-connected enabled server).
      */
     fun reconnectIfNeeded() {
+        reconnectPolicies.values.forEach { it.reset() }
+        // Immediately re-dial any enabled server whose existing connection is
+        // sitting Disconnected/Failed (the supervisor may be mid-backoff
+        // sleep). connect() is idempotent, so this is a no-op for live ones.
+        _servers.value.filter { it.enabled }.forEach { s ->
+            val conn = connections[s.id]
+            val down = conn?.state?.value.let {
+                it is ConnectionState.Disconnected || it is ConnectionState.Failed
+            }
+            if (conn != null && down) conn.connect()
+        }
         reconcileConnections(_servers.value)
     }
 
@@ -201,6 +275,11 @@ class ServerManager(
 
     /** Disconnect a single server by id, leaving the others connected. */
     fun disconnect(serverId: String): Unit = synchronized(connectionsLock) {
+        // Cancel the reconnect supervisor BEFORE tearing the socket down so
+        // the resulting Disconnected transition can't trigger an auto-redial
+        // of a server the operator just turned off (issue #102).
+        reconnectJobs.remove(serverId)?.cancel()
+        reconnectPolicies.remove(serverId)
         connections.remove(serverId)?.disconnect()
         stateJobs.remove(serverId)?.cancel()
         receivedJobs.remove(serverId)?.cancel()

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/ReconnectPolicyTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/ReconnectPolicyTest.kt
@@ -1,0 +1,128 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure backoff / dead-socket policy that drives
+ * application-level auto-reconnect (issue #102). No Android types here —
+ * this is the JVM-testable core of the keepalive feature, separated from
+ * the foreground-service + socket plumbing that needs a real device.
+ *
+ * Behaviour mirrors the proven GybManager BLE reconnect loop:
+ *   - the first retry after a drop is immediate (0 ms),
+ *   - subsequent retries escalate 2s → 4s → 8s → … capped at 30s,
+ *   - a successful (re)connect resets the backoff to 0.
+ */
+class ReconnectPolicyTest {
+
+    private fun policy() = ReconnectPolicy(
+        initialDelayMs = 2_000L,
+        maxDelayMs = 30_000L,
+    )
+
+    @Test
+    fun first_retry_is_immediate() {
+        val p = policy()
+        assertEquals(
+            "the first reconnect attempt after a drop should fire immediately",
+            0L,
+            p.nextDelayMs(),
+        )
+    }
+
+    @Test
+    fun delays_escalate_then_cap() {
+        val p = policy()
+        // 0 (immediate) → 2s → 4s → 8s → 16s → 30s (capped) → 30s …
+        assertEquals(0L, p.nextDelayMs())
+        assertEquals(2_000L, p.nextDelayMs())
+        assertEquals(4_000L, p.nextDelayMs())
+        assertEquals(8_000L, p.nextDelayMs())
+        assertEquals(16_000L, p.nextDelayMs())
+        assertEquals("backoff must cap at maxDelayMs", 30_000L, p.nextDelayMs())
+        assertEquals("backoff stays at the cap", 30_000L, p.nextDelayMs())
+    }
+
+    @Test
+    fun reset_returns_to_immediate() {
+        val p = policy()
+        p.nextDelayMs() // 0
+        p.nextDelayMs() // 2s
+        p.nextDelayMs() // 4s
+        p.reset()
+        assertEquals(
+            "after a successful connect the next drop should retry immediately again",
+            0L,
+            p.nextDelayMs(),
+        )
+    }
+
+    @Test
+    fun custom_bounds_are_honored() {
+        val p = ReconnectPolicy(initialDelayMs = 1_000L, maxDelayMs = 5_000L)
+        assertEquals(0L, p.nextDelayMs())
+        assertEquals(1_000L, p.nextDelayMs())
+        assertEquals(2_000L, p.nextDelayMs())
+        assertEquals(4_000L, p.nextDelayMs())
+        assertEquals("capped at the custom max", 5_000L, p.nextDelayMs())
+        assertEquals(5_000L, p.nextDelayMs())
+    }
+
+    // --- dead-socket detection: which states warrant a reconnect ---
+
+    @Test
+    fun dropped_states_want_reconnect_when_enabled() {
+        assertTrue(
+            "a server that was connected and is now Disconnected should be re-dialed",
+            ReconnectPolicy.shouldReconnect(
+                state = ConnectionState.Disconnected,
+                serverEnabled = true,
+            ),
+        )
+        assertTrue(
+            "a Failed read loop should be re-dialed",
+            ReconnectPolicy.shouldReconnect(
+                state = ConnectionState.Failed("read timeout"),
+                serverEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun live_or_inflight_states_do_not_reconnect() {
+        assertFalse(
+            "an already-connected socket must not be torn down + re-dialed",
+            ReconnectPolicy.shouldReconnect(
+                state = ConnectionState.Connected("srv", useTLS = true),
+                serverEnabled = true,
+            ),
+        )
+        assertFalse(
+            "a connect already in flight must not be duplicated",
+            ReconnectPolicy.shouldReconnect(
+                state = ConnectionState.Connecting("srv"),
+                serverEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun disabled_server_never_reconnects() {
+        assertFalse(
+            "a server the operator disabled must stay down even if the socket dropped",
+            ReconnectPolicy.shouldReconnect(
+                state = ConnectionState.Disconnected,
+                serverEnabled = false,
+            ),
+        )
+        assertFalse(
+            ReconnectPolicy.shouldReconnect(
+                state = ConnectionState.Failed("boom"),
+                serverEnabled = false,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Problem

After a successful enroll + connect, the TAK connection doesn't self-sustain in the background. Once the app is backgrounded with the screen off (Doze / app-standby), the TLS read loop dies, PPLI stops, and the server's "Last RX" goes stale. It only recovers when the operator foregrounds the app — the existing recovery hook is `MainActivity` ON_RESUME → `serverManager.reconnectIfNeeded()`, which by definition only fires on foreground.

## What was already in place

The **foreground service half** of this issue already shipped under #5:
- `TAKConnectionService` (persistent, ongoing, silent notification; `START_STICKY`)
- Registered in the manifest with `foregroundServiceType="dataSync"` + `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_DATA_SYNC` / `POST_NOTIFICATIONS` permissions
- Wired in `OmniTAKApp` to start (debounced) on `Connected` and stop on `Disconnected`

So a persistent FGS notification while connected already exists. The **missing** piece — and the actual root cause of #102 — was the **application-level keepalive + dead-socket detection → auto-reconnect**. Nothing re-established a dropped socket while backgrounded.

> Note on FGS type: I deliberately left it as `dataSync` and did **not** switch to `connectedDevice`. The git history (v0.2.4 → v0.2.5) shows `connectedDevice` was tried and reverted because it lacks the Background-Started-FGS exemption that `dataSync` has — and `OmniTAKApp.onCreate()` starts the FGS from a backgrounded process when reconnect completes, which crashes (`ForegroundServiceStartNotAllowedException`) under `connectedDevice`. My background auto-reconnect rides that **same** BSFGS-exempt path (background re-dial → `Connected` → `TAKConnectionService.start()`), so `dataSync` is the correct type here.

## Design

**1. `ReconnectPolicy` (pure JVM, unit-tested)** — the headless core, no Android types:
- `nextDelayMs()` — backoff curve: immediate (`0ms`) → `2s` → `4s` → `8s` → … capped at `30s`; computed in `Double` to avoid `Long` overflow on a long-lived loop.
- `reset()` — back to immediate after a successful connect.
- `shouldReconnect(state, serverEnabled)` — dead-socket detection: re-dial only when the server is still enabled **and** the socket is `Disconnected`/`Failed`; never tear down a `Connected` socket or stack a duplicate `Connecting`.

The escalation curve and reset-on-success semantics mirror the already-proven `GybManager` BLE reconnect loop, so this is consistent with how the app already recovers BLE links.

**2. `ServerManager` reconnect supervisor** — a per-server coroutine (one `Job` + one `ReconnectPolicy` per server, keyed by `TAKServer.id`) collects `TAKConnection.state`:
- `Connected` → `policy.reset()`
- `Disconnected`/`Failed` while still wanted → wait `policy.nextDelayMs()`, then re-dial the **same** `TAKConnection` (`conn.connect()` is idempotent while a connect is in flight).
- `drop(1)` skips the StateFlow's initial `Disconnected` replay so the explicit first dial isn't double-counted against the backoff.
- A post-sleep re-check (`target === conn && enabledNow && downNow`) means a disconnect / toggle-off / foreground-resume landing during the backoff sleep cancels the pending re-dial.
- `disconnect(serverId)` cancels the supervisor **before** tearing the socket down, so a deliberate disconnect can't trigger an auto-redial.
- `reconnectIfNeeded()` (ON_RESUME) now resets every policy **and** immediately re-dials any down-but-enabled connection, so a foreground resume is snappy instead of waiting out a pending backoff.

This keeps the existing connect/reconcile/multi-server behavior intact — the supervisor is purely additive per connection.

## Acceptance criteria mapping

| Criterion | How it's addressed | Verified |
|---|---|---|
| Device stays Healthy ≥30 min, screen off, backgrounded (off-charger) | FGS (`dataSync`, ongoing notification, `START_STICKY`) holds the process through Doze; the new supervisor re-dials if the read loop still dies | **Device-pending** (Doze can't be JVM-tested) |
| Auto-reconnect within ~30s after a transient drop (Wi-Fi↔LTE swap, brief outage) | First retry is **immediate** (`0ms`), then `2s/4s/8s/…` — well within 30s for a transient blip; re-dial no longer waits for ON_RESUME | Backoff curve **logic-verified**; end-to-end timing **device-pending** |
| PPLI continues at the configured interval while backgrounded | Unchanged app-owned broadcaster; once the socket is held/re-dialed, PPLI keeps flowing on its interval (the issue's own repro confirms PPLI holds while the socket lives) | **Device-pending** |
| Persistent foreground-service notification while connected | Already shipped (#5), unchanged | Pre-existing |

## Test plan

`./gradlew :app:testDebugUnitTest` — **496 tests, 0 failures** (7 new in `ReconnectPolicyTest`):
- `first_retry_is_immediate` — drop → `0ms`
- `delays_escalate_then_cap` — `0 → 2s → 4s → 8s → 16s → 30s (cap) → 30s`
- `reset_returns_to_immediate` — reset rewinds the curve
- `custom_bounds_are_honored` — honors injected initial/max
- `dropped_states_want_reconnect_when_enabled` — `Disconnected`/`Failed` + enabled → re-dial
- `live_or_inflight_states_do_not_reconnect` — `Connected`/`Connecting` → no-op
- `disabled_server_never_reconnects` — disabled stays down

TDD: tests were written first and confirmed RED (`Unresolved reference 'ReconnectPolicy'`) before the class existed, then GREEN.

`./gradlew :app:assembleDebug` — **BUILD SUCCESSFUL**.

## What needs on-device verification

The FGS lifecycle + Doze survival can't be JVM-unit-tested. On a real device, confirm:
1. **Doze survival** — connect to a TAK server, lock the screen, leave the app backgrounded off-charger ≥30 min; the device stays Healthy and PPLI keeps advancing "Last RX" (repro against ArgusTAK `:8089` mTLS per the issue).
2. **Auto-reconnect after a network blip** — toggle Wi-Fi↔LTE / airplane mode briefly while backgrounded; the contact reconnects within ~30s with no manual interaction (watch `ServerManager` re-dial in logcat).
3. **Persistent notification** — the "OmniTAK connected" notification is present the whole time a server is connected and clears on disconnect.
4. **No double-connect / no fight with a deliberate disconnect** — toggling a server off (or hitting disconnect) while backgrounded does not auto-reconnect.
5. **`dataSync` daily quota** — Android 14+ applies a rolling daily runtime budget to `dataSync` FGS. Confirm a long continuous deployment doesn't hit the cap; if it does, the longer-term fix (noted in the v0.2.5 revert commit) is to move FGS start to `MainActivity.onResume()` and reconsider the type — out of scope for this PR.

Logic-verified: the backoff/reconnect **policy** and the dead-socket **decision**. Device-pending: everything that depends on the real OS scheduler (Doze survival, end-to-end reconnect timing, PPLI continuity, FGS quota).

Closes #102