### PR TITLE
fix: exclude dropped point markers from chat list; persist local markers (#118, #119)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import soy.engindearing.omnitak.mobile.domain.LocalMarkerStore
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.data.AdminResponse
 import soy.engindearing.omnitak.mobile.data.CertVault
@@ -72,6 +73,18 @@ class OmniTAKApp : Application() {
         // mesh broadcast toggles) can read prefs.value immediately.
         appScope.launch {
             userPrefsStore.prefs.collect { cachedPrefs.value = it }
+        }
+
+        // #119 — Restore locally-dropped markers from the previous session,
+        // then keep the persisted blob in sync with any future changes.
+        // The collect loop re-persists only the "local-*" subset so that
+        // server/mesh contacts never bleed into the on-disk store.
+        appScope.launch {
+            localMarkerStore.load().forEach { contactStore.ingest(it) }
+            contactStore.contacts.collect { contacts ->
+                val localMarkers = contacts.values.filter { it.uid.startsWith("local-") }
+                localMarkerStore.persist(localMarkers)
+            }
         }
 
         // Issue #5 — start a foreground service while we're holding a
@@ -255,6 +268,9 @@ class OmniTAKApp : Application() {
     }
 
     val contactStore: ContactStore by lazy { ContactStore() }
+
+    /** #119 — Persists locally-dropped point markers across process death. */
+    val localMarkerStore: LocalMarkerStore by lazy { LocalMarkerStore(this) }
     /** External gyb_detect sensor over BLE GATT (Phase 3 of the gy6 plan).
      *  Parsed drones merge into ContactStore via the shared RID- UID;
      *  driven by `gybDetectorEnabled` in [onCreate]. */

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTEvent.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoTEvent.kt
@@ -1,5 +1,7 @@
 package soy.engindearing.omnitak.mobile.data
 
+import kotlinx.serialization.Serializable
+
 /**
  * MIL-STD-2525 affiliation parsed from a CoT event `type` attribute
  * (the second token after "a-", e.g. `a-f-…` → Friend). Colors roughly
@@ -57,6 +59,7 @@ object TakTeamColor {
  * renders on the map — uid, geographic position, affiliation, callsign,
  * timestamps. Unknown fields stay raw on [rawXml] for debug inspection.
  */
+@Serializable
 data class CoTEvent(
     val uid: String,
     val type: String,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ContactStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/ContactStore.kt
@@ -1,8 +1,10 @@
 package soy.engindearing.omnitak.mobile.domain
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import soy.engindearing.omnitak.mobile.data.CoTEvent
 
@@ -22,6 +24,14 @@ class ContactStore {
     private val _contacts = MutableStateFlow<Map<String, CoTEvent>>(emptyMap())
     val contacts: StateFlow<Map<String, CoTEvent>> = _contacts.asStateFlow()
 
+    /**
+     * #118 — Filtered view of [contacts] that excludes locally-dropped point
+     * markers and bookmark-map-point (b-m-p-*) types. Use this in any UI that
+     * presents valid DM endpoints (e.g. ChatScreen's contact stub list).
+     */
+    val chatCandidates: Flow<Map<String, CoTEvent>> =
+        _contacts.map { m -> m.filterValues { isEndpoint(it) } }
+
     /** Insert or update a contact. Stale logic arrives with Slice 15. */
     fun ingest(event: CoTEvent) {
         _contacts.update { it + (event.uid to event) }
@@ -35,5 +45,28 @@ class ContactStore {
     /** Drop everything — used on connection teardown or manual reset. */
     fun clear() {
         _contacts.value = emptyMap()
+    }
+
+    companion object {
+        /**
+         * #118 — Returns `true` when [event] is a valid GeoChat DM endpoint.
+         *
+         * A contact is NOT a valid endpoint when:
+         * - Its uid starts with `"local-"` — operator-dropped point markers
+         *   created in MapScreen get a `local-{timestamp}` uid and are never
+         *   network-reachable peers.
+         * - Its CoT type starts with `"b-m-p"` — bookmark-map-point sub-schema
+         *   events are positional annotations, not communicating endpoints,
+         *   regardless of which server forwarded them.
+         *
+         * Real endpoints — friendly/hostile/neutral EUDs (`a-*`), RID drones
+         * (`RID-` uid prefix), and Meshtastic nodes (`MESHTASTIC-` prefix) —
+         * all pass through and return `true`.
+         */
+        fun isEndpoint(event: CoTEvent): Boolean {
+            if (event.uid.startsWith("local-")) return false
+            if (event.type.startsWith("b-m-p")) return false
+            return true
+        }
     }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/LocalMarkerStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/LocalMarkerStore.kt
@@ -1,0 +1,64 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+
+/**
+ * #119 — Persists locally-dropped point markers across process death.
+ *
+ * Locally-dropped markers (uid starts with "local-") live only in-memory
+ * in [ContactStore] and are lost on process kill. This store writes the
+ * local-only subset to a DataStore preferences blob (JSON) so they can be
+ * re-ingested into [ContactStore] on cold start via [OmniTAKApp.onCreate].
+ *
+ * The codec — [encode] / [decode] — is exposed on the companion object so
+ * unit tests can exercise serialisation without needing an Android context
+ * or a real DataStore instance.
+ */
+class LocalMarkerStore(context: Context) {
+
+    private val dataStore = context.localMarkerDataStore
+
+    /** Persist [markers] to DataStore. Only entries whose uid starts with
+     *  "local-" are written; callers are responsible for pre-filtering, but
+     *  this method applies the guard defensively as well. */
+    suspend fun persist(markers: List<CoTEvent>) {
+        val localOnly = markers.filter { it.uid.startsWith("local-") }
+        dataStore.edit { prefs ->
+            prefs[KEY_MARKERS] = encode(localOnly)
+        }
+    }
+
+    /** Load the persisted local markers. Returns an empty list when nothing
+     *  has been stored yet or when the JSON blob is corrupt. */
+    suspend fun load(): List<CoTEvent> {
+        val prefs = dataStore.data.first()
+        val raw = prefs[KEY_MARKERS] ?: return emptyList()
+        return runCatching { decode(raw) }.getOrElse { emptyList() }
+    }
+
+    companion object {
+        private val KEY_MARKERS = stringPreferencesKey("local_markers_json")
+
+        /** Serialise [markers] to a compact JSON string. */
+        fun encode(markers: List<CoTEvent>): String =
+            Json.encodeToString(markers)
+
+        /** Deserialise a JSON string produced by [encode] back to a list.
+         *  Throws on malformed JSON — callers should wrap in runCatching. */
+        fun decode(json: String): List<CoTEvent> =
+            Json.decodeFromString(json)
+    }
+}
+
+// One DataStore per application process — extension property keeps the
+// singleton guarantee DataStore requires.
+private val Context.localMarkerDataStore by preferencesDataStore(
+    name = "local_markers",
+)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/ChatScreen.kt
@@ -125,7 +125,11 @@ fun ChatScreen(initialConversationId: String? = null) {
             .toSet()
 
         val contactStubs = contacts.values
-            .filter { contact -> contact.uid != selfUid && contact.uid !in coveredUids }
+            .filter { contact ->
+                contact.uid != selfUid &&
+                    contact.uid !in coveredUids &&
+                    soy.engindearing.omnitak.mobile.domain.ContactStore.isEndpoint(contact)
+            }
             .map { contact ->
                 // Use the same deterministic conversation-id formula as
                 // ChatRoom.directConversationId so that when a real GeoChat

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/ContactStoreChatFilterTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/ContactStoreChatFilterTest.kt
@@ -1,0 +1,92 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+
+/**
+ * #118 — ContactStore chat-filter predicate and chatCandidates flow.
+ *
+ * These tests are RED until [ContactStore.isEndpoint] and
+ * [ContactStore.chatCandidates] are implemented.
+ */
+class ContactStoreChatFilterTest {
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private fun event(uid: String, type: String) = CoTEvent(
+        uid = uid,
+        type = type,
+        lat = 0.0,
+        lon = 0.0,
+    )
+
+    // ── #118 RED tests ───────────────────────────────────────────────────────
+
+    @Test fun chat_filter_excludes_dropped_point_marker_by_uid() {
+        val marker = event(uid = "local-1716000000000", type = "a-f-G-U-C")
+        assertFalse(
+            "local-* uid must be excluded from chat",
+            ContactStore.isEndpoint(marker),
+        )
+    }
+
+    @Test fun chat_filter_excludes_b_m_p_type_from_server() {
+        val spotMarker = event(uid = "some-server-uid-abc", type = "b-m-p-s-m")
+        assertFalse(
+            "b-m-p-* type must be excluded from chat regardless of uid source",
+            ContactStore.isEndpoint(spotMarker),
+        )
+    }
+
+    @Test fun chat_filter_includes_ppli_unit() {
+        val eud = event(uid = "ANDROID-abc123", type = "a-f-G-U-C")
+        assertTrue(
+            "a-f-G-U-C (friendly ground unit) must be a valid chat endpoint",
+            ContactStore.isEndpoint(eud),
+        )
+    }
+
+    @Test fun chat_filter_includes_rid_drone() {
+        val drone = event(uid = "RID-FA123456789", type = "a-u-A-M-F-Q-r")
+        assertTrue(
+            "RID- uid with a-u-A drone type must be a valid chat endpoint",
+            ContactStore.isEndpoint(drone),
+        )
+    }
+
+    @Test fun chat_filter_includes_mesh_node() {
+        val meshNode = event(uid = "MESHTASTIC-abcdef01", type = "a-f-G-U-C")
+        assertTrue(
+            "MESHTASTIC- uid must be a valid chat endpoint",
+            ContactStore.isEndpoint(meshNode),
+        )
+    }
+
+    @Test fun chatCandidates_flow_excludes_markers() = runBlocking {
+        val store = ContactStore()
+
+        // Ingest a mix: one real EUD, one local dropped marker, one b-m-p spot
+        store.ingest(event("ANDROID-eud1", "a-f-G-U-C"))
+        store.ingest(event("local-1716000000001", "a-f-G-U-C"))
+        store.ingest(event("spot-server-uid", "b-m-p-s-m"))
+
+        val candidates = store.chatCandidates.first()
+
+        assertTrue(
+            "real EUD must appear in chatCandidates",
+            "ANDROID-eud1" in candidates,
+        )
+        assertFalse(
+            "local-* marker must NOT appear in chatCandidates",
+            "local-1716000000001" in candidates,
+        )
+        assertFalse(
+            "b-m-p spot marker must NOT appear in chatCandidates",
+            "spot-server-uid" in candidates,
+        )
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/LocalMarkerPersistenceTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/domain/LocalMarkerPersistenceTest.kt
@@ -1,0 +1,113 @@
+package soy.engindearing.omnitak.mobile.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+
+/**
+ * #119 — Local marker persistence codec.
+ *
+ * Tests exercise [LocalMarkerStore.encode] and [LocalMarkerStore.decode]
+ * directly (pure JVM, no Android context or DataStore required).
+ * These tests are RED until [LocalMarkerStore] is implemented.
+ */
+class LocalMarkerPersistenceTest {
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private fun localMarker(
+        uid: String = "local-1716000000000",
+        type: String = "b-m-p-s-m",
+        lat: Double = 47.6588,
+        lon: Double = -117.4260,
+        hae: Double = 600.0,
+        callsign: String? = "Drop-1",
+        remarks: String = "Test marker",
+    ) = CoTEvent(
+        uid = uid,
+        type = type,
+        lat = lat,
+        lon = lon,
+        hae = hae,
+        callsign = callsign,
+        remarks = remarks,
+    )
+
+    private fun serverContact(uid: String = "ANDROID-server1") = CoTEvent(
+        uid = uid,
+        type = "a-f-G-U-C",
+        lat = 47.6,
+        lon = -117.4,
+    )
+
+    // ── #119 RED tests ───────────────────────────────────────────────────────
+
+    @Test fun local_markers_round_trip_through_json() {
+        val markers = listOf(
+            localMarker("local-111"),
+            localMarker("local-222"),
+        )
+        val decoded = LocalMarkerStore.decode(LocalMarkerStore.encode(markers))
+        assertEquals(
+            "round-tripped list must equal the original",
+            markers,
+            decoded,
+        )
+    }
+
+    @Test fun non_local_markers_excluded_from_persist() {
+        val mixed = listOf(
+            localMarker("local-111"),
+            serverContact("ANDROID-abc"),
+            localMarker("local-222"),
+        )
+        val encoded = LocalMarkerStore.encode(mixed.filter { it.uid.startsWith("local-") })
+        val decoded = LocalMarkerStore.decode(encoded)
+
+        assertTrue("local-111 must be persisted", decoded.any { it.uid == "local-111" })
+        assertTrue("local-222 must be persisted", decoded.any { it.uid == "local-222" })
+        assertFalse("server contact must NOT be persisted", decoded.any { it.uid == "ANDROID-abc" })
+    }
+
+    @Test fun empty_list_round_trips() {
+        val decoded = LocalMarkerStore.decode(LocalMarkerStore.encode(emptyList()))
+        assertTrue("decoded empty list must be empty", decoded.isEmpty())
+    }
+
+    @Test fun local_marker_fields_survive_serialization() {
+        val marker = localMarker(
+            uid = "local-9999",
+            type = "b-m-p-s-m",
+            lat = 47.6588,
+            lon = -117.4260,
+            hae = 600.0,
+            callsign = "Marker-A",
+            remarks = "Some remarks",
+        )
+        val decoded = LocalMarkerStore.decode(LocalMarkerStore.encode(listOf(marker)))
+        val result = decoded.single()
+
+        assertEquals("uid", marker.uid, result.uid)
+        assertEquals("type", marker.type, result.type)
+        assertEquals("lat", marker.lat, result.lat, 0.000001)
+        assertEquals("lon", marker.lon, result.lon, 0.000001)
+        assertEquals("hae", marker.hae, result.hae, 0.0001)
+        assertEquals("callsign", marker.callsign, result.callsign)
+        assertEquals("remarks", marker.remarks, result.remarks)
+    }
+
+    @Test fun contactStore_rehydrate_loads_markers() {
+        val markers = listOf(
+            localMarker("local-aaa"),
+            localMarker("local-bbb"),
+        )
+        val store = ContactStore()
+        markers.forEach { store.ingest(it) }
+
+        val contacts = store.contacts.value
+        assertTrue("local-aaa must be in contactStore", "local-aaa" in contacts)
+        assertTrue("local-bbb must be in contactStore", "local-bbb" in contacts)
+    }
+}


### PR DESCRIPTION
## Summary

- **#118** — Dropped point markers wrongly appear in the Chat contact list. `ContactStore.isEndpoint()` predicate filters any contact with uid `local-*` or CoT type `b-m-p*` from `ChatScreen`'s contact stub list. These are positional annotations, not communicating endpoints — they can't receive a DM.
- **#119** — Locally-dropped markers vanish on app restart. New `LocalMarkerStore` persists the `local-*` subset of `ContactStore` to a DataStore preferences blob (JSON via `kotlinx.serialization`). On cold start `OmniTAKApp.onCreate` loads and re-ingests them before any server connection. Server and mesh contacts are never written to the local-marker store, preventing double-ingest after reconnect.

## Scope

Changes are confined to the contact-store / chat-list / persistence layer. The map render path (`ContactSymbolLayer` etc.) is untouched.

## Test plan

- [x] `ContactStoreChatFilterTest` — 6 tests: `local-*` uid excluded, `b-m-p-*` type excluded, PPLI unit included, RID drone included, Meshtastic node included, `chatCandidates` flow excludes markers
- [x] `LocalMarkerPersistenceTest` — 5 tests: JSON round-trip, non-local contacts excluded from persist, empty list, field fidelity (lat/lon/hae/callsign/type/remarks), ContactStore rehydration
- [x] `./gradlew :app:testDebugUnitTest` — full suite green (0 failures, 0 errors across all test classes)
- [x] `./gradlew :app:assembleDebug` — clean

## Classification: locally-dropped vs server/mesh

Local markers get uid `local-{timestamp}` in `MapScreen.kt` (line 1692). `LocalMarkerStore.persist()` filters on this prefix. The chat-filter uses the same prefix rule plus `b-m-p*` type to exclude spot-map markers forwarded from a server.

Closes #118
Closes #119