### PR TITLE
feat(settings): wire SAF icon-pack import trigger (#114)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -2,7 +2,9 @@ package soy.engindearing.omnitak.mobile.ui.screens
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -27,6 +29,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -55,6 +58,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.OmniTAKApp
 import soy.engindearing.omnitak.mobile.i18n.Loc
@@ -63,6 +67,7 @@ import soy.engindearing.omnitak.mobile.data.DistanceUnit
 import soy.engindearing.omnitak.mobile.data.MapProvider
 import soy.engindearing.omnitak.mobile.data.UserPrefs
 import soy.engindearing.omnitak.mobile.domain.ConnectionState
+import soy.engindearing.omnitak.mobile.domain.IconPackImporter
 import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material3.Icon
 import soy.engindearing.omnitak.mobile.ui.components.GybDeviceSheet
@@ -555,6 +560,67 @@ fun SettingsScreen(
                         )
                     }
                 }
+            }
+
+            // Issue #114 — icon-pack import. SAF picker routes the picked .zip
+            // to IconPackImporter on a background thread, then toasts the result.
+            // Registry.register() is called inside importStream, so the picker
+            // sees the new pack on its next recomposition.
+            SectionHeader("Symbology")
+            val iconPackCtx = LocalContext.current
+            val iconPackLauncher = rememberLauncherForActivityResult(
+                ActivityResultContracts.OpenDocument(),
+            ) { uri: Uri? ->
+                if (uri == null) return@rememberLauncherForActivityResult
+                scope.launch(Dispatchers.IO) {
+                    val importer = IconPackImporter(iconPackCtx)
+                    val stream = runCatching {
+                        iconPackCtx.contentResolver.openInputStream(uri)
+                    }.getOrNull()
+                    val result = if (stream != null) {
+                        stream.use { importer.importStream(it, uri.lastPathSegment ?: "pack.zip") }
+                    } else {
+                        IconPackImporter.ImportResult.Failure("Could not open the selected file")
+                    }
+                    val msg = when (result) {
+                        is IconPackImporter.ImportResult.Success ->
+                            "Icon pack \"${result.pack.name}\" imported (${result.pack.icons.size} icons)"
+                        is IconPackImporter.ImportResult.Failure ->
+                            "Import failed: ${result.reason}"
+                    }
+                    launch(Dispatchers.Main) {
+                        Toast.makeText(iconPackCtx, msg, Toast.LENGTH_LONG).show()
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable { iconPackLauncher.launch(arrayOf("application/zip", "application/octet-stream")) }
+                    .padding(vertical = 10.dp, horizontal = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                androidx.compose.material3.Icon(
+                    Icons.Filled.FileUpload,
+                    contentDescription = null,
+                    tint = TacticalAccent,
+                    modifier = Modifier.size(22.dp),
+                )
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Import icon pack (.zip)", color = MaterialTheme.colorScheme.onBackground)
+                    Text(
+                        "Add a custom ATAK iconset to the marker picker",
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                androidx.compose.material3.Icon(
+                    Icons.Filled.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                )
             }
 
             // Issue #95 / #97 — map behaviour toggles.

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/IconPackImporterResultTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/IconPackImporterResultTest.kt
@@ -1,0 +1,74 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.symbology.IconPackRegistry.ImportedIcon
+import soy.engindearing.omnitak.mobile.data.symbology.IconPackRegistry.ImportedPack
+
+/**
+ * Issue #114 — unit tests for [IconPackImporter.ImportResult] sealed class.
+ *
+ * The importer itself requires an Android Context (file I/O), so end-to-end
+ * import is covered on-device. These tests guard the result contract: that
+ * Success carries the pack and Failure carries a non-blank reason, so the
+ * Settings toast logic stays correct if the sealed class evolves.
+ */
+class IconPackImporterResultTest {
+
+    private val fakePack = ImportedPack(
+        uid = "test-uid-001",
+        name = "Test Pack",
+        version = 1,
+        dirRelative = "iconpacks/test-uid-001",
+        icons = listOf(
+            ImportedIcon(name = "Ambulance", filename = "Ground/Ambulance.png"),
+            ImportedIcon(name = "Police Car", filename = "Ground/PoliceCar.png"),
+        ),
+    )
+
+    @Test
+    fun `Success carries the imported pack`() {
+        val result: IconPackImporter.ImportResult = IconPackImporter.ImportResult.Success(fakePack)
+        assertTrue(result is IconPackImporter.ImportResult.Success)
+        val success = result as IconPackImporter.ImportResult.Success
+        assertEquals("test-uid-001", success.pack.uid)
+        assertEquals("Test Pack", success.pack.name)
+        assertEquals(2, success.pack.icons.size)
+    }
+
+    @Test
+    fun `Failure carries a non-blank reason`() {
+        val reason = "No iconset.xml found in pack.zip"
+        val result: IconPackImporter.ImportResult = IconPackImporter.ImportResult.Failure(reason)
+        assertTrue(result is IconPackImporter.ImportResult.Failure)
+        val failure = result as IconPackImporter.ImportResult.Failure
+        assertTrue("reason must not be blank", failure.reason.isNotBlank())
+        assertEquals(reason, failure.reason)
+    }
+
+    @Test
+    fun `toast message formats correctly for Success`() {
+        val result = IconPackImporter.ImportResult.Success(fakePack)
+        val msg = when (result) {
+            is IconPackImporter.ImportResult.Success ->
+                "Icon pack \"${result.pack.name}\" imported (${result.pack.icons.size} icons)"
+            is IconPackImporter.ImportResult.Failure ->
+                "Import failed: ${result.reason}"
+        }
+        assertEquals("Icon pack \"Test Pack\" imported (2 icons)", msg)
+    }
+
+    @Test
+    fun `toast message formats correctly for Failure`() {
+        val result = IconPackImporter.ImportResult.Failure("ZIP read error in pack.zip: premature end of file")
+        val msg = when (result) {
+            is IconPackImporter.ImportResult.Success ->
+                "Icon pack \"${result.pack.name}\" imported (${result.pack.icons.size} icons)"
+            is IconPackImporter.ImportResult.Failure ->
+                "Import failed: ${result.reason}"
+        }
+        assertTrue(msg.startsWith("Import failed:"))
+        assertTrue(msg.contains("premature end of file"))
+    }
+}


### PR DESCRIPTION
Adds the missing UI entry point for icon-pack import.

## What

- New **Symbology** section in Settings with an **Import icon pack (.zip)** row
- Tapping fires `ACTION_OPEN_DOCUMENT` (SAF) filtered to `application/zip` + `application/octet-stream`
- On pick, streams the Uri to `IconPackImporter.importStream` off the main thread (`Dispatchers.IO`)
- `IconPackRegistry.register()` is called inside the importer — new pack is immediately visible to `MarkerIconPickerSheet` on next open, no restart needed
- Toast reports success (`"Icon pack \"<name>\" imported (N icons)"`) or failure reason

## Pattern

Mirrors the existing SAF flow in `KmlOverlaysSheet` (copy-to-cache replaced by direct stream; zip import doesn't need a temp file) and `AddServerScreen` (same `rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument())`).

## Tests

`IconPackImporterResultTest` — 4 JVM unit tests covering the `ImportResult` sealed class contract and the exact toast message format used in the callback. `./gradlew :app:testDebugUnitTest` and `:app:assembleDebug` both green.

## Note

The full zip parsing and render pipeline from #98 / PR #112 is unchanged. A device pass is needed to verify end-to-end: import → icon appears in marker picker → renders on map → survives restart.

Closes #114