### PR TITLE
feat(fema): per-glyph SVG artwork for all 12 FEMA/ICS-237 kinds

### DIFF
--- a/app/src/main/assets/fema/aviation/helicopter_lz.svg
+++ b/app/src/main/assets/fema/aviation/helicopter_lz.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Helicopter LZ: cyan circle with bold H (LZ convention) -->
+  <circle cx="32" cy="32" r="28" fill="#00BCD4" stroke="#000" stroke-width="2.5"/>
+  <!-- Bold H for helicopter landing zone -->
+  <rect x="15" y="14" width="8" height="36" rx="2" fill="#FFF"/>
+  <rect x="41" y="14" width="8" height="36" rx="2" fill="#FFF"/>
+  <rect x="15" y="26" width="34" height="12" rx="2" fill="#FFF"/>
+  <!-- Small rotor arcs top to indicate helicopter -->
+  <path d="M20,10 Q32,4 44,10" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/app/src/main/assets/fema/incidentCommand/command_post.svg
+++ b/app/src/main/assets/fema/incidentCommand/command_post.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Command Post: orange pentagon with a star (CP marker) -->
+  <polygon points="32,4 60,22 50,54 14,54 4,22" fill="#FF9800" stroke="#000" stroke-width="2.5"/>
+  <!-- Star shape inside -->
+  <polygon points="32,14 35,24 46,24 37,30 40,41 32,35 24,41 27,30 18,24 29,24" fill="#FFF" stroke="#000" stroke-width="1"/>
+</svg>

--- a/app/src/main/assets/fema/incidentCommand/staging_area.svg
+++ b/app/src/main/assets/fema/incidentCommand/staging_area.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Staging Area: orange square with "S" marking and double arrows -->
+  <rect x="8" y="8" width="48" height="48" rx="4" fill="#FF9800" stroke="#000" stroke-width="2.5"/>
+  <!-- Box/staging grid lines -->
+  <line x1="8" y1="32" x2="56" y2="32" stroke="#000" stroke-width="1.5"/>
+  <line x1="32" y1="8" x2="32" y2="56" stroke="#000" stroke-width="1.5"/>
+  <!-- Inbound arrow top-left -->
+  <path d="M16,16 L16,26 L26,26" fill="none" stroke="#FFF" stroke-width="2" stroke-linecap="round"/>
+  <!-- Inbound arrow bottom-right -->
+  <path d="M48,48 L48,38 L38,38" fill="none" stroke="#FFF" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/app/src/main/assets/fema/medical/medical_supply.svg
+++ b/app/src/main/assets/fema/medical/medical_supply.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Medical Supply: red rectangle (cache box) with cross + pill symbol -->
+  <rect x="8" y="16" width="48" height="36" rx="4" fill="#F44336" stroke="#000" stroke-width="2.5"/>
+  <!-- Handle on top (medic kit handle) -->
+  <rect x="20" y="9" width="24" height="10" rx="4" fill="none" stroke="#000" stroke-width="2.5"/>
+  <!-- White cross smaller, centered -->
+  <rect x="26" y="22" width="12" height="24" rx="2" fill="#FFF"/>
+  <rect x="20" y="28" width="24" height="12" rx="2" fill="#FFF"/>
+</svg>

--- a/app/src/main/assets/fema/medical/triage_station.svg
+++ b/app/src/main/assets/fema/medical/triage_station.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Triage Station: red circle with white cross (classic medical) -->
+  <circle cx="32" cy="32" r="28" fill="#F44336" stroke="#000" stroke-width="2.5"/>
+  <!-- White cross -->
+  <rect x="26" y="10" width="12" height="44" rx="3" fill="#FFF"/>
+  <rect x="10" y="26" width="44" height="12" rx="3" fill="#FFF"/>
+</svg>

