### PR TITLE
fix(map): re-resolve symbol icon-image + repaint after runtime addImage (#77) [candidate — needs device verification]

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayer.kt
@@ -91,10 +91,36 @@ class ContactSymbolLayer {
         // Image name prefix in [Style.addImage]. Keyed by SIDC so
         // each distinct symbol is uploaded exactly once per style.
         const val ICON_IMAGE_PREFIX = "milstd-"
+
+        /**
+         * The MapLibre image id a MIL-STD-2525 contact registers + references.
+         * Pure: no Android deps. Pinned by tests so the id written into a
+         * feature's [PROP_IMAGE] (what the SymbolLayer's icon-image expression
+         * resolves) can never drift from the id passed to [Style.addImage].
+         * A mismatch here is exactly the "symbol resolves to nothing → blank"
+         * failure mode #77 is about.
+         */
+        fun milStdImageId(sidc: String): String = ICON_IMAGE_PREFIX + sidc
+
+        /**
+         * Resolve the final icon-image id for a contact: a bundled / imported
+         * TAK-suite id when one was registered ([takImageId] non-null, #98),
+         * otherwise the MIL-STD-2525 id. This is the single source of truth the
+         * feature's [PROP_IMAGE] is built from; keeping it pure lets a JVM test
+         * assert the SymbolLayer always references a real, registered image.
+         */
+        fun resolveImageName(sidc: String, takImageId: String?): String =
+            takImageId ?: milStdImageId(sidc)
     }
 
     private var installed: Boolean = false
     private val registeredSidcs: MutableSet<String> = mutableSetOf()
+
+    // Issue #77 — set true by [registerTakIconImage] whenever it performs a
+    // fresh [Style.addImage] on this call, so [update] knows a new icon
+    // entered the atlas via the TAK/imported path (not just the MIL-STD
+    // path) and must re-assert + repaint. Reset at the top of each [update].
+    private var takImageAddedThisCall: Boolean = false
 
     /**
      * Wire the source + layer into [style] and pre-warm the cache
@@ -155,7 +181,36 @@ class ContactSymbolLayer {
      * not yet registered in [Style] is rasterised + added before the
      * source is updated. Contacts with NaN lat/lon are skipped.
      *
-     * @return number of distinct SIDCs newly registered on this call
+     * Issue #77 — the candidate render fix lives here. Two ordering
+     * problems caused dropped markers to stay blank on Mali/Adreno
+     * (Pixel 9 Pro) until a full style reload (3D-terrain toggle):
+     *
+     *   1. ATLAS-RESOLVE RACE. Each first-sighting [Style.addImage] posts
+     *      a sprite-atlas mutation to the native render thread, but the
+     *      `setGeoJson` push that follows in the SAME synchronous block
+     *      makes the SymbolLayer resolve `icon-image` against the atlas
+     *      on the very next frame — potentially before the new image has
+     *      committed. The symbol resolves to a missing id and draws blank.
+     *      A style reload rebuilds the atlas with every image present,
+     *      which is exactly why toggling terrain "fixes" it. SwiftShader /
+     *      the CI emulator have different upload timing, so it never repros
+     *      there — this is a device-only GPU/driver-timing bug.
+     *
+     *   2. NO LAYER RE-RESOLVE + NO REPAINT. Neither [Style.addImage] nor
+     *      `setGeoJson` re-evaluates an already-added layer's `icon-image`
+     *      property or forces a redraw. PR #107's `triggerRepaint` on the
+     *      source push didn't help because it invalidated source tiles,
+     *      not the icon-image → atlas resolution.
+     *
+     * Fix: register all referenced images FIRST (separate phase), push the
+     * source data, and only when at least one NEW image was added this call,
+     * re-assert the SymbolLayer's `iconImage` (so the layer re-resolves
+     * against the now-current atlas) and [MapLibreMap.triggerRepaint] (so
+     * the render thread actually redraws the frame). On steady-state updates
+     * (no new icons) we skip the re-assert — it's only needed the first time
+     * a given symbol id appears.
+     *
+     * @return number of distinct images newly registered on this call
      *   (useful for tests + diagnostics).
      */
     fun update(map: MapLibreMap, context: Context, contacts: Collection<CoTEvent>): Int {
@@ -165,11 +220,14 @@ class ContactSymbolLayer {
             return 0
         }
 
-        // First pass: make sure every image referenced by the
-        // FeatureCollection has been registered. Skip rows with bad
-        // coordinates. Issue #98 — a contact carrying a TAK-suite iconset
-        // (Spot Map today; Markers/Google when a clean pack lands) resolves to
-        // a bundled icon FIRST; everything else falls back to MIL-STD-2525.
+        // Phase 1 — register every image the FeatureCollection will
+        // reference, BEFORE the source push, so the icon-image expression
+        // never resolves against an atlas that's missing an entry. Skip
+        // rows with bad coordinates. Issue #98 — a contact carrying a
+        // TAK-suite iconset (Spot Map today; Markers/Google when a clean
+        // pack lands) resolves to a bundled icon FIRST; everything else
+        // falls back to MIL-STD-2525.
+        takImageAddedThisCall = false
         var newlyRegistered = 0
         val features = JSONArray()
         for (c in contacts) {
@@ -179,12 +237,50 @@ class ContactSymbolLayer {
             if (takImageId == null && registerSidcImage(style, context, sidc)) {
                 newlyRegistered++
             }
-            val imageName = takImageId ?: (ICON_IMAGE_PREFIX + sidc)
+            val imageName = resolveImageName(sidc, takImageId)
             features.put(featureJson(c, sidc, imageName))
         }
+        // Fold in fresh TAK/imported-icon registrations (#98 path) so the
+        // re-resolve below fires for them too — they hit a different addImage
+        // call than the MIL-STD branch counted above.
+        if (takImageAddedThisCall) newlyRegistered++
 
+        // Phase 2 — push the source data.
         GeoJsonLayerFeeder.push(style, SOURCE_ID, features)
+
+        // Phase 3 — Issue #77. If any image was added on THIS call, the
+        // symbol layer was built/last-resolved against an atlas that didn't
+        // contain it. Re-assert icon-image to force a fresh resolve and
+        // trigger one repaint so the new sprite actually paints without a
+        // style reload. No-op for steady-state updates (newlyRegistered==0).
+        if (newlyRegistered > 0) {
+            reassertIconResolution(map, style)
+        }
         return newlyRegistered
+    }
+
+    /**
+     * Issue #77 — force the symbol layer to re-resolve its `icon-image`
+     * against the current sprite atlas and request a redraw. Called after a
+     * runtime [Style.addImage] so a just-registered marker icon paints on
+     * Mali/Adreno without waiting for a full style reload.
+     *
+     * Re-applying the same [iconImage] expression via [setProperties] makes
+     * MapLibre re-evaluate the layer's icon resolution on the next render
+     * pass (now that the atlas entry exists); [MapLibreMap.triggerRepaint]
+     * guarantees that pass happens immediately rather than on the next
+     * incidental invalidation (camera move, etc.). Defensive: if the layer
+     * is somehow absent (e.g. a partial style swap) we log and no-op rather
+     * than crash — the next [installInto] re-creates it.
+     */
+    private fun reassertIconResolution(map: MapLibreMap, style: Style) {
+        val symbolLayer = style.getLayerAs<SymbolLayer>(SYMBOL_LAYER_ID)
+        if (symbolLayer == null) {
+            Log.w(TAG, "reassertIconResolution: $SYMBOL_LAYER_ID missing — skipping re-resolve")
+            return
+        }
+        symbolLayer.setProperties(iconImage(Expression.get(PROP_IMAGE)))
+        map.triggerRepaint()
     }
 
     /**
@@ -208,6 +304,7 @@ class ContactSymbolLayer {
                 if (bitmap != null) {
                     style.addImage(imageId, bitmap)
                     registeredSidcs.add(imageId)
+                    takImageAddedThisCall = true
                 }
             }
             // Return the id even if the bitmap was missing — avoids repeated
@@ -229,6 +326,7 @@ class ContactSymbolLayer {
         ) ?: return null
         style.addImage(imageId, bitmap)
         registeredSidcs.add(imageId)
+        takImageAddedThisCall = true
         return imageId
     }
 
@@ -246,7 +344,7 @@ class ContactSymbolLayer {
                 Log.w(TAG, "no bitmap available for sidc=$sidc; skipping addImage")
                 return false
             }
-        style.addImage(ICON_IMAGE_PREFIX + sidc, bitmap)
+        style.addImage(milStdImageId(sidc), bitmap)
         registeredSidcs.add(sidc)
         return true
     }

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayerImageIdTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolLayerImageIdTest.kt
@@ -1,0 +1,80 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
+
+/**
+ * Issue #77 — candidate fix for "dropped markers don't paint on the 2D
+ * MapLibre map until a full style reload" on Mali/Adreno (Pixel 9 Pro).
+ *
+ * The render fix itself (re-assert `icon-image` + [org.maplibre.android.maps.MapLibreMap.triggerRepaint]
+ * after a runtime [org.maplibre.android.maps.Style.addImage]) can only be
+ * confirmed on a real GPU — it is a device-only driver-timing bug and does NOT
+ * reproduce on SwiftShader / the CI emulator. What IS pinnable in pure JVM is
+ * the invariant the fix leans on: every contact feature's `icon-image` id MUST
+ * equal an id the layer actually registered via `addImage`. If those two ever
+ * drift, the SymbolLayer resolves `icon-image` to nothing and the marker draws
+ * blank — the same visible symptom #77 reports — regardless of any repaint.
+ *
+ * These tests lock [ContactSymbolLayer.resolveImageName] /
+ * [ContactSymbolLayer.milStdImageId] so a future refactor of either the
+ * `addImage` id or the feature-property id can't silently re-open #77.
+ */
+class ContactSymbolLayerImageIdTest {
+
+    // ── MIL-STD id: feature id == addImage id ────────────────────────────────
+
+    @Test fun `milStd image id is the prefixed sidc`() {
+        // This is the exact string passed to BOTH Style.addImage (registerSidcImage)
+        // and the feature's icon-image property (resolveImageName). They must match.
+        val sidc = MilStdIconService.getSidc("a-f-G-U-C") // friendly ground
+        assertEquals(ContactSymbolLayer.ICON_IMAGE_PREFIX + sidc, ContactSymbolLayer.milStdImageId(sidc))
+    }
+
+    @Test fun `milStd image id is stable and non-empty for every prewarmed cot type`() {
+        // Every pre-warmed contact type must yield a usable, prefixed image id —
+        // these are the icons registered at install time, so a blank/duplicate id
+        // here would mean a pre-warmed symbol never resolves.
+        val prewarm = listOf(
+            "a-f-G-U", "a-h-G-U", "a-n-G-U", "a-u-G-U",
+            "a-f-G-U-C-I", "a-u-A", "a-u-A-M-H-Q", "a-u-A-M-F-Q", "a-u-G",
+        )
+        val ids = prewarm.map { ContactSymbolLayer.milStdImageId(MilStdIconService.getSidc(it)) }
+        for (id in ids) {
+            assertTrue("image id must carry the milstd- prefix, got '$id'", id.startsWith(ContactSymbolLayer.ICON_IMAGE_PREFIX))
+            assertTrue("image id must have a sidc after the prefix, got '$id'", id.length > ContactSymbolLayer.ICON_IMAGE_PREFIX.length)
+        }
+    }
+
+    // ── resolveImageName: TAK-suite id wins, else MIL-STD ────────────────────
+
+    @Test fun `resolveImageName falls back to milStd id when no tak icon`() {
+        // takImageId == null is the common case (point-dropper friendly/hostile/neutral):
+        // the contact must reference the MIL-STD id that registerSidcImage added.
+        val sidc = MilStdIconService.getSidc("a-h-G-U-C")
+        assertEquals(
+            ContactSymbolLayer.milStdImageId(sidc),
+            ContactSymbolLayer.resolveImageName(sidc, takImageId = null),
+        )
+    }
+
+    @Test fun `resolveImageName prefers the tak-suite id when one was registered`() {
+        // Issue #98 path: a contact carrying a bundled/imported iconset registers a
+        // TAK-suite image and the feature must reference THAT id, not the milstd one.
+        val sidc = MilStdIconService.getSidc("a-f-G-U-C")
+        val takId = "takicon-spot-red"
+        assertEquals(takId, ContactSymbolLayer.resolveImageName(sidc, takImageId = takId))
+        assertNotEquals(ContactSymbolLayer.milStdImageId(sidc), ContactSymbolLayer.resolveImageName(sidc, takId))
+    }
+
+    @Test fun `distinct sidcs map to distinct image ids`() {
+        // No two different symbols may collide on one atlas id (a collision would
+        // make one symbol render as the other's bitmap).
+        val friendly = ContactSymbolLayer.milStdImageId(MilStdIconService.getSidc("a-f-G-U-C"))
+        val hostile = ContactSymbolLayer.milStdImageId(MilStdIconService.getSidc("a-h-G-U-C"))
+        assertNotEquals("friendly and hostile must not share an image id", friendly, hostile)
+    }
+}


### PR DESCRIPTION
## Candidate fix for #77 — DRAFT, needs on-device verification

Dropped markers render only after a full style reload (e.g. toggling 3D Terrain), never on the 2D MapLibre map on first drop. Reported on a Pixel 9 Pro (Mali/Adreno class), v0.35.5. **This is a device-only GPU/driver-timing bug — it does not reproduce on the SwiftShader emulator or in CI**, so this PR cannot be self-verified here and is opened as a draft.

### Hypothesis implemented (the marker ICON path)
`ContactSymbolLayer` registers each first-sighting marker icon at runtime with `Style.addImage(...)` and references it from a `SymbolLayer` `icon-image` expression. Two ordering problems combine on affected drivers:

1. **Atlas-resolve race.** The synchronous `Style.addImage` posts a sprite-atlas mutation to the native render thread, but the `setGeoJson` source push that previously ran *in the same synchronous block* makes the `SymbolLayer` resolve `icon-image` against the atlas on the next frame — potentially **before** the freshly added image has committed. The symbol resolves to a missing id and draws blank. A full style reload rebuilds the atlas with every image present, which is exactly why a 3D-terrain toggle "fixes" it.
2. **No re-resolve, no repaint.** Neither `addImage` nor `setGeoJson` re-evaluates an already-added layer's `icon-image` or forces a redraw. Draft PR #107 added `triggerRepaint` to the *source* push and it didn't help — that invalidates source tiles, not the `icon-image → atlas` resolution.

### What changed
- `ContactSymbolLayer.update()` is now ordered into explicit phases: **register all referenced images → push source data → re-resolve**.
- When at least one **new** image was added on this call, it re-asserts the `SymbolLayer`'s `iconImage` via `setProperties(...)` (forces a fresh atlas resolve now that the entry exists) and calls `MapLibreMap.triggerRepaint()` so the render thread redraws immediately. It is a **no-op on steady-state updates** (no new icons), so there's no per-frame cost once icons are warm.
- The TAK/imported-iconset path (#98) now also flags a fresh `addImage`, so the re-resolve fires for bundled-iconset first-sightings, not just MIL-STD ones (previously that branch wasn't counted, so the repaint wouldn't fire for a SpotMap/imported marker's first appearance).
- The `SymbolLayer` is already an independent render path from the `contacts-circles` CircleLayer (documented to silently fail on Adreno 610 / SwiftShader), so the symbol path does not depend on the failing circle-color expression. No change to the circle expression.
- Extracted pure `milStdImageId(sidc)` / `resolveImageName(sidc, takImageId)` helpers so the id passed to `addImage` and the id written into the feature's `icon-image` property **cannot drift** — a mismatch there is the same blank-symbol symptom. Pinned by new JVM unit tests.

### Tests / build
- `:app:testDebugUnitTest` green (full suite). New `ContactSymbolLayerImageIdTest` (5 tests) pins the image-id resolution invariant.
- `:app:compileDebugKotlin` green (no new warnings from this change).
- The render fix itself (re-resolve + repaint timing) is **not** unit-testable — it requires a real GPU.

### ⚠️ Needs device verification before #77 can close
This is a **candidate**, not a confirmed fix. Please verify on real Mali/Adreno hardware (ideally a Pixel 9 Pro, matching the reporter):

1. Cold-start the app on a 2D basemap (no 3D terrain).
2. Drop a marker (point-dropper / coordinate-entry / FEMA palette).
3. **Confirm the marker icon paints immediately on the 2D map with NO 3D-terrain toggle and no other style reload.**
4. Drop a second marker of a different affiliation/type; confirm it also paints on first drop.
5. Confirm steady-state contact updates (moving PPLI) still render and there's no visible flicker from the repaint.

If markers still don't paint after this, the next thing to try is the async upload path (`Style.addImageAsync` exists in MapLibre 11.8.0) and/or removing+re-adding the symbol layer after the atlas commit — but the synchronous re-resolve + `triggerRepaint` is the lowest-risk first attempt and matches the LocationComponent path that already renders on these drivers.