--- a/app/src/main/assets/fema/support/base_camp.svg
+++ b/app/src/main/assets/fema/support/base_camp.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Base Camp: green house/tent silhouette -->
+  <!-- Tent body -->
+  <polygon points="32,6 58,38 6,38" fill="#4CAF50" stroke="#000" stroke-width="2.5"/>
+  <!-- Tent opening / door -->
+  <polygon points="32,14 44,38 20,38" fill="#2E7D32" stroke="#000" stroke-width="1"/>
+  <!-- Base rectangle -->
+  <rect x="6" y="38" width="52" height="18" rx="2" fill="#4CAF50" stroke="#000" stroke-width="2"/>
+  <!-- Door on base -->
+  <rect x="25" y="44" width="14" height="12" rx="2" fill="#1B5E20"/>
+</svg>

--- a/app/src/main/assets/fema/support/communications_hub.svg
+++ b/app/src/main/assets/fema/support/communications_hub.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Communications Hub: green diamond with antenna/signal arcs -->
+  <polygon points="32,4 60,32 32,60 4,32" fill="#4CAF50" stroke="#000" stroke-width="2.5"/>
+  <!-- Antenna mast -->
+  <line x1="32" y1="18" x2="32" y2="46" stroke="#FFF" stroke-width="3" stroke-linecap="round"/>
+  <!-- Signal arcs left -->
+  <path d="M26,22 Q18,32 26,42" fill="none" stroke="#FFF" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M20,18 Q8,32 20,46" fill="none" stroke="#FFF" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <!-- Signal arcs right -->
+  <path d="M38,22 Q46,32 38,42" fill="none" stroke="#FFF" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M44,18 Q56,32 44,46" fill="none" stroke="#FFF" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <!-- Base dot -->
+  <circle cx="32" cy="46" r="3" fill="#FFF"/>
+</svg>

--- a/app/src/main/assets/fema/support/food_water.svg
+++ b/app/src/main/assets/fema/support/food_water.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Food/Water: green circle with fork+water droplet symbols -->
+  <circle cx="32" cy="32" r="28" fill="#4CAF50" stroke="#000" stroke-width="2.5"/>
+  <!-- Fork (left) -->
+  <line x1="20" y1="14" x2="20" y2="50" stroke="#FFF" stroke-width="3" stroke-linecap="round"/>
+  <line x1="16" y1="14" x2="16" y2="26" stroke="#FFF" stroke-width="2" stroke-linecap="round"/>
+  <line x1="24" y1="14" x2="24" y2="26" stroke="#FFF" stroke-width="2" stroke-linecap="round"/>
+  <path d="M16,26 Q20,30 24,26" fill="none" stroke="#FFF" stroke-width="2"/>
+  <!-- Divider -->
+  <line x1="32" y1="16" x2="32" y2="48" stroke="#FFF" stroke-width="1.5" opacity="0.5"/>
+  <!-- Water droplet (right) -->
+  <path d="M44,48 Q36,38 44,26 Q52,38 44,48 Z" fill="#FFF" stroke="#FFF" stroke-width="1"/>
+</svg>

--- a/app/src/main/assets/fema/support/generator.svg
+++ b/app/src/main/assets/fema/support/generator.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Generator: green rectangle with lightning bolt -->
+  <rect x="8" y="14" width="48" height="36" rx="5" fill="#4CAF50" stroke="#000" stroke-width="2.5"/>
+  <!-- Lightning bolt centered -->
+  <polygon points="38,16 26,34 33,34 26,52 42,30 34,30" fill="#FFEB3B" stroke="#F57F17" stroke-width="1.5"/>
+  <!-- Output terminal lines -->
+  <line x1="14" y1="26" x2="8" y2="26" stroke="#FFF" stroke-width="2" stroke-linecap="round"/>
+  <line x1="14" y1="38" x2="8" y2="38" stroke="#FFF" stroke-width="2" stroke-linecap="round"/>
+  <line x1="50" y1="26" x2="56" y2="26" stroke="#FFF" stroke-width="2" stroke-linecap="round"/>
+  <line x1="50" y1="38" x2="56" y2="38" stroke="#FFF" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/app/src/main/assets/fema/vehicles/ambulance.svg
+++ b/app/src/main/assets/fema/vehicles/ambulance.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Ambulance: white van with red cross + stripe -->
+  <!-- Body -->
+  <rect x="6" y="22" width="46" height="22" rx="3" fill="#FAFAFA" stroke="#000" stroke-width="2"/>
+  <!-- Cab -->
+  <rect x="38" y="15" width="14" height="11" rx="3" fill="#FAFAFA" stroke="#000" stroke-width="2"/>
+  <!-- Window -->
+  <rect x="40" y="17" width="10" height="7" rx="1" fill="#B3E5FC"/>
+  <!-- Red cross on side -->
+  <rect x="14" y="27" width="10" height="12" rx="0" fill="#F44336"/>
+  <rect x="10" y="31" width="18" height="4" rx="0" fill="#FFF"/>
+  <rect x="17" y="27" width="4" height="12" rx="0" fill="#FFF"/>
+  <!-- Red stripe -->
+  <rect x="6" y="30" width="46" height="4" fill="#F44336" opacity="0.35"/>
+  <!-- Wheels -->
+  <circle cx="16" cy="46" r="7" fill="#212121" stroke="#000" stroke-width="1.5"/>
+  <circle cx="16" cy="46" r="3" fill="#757575"/>
+  <circle cx="44" cy="46" r="7" fill="#212121" stroke="#000" stroke-width="1.5"/>
+  <circle cx="44" cy="46" r="3" fill="#757575"/>
+  <!-- Light bar -->
+  <rect x="38" y="12" width="6" height="3" rx="1" fill="#2196F3"/>
+  <rect x="46" y="12" width="6" height="3" rx="1" fill="#F44336"/>
+</svg>

--- a/app/src/main/assets/fema/vehicles/fire_truck.svg
+++ b/app/src/main/assets/fema/vehicles/fire_truck.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Fire Engine: red truck silhouette -->
+  <!-- Body -->
+  <rect x="8" y="24" width="44" height="20" rx="3" fill="#F44336" stroke="#000" stroke-width="2"/>
+  <!-- Cab -->
+  <rect x="38" y="16" width="14" height="12" rx="3" fill="#F44336" stroke="#000" stroke-width="2"/>
+  <!-- Cab window -->
+  <rect x="40" y="18" width="10" height="7" rx="1" fill="#B3E5FC"/>
+  <!-- Wheels -->
+  <circle cx="18" cy="46" r="7" fill="#212121" stroke="#000" stroke-width="1.5"/>
+  <circle cx="18" cy="46" r="3" fill="#757575"/>
+  <circle cx="46" cy="46" r="7" fill="#212121" stroke="#000" stroke-width="1.5"/>
+  <circle cx="46" cy="46" r="3" fill="#757575"/>
+  <!-- Ladder on top -->
+  <rect x="8" y="21" width="30" height="4" rx="1" fill="#FFC107" stroke="#000" stroke-width="1"/>
+  <line x1="14" y1="21" x2="14" y2="25" stroke="#000" stroke-width="1"/>
+  <line x1="20" y1="21" x2="20" y2="25" stroke="#000" stroke-width="1"/>
+  <line x1="26" y1="21" x2="26" y2="25" stroke="#000" stroke-width="1"/>
+  <line x1="32" y1="21" x2="32" y2="25" stroke="#000" stroke-width="1"/>
+  <!-- Flashing light -->
+  <rect x="10" y="17" width="6" height="4" rx="1" fill="#FF1744"/>
+</svg>

--- a/app/src/main/assets/fema/vehicles/search_team.svg
+++ b/app/src/main/assets/fema/vehicles/search_team.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- ICS Search Team: yellow circle with 3 person silhouettes and magnifier -->
+  <circle cx="32" cy="32" r="28" fill="#FFEB3B" stroke="#000" stroke-width="2.5"/>
+  <!-- Three person silhouettes in a row -->
+  <!-- Left person -->
+  <circle cx="18" cy="24" r="5" fill="#212121"/>
+  <path d="M13,42 Q18,30 23,42" fill="#212121"/>
+  <!-- Center person -->
+  <circle cx="32" cy="22" r="5" fill="#212121"/>
+  <path d="M27,42 Q32,28 37,42" fill="#212121"/>
+  <!-- Right person -->
+  <circle cx="46" cy="24" r="5" fill="#212121"/>
+  <path d="M41,42 Q46,30 51,42" fill="#212121"/>
+  <!-- Magnifier overlay bottom-right -->
+  <circle cx="48" cy="46" r="7" fill="none" stroke="#000" stroke-width="2.5"/>
+  <line x1="53" y1="51" x2="58" y2="56" stroke="#000" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/FemaIconCache.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/FemaIconCache.kt
@@ -1,0 +1,121 @@
+package soy.engindearing.omnitak.mobile.data.symbology
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.util.Log
+import androidx.collection.LruCache
+import com.caverock.androidsvg.SVG
+import soy.engindearing.omnitak.mobile.data.FemaIconCatalog
+import java.io.IOException
+
+/**
+ * Process-wide cache of rasterised FEMA / ICS-237 glyph icons for the
+ * [soy.engindearing.omnitak.mobile.ui.components.ContactSymbolLayer] and
+ * the legacy [soy.engindearing.omnitak.mobile.ui.components.ContactLayer].
+ *
+ * SVGs live under `assets/fema/<category>/<kind>.svg` — exactly the path
+ * structure the [FemaIconCatalog.iconsetPath] emits via
+ * `COT_MAPPING_FEMA/<category>/<kind>`.  That makes the asset address a
+ * direct transform of the iconsetPath:
+ *
+ *   "COT_MAPPING_FEMA/incidentCommand/command_post"
+ *   → "fema/incidentCommand/command_post.svg"
+ *
+ * Receivers without the FEMA asset bundle (third-party ATAK, iTAK) are
+ * unaffected — they never call into this cache; their fallback is the
+ * MIL-STD friendly-installation rendering driven by the CoT type.
+ *
+ * Closes #46.
+ */
+object FemaIconCache {
+
+    private const val TAG = "FemaIconCache"
+    private const val DEFAULT_SIZE_PX = 64
+
+    /**
+     * Stable image-name prefix used when registering FEMA bitmaps in a
+     * MapLibre [org.maplibre.android.maps.Style] via `addImage`.  Callers
+     * must use this prefix so the symbol-layer `icon-image` expression can
+     * match against it (e.g. `"fema-command_post"`).
+     */
+    const val ICON_IMAGE_PREFIX = "fema-"
+
+    private data class Key(val assetPath: String, val sizePx: Int)
+
+    private val cache = LruCache<Key, Bitmap>(64)
+
+    /**
+     * Resolve the [Bitmap] for the given FEMA [kind].
+     *
+     * Returns null only when the underlying asset is missing or unparseable,
+     * which should never happen in a correctly packaged build.
+     */
+    fun bitmapFor(
+        context: Context,
+        kind: FemaIconCatalog.Kind,
+        sizePx: Int = DEFAULT_SIZE_PX,
+    ): Bitmap? {
+        val icon = FemaIconCatalog.iconFor(kind) ?: return null
+        return bitmapForPath(context, assetPathFor(icon), sizePx)
+    }
+
+    /**
+     * Resolve by [iconsetPath] string — the value parsed from an inbound
+     * CoT `<usericon iconsetpath="COT_MAPPING_FEMA/...">` element.  Returns
+     * null when [iconsetPath] doesn't map to a known FEMA kind.
+     */
+    fun bitmapForIconsetPath(
+        context: Context,
+        iconsetPath: String,
+        sizePx: Int = DEFAULT_SIZE_PX,
+    ): Bitmap? {
+        val icon = FemaIconCatalog.iconByIconsetPath(iconsetPath) ?: return null
+        return bitmapForPath(context, assetPathFor(icon), sizePx)
+    }
+
+    /**
+     * Stable image key for [Style.addImage] registration.  Callers that
+     * register a bitmap in the MapLibre style should use this key so the
+     * symbol layer can reference it via [ICON_IMAGE_PREFIX] expressions.
+     */
+    fun imageKeyFor(kind: FemaIconCatalog.Kind): String = ICON_IMAGE_PREFIX + kind.raw
+
+    /** Clear the cache — e.g. on `onTrimMemory(TRIM_MEMORY_RUNNING_LOW)`. */
+    fun clear() {
+        cache.evictAll()
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────
+
+    private fun assetPathFor(icon: FemaIconCatalog.FemaIcon): String {
+        // iconsetPath is "COT_MAPPING_FEMA/<category>/<kind>"
+        // asset path is  "fema/<category>/<kind>.svg"
+        val segments = icon.iconsetPath.split('/')
+        // segments[0] = "COT_MAPPING_FEMA", [1] = category, [2] = kind
+        return "fema/${segments[1]}/${segments[2]}.svg"
+    }
+
+    private fun bitmapForPath(context: Context, assetPath: String, sizePx: Int): Bitmap? {
+        val key = Key(assetPath, sizePx)
+        cache.get(key)?.let { return it }
+
+        return try {
+            context.assets.open(assetPath).use { stream ->
+                val svg = SVG.getFromInputStream(stream)
+                svg.setDocumentWidth(sizePx.toFloat())
+                svg.setDocumentHeight(sizePx.toFloat())
+                val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+                svg.renderToCanvas(Canvas(bitmap))
+                cache.put(key, bitmap)
+                bitmap
+            }
+        } catch (e: IOException) {
+            Log.w(TAG, "FEMA asset missing: $assetPath")
+            null
+        } catch (e: com.caverock.androidsvg.SVGParseException) {
+            Log.w(TAG, "SVG parse failed for $assetPath", e)
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistry.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/symbology/TakIconRegistry.kt
@@ -311,13 +311,18 @@ object TakIconRegistry {
             val color = argb ?: SpotIcon.WHITE.argb
             return spotDot(color, sizePx, "spot|type|$color")
         }
-        // 3. FEMA / ICS catalog — rendered as a category-accented coloured dot.
-        //    No Context needed (runtime-rendered like Spot Map). TODO #46: once
-        //    per-glyph SVG assets land in app/src/main/assets/fema/, switch to
-        //    asset rasterisation here and remove the dot fallback.
+        // 3. FEMA / ICS catalog — rasterised from per-kind SVG glyphs (#46).
+        //    Context is required; fall through to the dot only when context
+        //    is null (should not happen in production — the symbol layer always
+        //    has a context). If the SVG asset is somehow absent (corrupted APK),
+        //    the dot ensures the marker still renders rather than disappearing.
         resolveFemaIcon(iconsetPath)?.let { femaIcon ->
-            val accentArgb = femaIcon.category.accentArgb
-            return spotDot(accentArgb, sizePx, "fema|${femaIcon.kind.raw}|$sizePx")
+            if (context != null) {
+                val bmp = FemaIconCache.bitmapFor(context, femaIcon.kind, sizePx)
+                if (bmp != null) return bmp
+            }
+            // Fallback dot — context null or asset missing.
+            return spotDot(femaIcon.category.accentArgb, sizePx, "fema-dot|${femaIcon.kind.raw}|$sizePx")
         }
         // 4. Markers / Google bitmap packs — Material-Symbols (Apache-2.0)
         //    vector glyphs on a rounded badge. Needs a Context to decode.

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/FemaGlyphResolutionTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/symbology/FemaGlyphResolutionTest.kt
@@ -1,0 +1,217 @@
+package soy.engindearing.omnitak.mobile.data.symbology
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.FemaIconCatalog
+
+/**
+ * Issue #46 — FEMA glyph resolution contract.
+ *
+ * These tests assert that:
+ *  1. Every FEMA kind maps to a DISTINCT asset path (not a fallback dot,
+ *     not a MIL-STD SIDC), so a command_post and a triage_station can
+ *     never resolve to the same image.
+ *  2. The asset paths follow the `fema/<category>/<kind>.svg` convention
+ *     the [FemaIconCache] expects.
+ *  3. [TakIconRegistry.styleImageId] produces a per-kind stable image
+ *     key (NOT a shared "takicon-fema-…" from the category alone), and
+ *     no two kinds share the same key.
+ *  4. [TakIconRegistry.handles] is true for FEMA iconset paths so the
+ *     ContactSymbolLayer routes them through the TAK-suite path rather
+ *     than falling through to MIL-STD art.
+ *  5. Non-FEMA paths are rejected cleanly.
+ *
+ * The bitmap half ([FemaIconCache.bitmapFor]) requires an Android [Context]
+ * and is NOT exercised here — that is covered by instrumented tests or
+ * a device render. These unit tests pin the resolution + routing logic
+ * that runs without Android.
+ */
+class FemaGlyphResolutionTest {
+
+    // ── Asset path convention ─────────────────────────────────────────────
+
+    @Test
+    fun `every kind maps to a distinct fema asset path`() {
+        // No two kinds should resolve to the same asset. If the asset path
+        // were wrong (e.g. same kind raw OR same category segment), two different
+        // markers would render the same glyph, defeating the whole point of #46.
+        val paths = FemaIconCatalog.Kind.entries.map { kind ->
+            assetPathFor(kind)
+        }
+        // All 12 paths are distinct.
+        assertEquals(
+            "Expected 12 distinct asset paths but got: $paths",
+            FemaIconCatalog.Kind.entries.size,
+            paths.toSet().size,
+        )
+    }
+
+    @Test
+    fun `asset paths follow the fema-category-kind-dot-svg convention`() {
+        for (kind in FemaIconCatalog.Kind.entries) {
+            val path = assetPathFor(kind)
+            assertTrue(
+                "Expected path to start with 'fema/' but was: $path",
+                path.startsWith("fema/"),
+            )
+            assertTrue(
+                "Expected path to end with '.svg' but was: $path",
+                path.endsWith(".svg"),
+            )
+            // Three segments: fema / <category> / <kind>.svg
+            val parts = path.split('/')
+            assertEquals(
+                "Expected 3 path segments (fema/<cat>/<kind>.svg) but got $parts",
+                3,
+                parts.size,
+            )
+            assertEquals("fema", parts[0])
+            assertTrue("Middle segment must not be empty", parts[1].isNotEmpty())
+            assertTrue("Kind segment must not be empty", parts[2].removeSuffix(".svg").isNotEmpty())
+        }
+    }
+
+    @Test
+    fun `command_post asset is fema-incidentCommand-command_post-svg`() {
+        assertEquals("fema/incidentCommand/command_post.svg", assetPathFor(FemaIconCatalog.Kind.COMMAND_POST))
+    }
+
+    @Test
+    fun `triage_station asset is fema-medical-triage_station-svg`() {
+        assertEquals("fema/medical/triage_station.svg", assetPathFor(FemaIconCatalog.Kind.TRIAGE_STATION))
+    }
+
+    @Test
+    fun `helicopter_lz asset is fema-aviation-helicopter_lz-svg`() {
+        assertEquals("fema/aviation/helicopter_lz.svg", assetPathFor(FemaIconCatalog.Kind.HELICOPTER_LZ))
+    }
+
+    @Test
+    fun `communications_hub asset is fema-support-communications_hub-svg`() {
+        assertEquals("fema/support/communications_hub.svg", assetPathFor(FemaIconCatalog.Kind.COMMUNICATIONS_HUB))
+    }
+
+    // ── TakIconRegistry routing ───────────────────────────────────────────
+
+    @Test
+    fun `handles is true for every FEMA iconset path`() {
+        for (icon in FemaIconCatalog.all) {
+            assertTrue(
+                "handles must be true for FEMA path ${icon.iconsetPath}",
+                TakIconRegistry.handles(icon.cotType, icon.iconsetPath),
+            )
+        }
+    }
+
+    @Test
+    fun `handles is false for a null iconset path on a FEMA cot type`() {
+        // A FEMA-typed event whose iconsetPath was stripped in transit must NOT
+        // claim to be a TAK-suite icon — it would render blank. Receivers without
+        // the FEMA bundle should fall back to MIL-STD friendly-installation art.
+        assertFalse(
+            "FEMA cotType without an iconsetPath must fall through to MIL-STD",
+            TakIconRegistry.handles("a-f-G-I-U-T", null),
+        )
+    }
+
+    @Test
+    fun `styleImageId is a distinct per-kind key for every FEMA icon`() {
+        val ids = FemaIconCatalog.all.map { icon ->
+            TakIconRegistry.styleImageId(icon.cotType, icon.iconsetPath, null)
+        }
+        // Every id is non-null.
+        assertTrue("styleImageId returned null for a FEMA icon", ids.none { it == null })
+        // Every id starts with the expected prefix.
+        assertTrue(
+            "All FEMA image ids must start with 'takicon-fema-'",
+            ids.all { it!!.startsWith("takicon-fema-") },
+        )
+        // All 12 ids are DISTINCT — no two kinds share a MapLibre image slot.
+        assertEquals(
+            "Expected 12 distinct styleImageIds but collisions found: ${ids.groupBy { it }.filter { it.value.size > 1 }.keys}",
+            FemaIconCatalog.all.size,
+            ids.toSet().size,
+        )
+    }
+
+    @Test
+    fun `styleImageId uses the kind raw not the category so kinds within the same category differ`() {
+        // INCIDENT_COMMAND has two kinds: COMMAND_POST and STAGING_AREA.
+        // They must produce distinct ids or both command markers render the same glyph.
+        val cpId = TakIconRegistry.styleImageId(
+            "a-f-G-I-U-T",
+            "COT_MAPPING_FEMA/incidentCommand/command_post",
+            null,
+        )
+        val saId = TakIconRegistry.styleImageId(
+            "a-f-G-I-B-A",
+            "COT_MAPPING_FEMA/incidentCommand/staging_area",
+            null,
+        )
+        assertNotNull(cpId)
+        assertNotNull(saId)
+        assertTrue("command_post and staging_area must have distinct image ids", cpId != saId)
+    }
+
+    @Test
+    fun `styleImageId returns null for a non-FEMA path`() {
+        // A MIL-STD contact with no iconset path gets null → the MIL-STD path
+        // takes over, just like before.
+        assertNull(TakIconRegistry.styleImageId("a-f-G-U-C-I", null, null))
+    }
+
+    @Test
+    fun `resolveFemaIcon identifies every FEMA iconset path`() {
+        for (icon in FemaIconCatalog.all) {
+            val resolved = TakIconRegistry.resolveFemaIcon(icon.iconsetPath)
+            assertNotNull("resolveFemaIcon returned null for ${icon.iconsetPath}", resolved)
+            assertEquals(icon.kind, resolved!!.kind)
+        }
+    }
+
+    @Test
+    fun `resolveFemaIcon rejects a non-FEMA path`() {
+        assertNull(TakIconRegistry.resolveFemaIcon("COT_MAPPING_SPOTMAP/red"))
+        assertNull(TakIconRegistry.resolveFemaIcon("COT_MAPPING_2525C/flag"))
+        assertNull(TakIconRegistry.resolveFemaIcon(null))
+    }
+
+    // ── FemaIconCache asset path derivation (no context) ─────────────────
+
+    @Test
+    fun `FemaIconCache imageKeyFor returns the fema dash kind raw key`() {
+        assertEquals(
+            FemaIconCache.ICON_IMAGE_PREFIX + FemaIconCatalog.Kind.COMMAND_POST.raw,
+            FemaIconCache.imageKeyFor(FemaIconCatalog.Kind.COMMAND_POST),
+        )
+        // Prefix must be "fema-".
+        assertTrue(
+            FemaIconCache.imageKeyFor(FemaIconCatalog.Kind.TRIAGE_STATION)
+                .startsWith(FemaIconCache.ICON_IMAGE_PREFIX),
+        )
+    }
+
+    @Test
+    fun `FemaIconCache imageKeys are distinct for all 12 kinds`() {
+        val keys = FemaIconCatalog.Kind.entries.map { FemaIconCache.imageKeyFor(it) }
+        assertEquals(
+            "Expected 12 distinct FemaIconCache image keys",
+            FemaIconCatalog.Kind.entries.size,
+            keys.toSet().size,
+        )
+    }
+
+    // ── Helper: mirror FemaIconCache.assetPathFor without needing the object ──
+
+    /** Derive the asset path from a Kind's iconsetPath — mirrors FemaIconCache. */
+    private fun assetPathFor(kind: FemaIconCatalog.Kind): String {
+        val icon = FemaIconCatalog.iconFor(kind)!!
+        val segments = icon.iconsetPath.split('/')
+        // segments: ["COT_MAPPING_FEMA", "<category>", "<kind>"]
+        return "fema/${segments[1]}/${segments[2]}.svg"
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the category-accented dot stopgap (#47/#109) with hand-authored ICS-style vector glyphs for all 12 FEMA/ICS-237 marker kinds.
- Adds `FemaIconCache` — a sibling to `MilStdIconCache` using the same AndroidSVG rasterisation pipeline, keyed by `FemaIconCatalog.Kind`.
- Updates `TakIconRegistry.resolveBitmap` step 3: now delegates to `FemaIconCache` for per-glyph SVG art; falls back to the category-accented dot when context is null or the asset is absent (no behaviour regression for receivers without the bundle).
- Asset convention: `assets/fema/<category>/<kind>.svg` — direct transform of the iconsetPath (`COT_MAPPING_FEMA/<category>/<kind>` → `fema/<category>/<kind>.svg`).

## Glyphs authored (12 kinds)

| Category | Kind | Glyph design |
|---|---|---|
| Command | `command_post` | Orange pentagon with a star (CP convention) |
| Command | `staging_area` | Orange square with quadrant grid + inbound arrows |
| Medical | `triage_station` | Red circle with white cross |
| Medical | `medical_supply` | Red medic-kit box with cross + handle |
| Aviation | `helicopter_lz` | Cyan circle with bold **H** + rotor arc |
| Vehicles | `fire_truck` | Red truck silhouette with ladder + light |
| Vehicles | `ambulance` | White van with red cross + stripe + light bar |
| Vehicles | `search_team` | Yellow circle with three silhouettes + magnifier |
| Support | `base_camp` | Green tent + base rectangle with door |
| Support | `food_water` | Green circle with fork + water droplet |
| Support | `generator` | Green rectangle with lightning bolt + terminals |
| Support | `communications_hub` | Green diamond with antenna mast + signal arcs |

These are hand-authored ICS-style SVGs — not official FEMA/DHS artwork. If official ICS-237 vector art is sourced later, drop the SVGs in `assets/fema/<category>/<kind>.svg` and the resolver picks them up automatically.

## Test plan

- [x] `FemaGlyphResolutionTest` (new): asserts every kind maps to a distinct asset path, `styleImageId` is per-kind and distinct across all 12, `handles` is true for all FEMA iconset paths, `FemaIconCache.imageKeyFor` keys are distinct — all green.
- [x] Existing `FemaIconCatalogTest` — unchanged, green.
- [x] Existing `TakIconRegistryTest` — no regressions, green.
- [x] Full unit test suite — green (`./gradlew :app:testDebugUnitTest`).
- [x] `./gradlew :app:assembleDebug` — green; all 12 SVGs confirmed in APK at `assets/fema/`.
- [ ] Device glance needed — drop a FEMA Command Post and Triage Station from the palette and confirm each renders its distinct glyph on the map (not a dot, not a flag).

Closes #46