### PR TITLE
Offline map region download + cache (#120)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -468,6 +468,11 @@ class OmniTAKApp : Application() {
     val rasterOverlayStore: soy.engindearing.omnitak.mobile.data.RasterOverlayStore by lazy {
         soy.engindearing.omnitak.mobile.data.RasterOverlayStore(this)
     }
+    /** Downloaded offline map regions (#120) — each is an MBTiles file served
+     *  by the shared MBTilesServer so the map works with no network. */
+    val offlineRegionStore: soy.engindearing.omnitak.mobile.data.offline.OfflineRegionStore by lazy {
+        soy.engindearing.omnitak.mobile.data.offline.OfflineRegionStore(this)
+    }
 
     /** Single Remote ID track roster shared by the phone scanner and the
      *  gyb sensor. One store means either source refreshes a drone's

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/OfflineMbtilesWriter.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/OfflineMbtilesWriter.kt
@@ -1,0 +1,105 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import java.io.File
+
+/**
+ * Writable MBTiles file backing a downloaded region (#120). Creates the
+ * standard MBTiles 1.3 schema (a `metadata` table + a `tiles` table keyed by
+ * zoom_level/tile_column/tile_row in TMS order) and implements [TileSink] so
+ * [TileCacheWriter] / [RegionDownloader] can stream tiles straight in.
+ *
+ * Because the file is a bog-standard MBTiles, the existing read+serve path —
+ * [soy.engindearing.omnitak.mobile.data.MBTilesDb] +
+ * [soy.engindearing.omnitak.mobile.data.MBTilesServer] — reads it back with
+ * no new code: the offline-serve story is "register the file as an MBTiles
+ * overlay". That reuse is the whole point of writing MBTiles rather than a
+ * bespoke cache format.
+ *
+ * Device/instrumented-verified: SQLite is an Android API with no JVM impl in
+ * this module's unit-test config. The key/flip logic it relies on is covered
+ * by [TileStoreRoundTripTest] over an in-memory [TileSink]; this class is the
+ * thin SQLite binding around that logic.
+ */
+class OfflineMbtilesWriter private constructor(
+    private val db: SQLiteDatabase,
+    val format: String,
+) : TileSink, AutoCloseable {
+
+    override fun put(z: Int, column: Int, tmsRow: Int, data: ByteArray) {
+        val cv = ContentValues(4).apply {
+            put("zoom_level", z)
+            put("tile_column", column)
+            put("tile_row", tmsRow)
+            put("tile_data", data)
+        }
+        db.insertWithOnConflict("tiles", null, cv, SQLiteDatabase.CONFLICT_REPLACE)
+    }
+
+    override fun get(z: Int, column: Int, tmsRow: Int): ByteArray? = runCatching {
+        db.rawQuery(
+            "SELECT tile_data FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?",
+            arrayOf(z.toString(), column.toString(), tmsRow.toString()),
+        ).use { c -> if (c.moveToFirst()) c.getBlob(0) else null }
+    }.getOrNull()
+
+    /** Number of tiles written so far. */
+    fun tileCount(): Int = runCatching {
+        db.rawQuery("SELECT COUNT(*) FROM tiles", null).use { c ->
+            if (c.moveToFirst()) c.getInt(0) else 0
+        }
+    }.getOrDefault(0)
+
+    /**
+     * Stamp the MBTiles `metadata` table from a finished region so the file
+     * is a valid, self-describing MBTiles (and the existing
+     * [soy.engindearing.omnitak.mobile.data.MBTilesDb] reader picks up the
+     * right zoom range + bounds).
+     */
+    fun writeMetadata(region: OfflineRegion) {
+        fun meta(name: String, value: String) {
+            db.insertWithOnConflict(
+                "metadata", null,
+                ContentValues(2).apply { put("name", name); put("value", value) },
+                SQLiteDatabase.CONFLICT_REPLACE,
+            )
+        }
+        meta("name", region.name)
+        meta("format", format)
+        meta("type", "baselayer")
+        meta("version", "1.0")
+        meta("minzoom", region.minZoom.toString())
+        meta("maxzoom", region.maxZoom.toString())
+        // MBTiles bounds are "west,south,east,north" in WGS84.
+        meta("bounds", "${region.west},${region.south},${region.east},${region.north}")
+        meta("description", "OmniTAK offline region")
+    }
+
+    override fun close() {
+        runCatching { db.close() }
+    }
+
+    companion object {
+        /**
+         * Create (or open) a writable MBTiles file at [path] and ensure the
+         * schema exists. [format] is the tile image type stored ("png" /
+         * "jpg") — drives the metadata + the content-type the server returns.
+         */
+        fun create(path: String, format: String = "png"): OfflineMbtilesWriter {
+            File(path).parentFile?.mkdirs()
+            val db = SQLiteDatabase.openOrCreateDatabase(path, null)
+            db.execSQL(
+                "CREATE TABLE IF NOT EXISTS tiles (" +
+                    "zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB)",
+            )
+            db.execSQL(
+                "CREATE UNIQUE INDEX IF NOT EXISTS tile_index ON tiles " +
+                    "(zoom_level, tile_column, tile_row)",
+            )
+            db.execSQL("CREATE TABLE IF NOT EXISTS metadata (name TEXT, value TEXT)")
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS metadata_name ON metadata (name)")
+            return OfflineMbtilesWriter(db, format)
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/OfflineRegion.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/OfflineRegion.kt
@@ -1,0 +1,65 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Metadata for one downloaded offline region (#120). The tiles themselves
+ * live in [fileName] (a standard MBTiles SQLite file under the app's
+ * `offline-tiles/` dir), which the existing
+ * [soy.engindearing.omnitak.mobile.data.MBTilesDb] reads and
+ * [soy.engindearing.omnitak.mobile.data.MBTilesServer] serves — so a region
+ * is, on the map, just another raster tile source.
+ */
+@Serializable
+data class OfflineRegion(
+    val id: String,
+    val name: String,
+    val fileName: String,
+    val north: Double,
+    val south: Double,
+    val east: Double,
+    val west: Double,
+    val minZoom: Int,
+    val maxZoom: Int,
+    /** Tiles successfully written (for the manage/list UI). */
+    val tileCount: Int,
+    /** On-disk size of the MBTiles file in bytes. */
+    val sizeBytes: Long,
+    val createdAt: Long,
+    /** Which basemap the tiles were pulled from, for display ("OSM", "Topo"…). */
+    val sourceLabel: String = "",
+    val visible: Boolean = true,
+) {
+    /** True if [lat]/[lon] falls inside this region's bbox. */
+    fun contains(lat: Double, lon: Double): Boolean =
+        lat in south..north && lon in west..east
+
+    /** True if [z] is within the downloaded zoom range. */
+    fun coversZoom(z: Int): Boolean = z in minZoom..maxZoom
+
+    fun bbox(): BoundingBox = BoundingBox(north, south, east, west)
+}
+
+/** The rendering decision for the current online/offline state. */
+data class OfflineDecision(
+    /** Region ids whose cached layers should be present on the map. */
+    val activeRegionIds: List<String>,
+    /** True when cached layers should be drawn *above* the live basemap so
+     *  they win — i.e. the network is down. When false, cached layers are
+     *  still added (free, instant) but the live basemap shows through outside
+     *  downloaded areas. */
+    val cachePreferred: Boolean,
+)
+
+/**
+ * Pure policy for "serve from cache when offline". Kept free of Android and
+ * MapLibre types so it unit-tests directly; the map layer translates an
+ * [OfflineDecision] into raster source/layer ordering on device.
+ */
+object OfflineTilePolicy {
+    fun decide(regions: List<OfflineRegion>, networkAvailable: Boolean): OfflineDecision =
+        OfflineDecision(
+            activeRegionIds = regions.filter { it.visible }.map { it.id },
+            cachePreferred = !networkAvailable && regions.any { it.visible },
+        )
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/OfflineRegionStore.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/OfflineRegionStore.kt
@@ -1,0 +1,199 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import soy.engindearing.omnitak.mobile.data.MBTilesDb
+import soy.engindearing.omnitak.mobile.data.MBTilesServer
+import java.io.File
+import java.util.UUID
+
+/** Live progress for the in-flight region download (UI binds to this). */
+data class RegionDownloadProgress(
+    val regionId: String,
+    val processed: Int,
+    val total: Long,
+    val downloaded: Int,
+    val failed: Int,
+) {
+    val fraction: Float get() = if (total <= 0) 0f else (processed.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+}
+
+/**
+ * Owns the set of downloaded offline regions (#120): runs downloads, persists
+ * region metadata, registers each finished region's MBTiles file with the
+ * shared [MBTilesServer] (so it serves over the same in-app tile HTTP path),
+ * and exposes list/delete.
+ *
+ * A downloaded region is a standard MBTiles file, so once registered the map
+ * renders it exactly like an imported MBTiles overlay (#33) — no new render
+ * path. [OfflineTilePolicy] decides ordering vs the live basemap; the map
+ * layer consumes that decision.
+ */
+class OfflineRegionStore(private val context: Context) {
+
+    private val dir = File(context.filesDir, "offline-tiles").apply { mkdirs() }
+    private val metaFile = File(dir, "regions.json")
+    private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
+
+    private val _regions = MutableStateFlow(load())
+    val regions: StateFlow<List<OfflineRegion>> = _regions.asStateFlow()
+
+    private val _progress = MutableStateFlow<RegionDownloadProgress?>(null)
+    val progress: StateFlow<RegionDownloadProgress?> = _progress.asStateFlow()
+
+    private val _lastError = MutableStateFlow<String?>(null)
+    val lastError: StateFlow<String?> = _lastError.asStateFlow()
+
+    @Volatile private var activeDownloader: RegionDownloader? = null
+
+    init {
+        // Re-register persisted regions with the tile server on launch so
+        // they serve immediately (mirrors MBTilesOverlayStore.init).
+        _regions.value.forEach { r ->
+            MBTilesDb.open(fileFor(r).absolutePath)?.let { MBTilesServer.register(serverId(r.id), it) }
+        }
+    }
+
+    fun fileFor(region: OfflineRegion): File = File(dir, region.fileName)
+    /** Server-registration id — distinct namespace from imported MBTiles. */
+    private fun serverId(regionId: String) = "offline-$regionId"
+    fun tileUrlTemplate(region: OfflineRegion): String? =
+        MBTilesServer.tileUrlTemplate(serverId(region.id))
+
+    /** Estimate before committing (drives the UI's count + size readout). */
+    fun estimate(bbox: BoundingBox, minZoom: Int, maxZoom: Int): Pair<Long, Long> {
+        val count = TileMath.tileCount(bbox, minZoom, maxZoom)
+        return count to (count * TileMath.AVG_TILE_BYTES)
+    }
+
+    /**
+     * Download [bbox] over [minZoom]..[maxZoom] from [template], writing into
+     * a fresh MBTiles file, then persist + register the region. Returns the
+     * created [OfflineRegion] on success, null if nothing was cached (all
+     * fetches failed) or it was cancelled before any tile landed.
+     *
+     * Device-pending end-to-end: drives real HTTP + SQLite. The orchestration
+     * + tile math + cache-key logic are unit-verified
+     * ([RegionDownloaderTest], [TileMathTest], [TileStoreRoundTripTest]).
+     */
+    suspend fun download(
+        name: String,
+        bbox: BoundingBox,
+        minZoom: Int,
+        maxZoom: Int,
+        template: String,
+        sourceLabel: String = "",
+        fetch: suspend (String) -> ByteArray? = HttpTileFetcher::fetch,
+    ): OfflineRegion? {
+        _lastError.value = null
+        val id = UUID.randomUUID().toString()
+        val file = File(dir, "$id.mbtiles")
+        val total = TileMath.tileCount(bbox, minZoom, maxZoom)
+        _progress.value = RegionDownloadProgress(id, 0, total, 0, 0)
+
+        return try {
+            val writer = OfflineMbtilesWriter.create(file.absolutePath)
+            val downloader = RegionDownloader(sink = writer, fetch = fetch)
+            activeDownloader = downloader
+            val result = downloader.download(bbox, minZoom, maxZoom, template) { done, t ->
+                val cur = _progress.value
+                _progress.value = RegionDownloadProgress(
+                    id, done, t,
+                    downloaded = cur?.downloaded ?: 0,
+                    failed = cur?.failed ?: 0,
+                )
+            }
+            val region = OfflineRegion(
+                id = id, name = name.ifBlank { "Region" }, fileName = file.name,
+                north = bbox.normN, south = bbox.normS, east = bbox.normE, west = bbox.normW,
+                minZoom = minOf(minZoom, maxZoom).coerceIn(0, TileMath.MAX_ZOOM),
+                maxZoom = maxOf(minZoom, maxZoom).coerceIn(0, TileMath.MAX_ZOOM),
+                tileCount = result.downloaded + result.skipped,
+                sizeBytes = file.length(),
+                createdAt = System.currentTimeMillis(),
+                sourceLabel = sourceLabel,
+            )
+            writer.writeMetadata(region)
+            writer.close()
+            activeDownloader = null
+
+            // Nothing cached (offline / all failed) → don't keep an empty file.
+            if (region.tileCount == 0) {
+                file.delete()
+                _progress.value = null
+                if (result.failed > 0) _lastError.value = "Download failed — no tiles cached (network?)."
+                return null
+            }
+
+            // Register so it serves immediately, persist metadata.
+            MBTilesDb.open(file.absolutePath)?.let { MBTilesServer.register(serverId(id), it) }
+            _regions.value = _regions.value + region
+            persist()
+            _progress.value = null
+            region
+        } catch (e: Exception) {
+            file.delete()
+            activeDownloader = null
+            _progress.value = null
+            _lastError.value = "Offline download failed: ${e.message}"
+            null
+        }
+    }
+
+    /** Cancel the in-flight download, if any. */
+    fun cancel() {
+        activeDownloader?.cancel()
+    }
+
+    fun setVisible(id: String, visible: Boolean) {
+        _regions.value = _regions.value.map { if (it.id == id) it.copy(visible = visible) else it }
+        persist()
+    }
+
+    fun rename(id: String, name: String) {
+        val t = name.trim(); if (t.isEmpty()) return
+        _regions.value = _regions.value.map { if (it.id == id) it.copy(name = t) else it }
+        persist()
+    }
+
+    fun remove(id: String) {
+        MBTilesServer.unregister(serverId(id))
+        _regions.value.firstOrNull { it.id == id }?.let { fileFor(it).delete() }
+        _regions.value = _regions.value.filterNot { it.id == id }
+        persist()
+    }
+
+    fun removeAll() {
+        _regions.value.forEach { MBTilesServer.unregister(serverId(it.id)); fileFor(it).delete() }
+        _regions.value = emptyList()
+        persist()
+    }
+
+    /** Current network state — feeds [OfflineTilePolicy.decide]. */
+    fun networkAvailable(): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+            ?: return true
+        val net = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(net) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    private fun persist() {
+        runCatching { metaFile.writeText(json.encodeToString(_regions.value)) }
+    }
+
+    private fun load(): List<OfflineRegion> {
+        if (!metaFile.exists()) return emptyList()
+        return runCatching {
+            json.decodeFromString<List<OfflineRegion>>(metaFile.readText())
+                .filter { File(dir, it.fileName).exists() }
+        }.getOrDefault(emptyList())
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/RegionDownloader.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/RegionDownloader.kt
@@ -1,0 +1,161 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Outcome of a region download run.
+ *
+ * [downloaded] = tiles freshly fetched and written. [skipped] = tiles already
+ * in the cache (resume). [failed] = fetch errors (404 / offline). Progress
+ * for the UI is (downloaded + skipped + failed) out of [total].
+ */
+data class DownloadResult(
+    val total: Long,
+    val downloaded: Int,
+    val skipped: Int,
+    val failed: Int,
+    val completed: Boolean,
+) {
+    /** Tiles processed so far — what a progress bar measures against [total]. */
+    val processed: Int get() = downloaded + skipped + failed
+}
+
+/**
+ * Orchestrates an offline region download (#120): enumerate the bbox×zoom
+ * tile set, fetch each tile from the active source template with a bounded
+ * number of concurrent requests, write hits into the [TileSink], and report
+ * progress. Honours cancellation and (optionally) skips tiles already in the
+ * cache so an interrupted download resumes cheaply.
+ *
+ * The HTTP fetch is injected ([fetch]) so this orchestration is pure,
+ * deterministic, and unit-testable. The production fetch is
+ * [HttpTileFetcher.fetch] (a thin HttpURLConnection call — device-verified).
+ *
+ * Concurrency is intentionally capped (default [DEFAULT_CONCURRENCY]) to
+ * respect public tile-server usage policy; the UI further caps the zoom
+ * depth via [TileMath.MAX_ZOOM].
+ */
+class RegionDownloader(
+    private val sink: TileSink,
+    private val fetch: suspend (url: String) -> ByteArray?,
+    private val concurrency: Int = DEFAULT_CONCURRENCY,
+    private val skipExisting: Boolean = true,
+    private val subdomains: List<String> = listOf("a", "b", "c"),
+) {
+    private val writer = TileCacheWriter(sink)
+    private val cancelled = AtomicBoolean(false)
+
+    /** Request the in-flight download stop as soon as possible. */
+    fun cancel() { cancelled.set(true) }
+
+    /**
+     * Run the download. Suspends until every tile has been attempted or the
+     * download is cancelled. [onProgress] fires (done, total) as tiles
+     * complete — already-cached skips count as done so the bar still fills.
+     */
+    suspend fun download(
+        bbox: BoundingBox,
+        minZoom: Int,
+        maxZoom: Int,
+        template: String,
+        onProgress: (done: Int, total: Long) -> Unit = { _, _ -> },
+    ): DownloadResult {
+        cancelled.set(false)
+        val tiles = TileMath.enumerateTiles(bbox, minZoom, maxZoom)
+        val total = tiles.size.toLong()
+        val done = AtomicInteger(0)       // processed (for progress)
+        val downloaded = AtomicInteger(0) // fresh successful writes
+        val skipped = AtomicInteger(0)    // already-cached hits
+        val failed = AtomicInteger(0)     // fetch errors
+
+        val gate = Semaphore(concurrency.coerceAtLeast(1))
+        runCatching {
+            coroutineScope {
+                for (tile in tiles) {
+                    if (cancelled.get()) break
+                    launch(Dispatchers.IO) {
+                        if (cancelled.get()) return@launch
+                        gate.withPermit {
+                            if (cancelled.get()) return@withPermit
+                            // Resume optimization: a tile already cached is a
+                            // hit — count it, don't re-fetch.
+                            if (skipExisting && isCached(tile)) {
+                                skipped.incrementAndGet()
+                                onProgress(done.incrementAndGet(), total)
+                                return@withPermit
+                            }
+                            val url = TileMath.fillTemplate(template, tile, subdomains)
+                            val bytes = runCatching { fetch(url) }.getOrNull()
+                            if (bytes != null && bytes.isNotEmpty()) {
+                                writer.writeXyz(tile, bytes)
+                                downloaded.incrementAndGet()
+                            } else {
+                                failed.incrementAndGet()
+                            }
+                            onProgress(done.incrementAndGet(), total)
+                        }
+                    }
+                }
+            }
+        }.onFailure { if (it is CancellationException) cancelled.set(true) else throw it }
+
+        val finished = !cancelled.get()
+        return DownloadResult(
+            total = total,
+            downloaded = downloaded.get(),
+            skipped = skipped.get(),
+            failed = failed.get(),
+            completed = finished,
+        )
+    }
+
+    private fun isCached(tile: Tile): Boolean =
+        sink.get(tile.z, tile.x, MbtilesRow.xyzToTms(tile.z, tile.y)) != null
+
+    companion object {
+        /** Polite default — public OSM/Topo servers throttle aggressive
+         *  parallel pulls. Operators on a private LAN tile server can run
+         *  hotter, but the floor protects the shared sources. */
+        const val DEFAULT_CONCURRENCY = 4
+    }
+}
+
+/**
+ * Production tile fetch over HTTP — a thin HttpURLConnection GET, mirroring
+ * the proven pattern in
+ * [soy.engindearing.omnitak.mobile.data.uas.TerrainSampler]. Returns the raw
+ * tile bytes on 200, null on any non-200 / IO error (the downloader counts
+ * those as failures without aborting the whole region).
+ *
+ * Device-pending: exercised against a real tile server on device, not in JVM
+ * unit tests (which inject a fake fetch into [RegionDownloader]).
+ */
+object HttpTileFetcher {
+    private const val TIMEOUT_MS = 8_000
+    private const val USER_AGENT = "OmniTAK-Android offline-tile-cache"
+
+    suspend fun fetch(url: String): ByteArray? = withContext(Dispatchers.IO) {
+        val conn = (java.net.URL(url).openConnection() as java.net.HttpURLConnection).apply {
+            connectTimeout = TIMEOUT_MS
+            readTimeout = TIMEOUT_MS
+            requestMethod = "GET"
+            setRequestProperty("User-Agent", USER_AGENT)
+        }
+        try {
+            if (conn.responseCode != 200) return@withContext null
+            conn.inputStream.use { it.readBytes() }
+        } catch (e: java.io.IOException) {
+            null
+        } finally {
+            conn.disconnect()
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/TileCache.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/TileCache.kt
@@ -1,0 +1,47 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+/**
+ * MBTiles row addressing. An MBTiles `tiles` table is keyed by
+ * (zoom_level, tile_column, tile_row) where tile_row is in TMS order
+ * (origin bottom-left, y grows north). The map requests XYZ (origin
+ * top-left, y grows south), so a Y flip bridges the two.
+ *
+ * This is the exact identity [soy.engindearing.omnitak.mobile.data.MBTilesDb]
+ * applies on read; the offline writer applies it on write so tiles persisted
+ * here are served back correctly by the existing read path.
+ */
+object MbtilesRow {
+    /** XYZ y -> MBTiles TMS tile_row at zoom [z]. */
+    fun xyzToTms(z: Int, y: Int): Int = (1 shl z) - 1 - y
+    /** MBTiles TMS tile_row -> XYZ y at zoom [z] (same formula, self-inverse). */
+    fun tmsToXyz(z: Int, tmsRow: Int): Int = (1 shl z) - 1 - tmsRow
+}
+
+/**
+ * Write-side storage for raw tile blobs, keyed exactly like the MBTiles
+ * `tiles` table: (zoom_level, tile_column, tile_row[TMS]). The on-device
+ * implementation ([OfflineMbtilesWriter]) backs this with a writable
+ * SQLite MBTiles file; tests back it with an in-memory map to verify the
+ * key/flip logic without an Android SQLite runtime.
+ */
+interface TileSink {
+    fun put(z: Int, column: Int, tmsRow: Int, data: ByteArray)
+    fun get(z: Int, column: Int, tmsRow: Int): ByteArray? = null
+}
+
+/**
+ * Bridges XYZ tile coordinates (what the downloader fetches and the map
+ * requests) to MBTiles TMS rows (what the [TileSink] stores). Pure logic —
+ * no Android dependency — so the round-trip is unit-testable.
+ */
+class TileCacheWriter(private val sink: TileSink) {
+
+    /** Persist an XYZ tile's bytes, flipping Y to the MBTiles TMS row. */
+    fun writeXyz(tile: Tile, data: ByteArray) {
+        sink.put(tile.z, tile.x, MbtilesRow.xyzToTms(tile.z, tile.y), data)
+    }
+
+    /** Read back an XYZ tile's bytes (mirrors the write flip). */
+    fun readXyz(tile: Tile): ByteArray? =
+        sink.get(tile.z, tile.x, MbtilesRow.xyzToTms(tile.z, tile.y))
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/TileMath.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/TileMath.kt
@@ -1,0 +1,195 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import soy.engindearing.omnitak.mobile.data.MapProvider
+import kotlin.math.PI
+import kotlin.math.asinh
+import kotlin.math.tan
+
+/** A single Web-Mercator slippy-map tile. */
+data class Tile(val z: Int, val x: Int, val y: Int)
+
+/**
+ * Geographic bounding box in WGS84 degrees. Corners may arrive in any
+ * order (a drag rectangle can be top-left→bottom-right or reversed); the
+ * tile math normalizes via [normN]/[normS]/[normE]/[normW].
+ */
+data class BoundingBox(
+    val north: Double,
+    val south: Double,
+    val east: Double,
+    val west: Double,
+) {
+    val normN: Double get() = maxOf(north, south)
+    val normS: Double get() = minOf(north, south)
+    val normE: Double get() = maxOf(east, west)
+    val normW: Double get() = minOf(east, west)
+}
+
+/**
+ * Pure Web-Mercator (EPSG:3857 / XYZ slippy-map) tile math for offline
+ * region download (#120). No Android dependencies so it unit-tests as
+ * plain JVM code.
+ *
+ * NOTE: this is the standard Web-Mercator scheme the basemaps use (OSM,
+ * OpenTopoMap, ESRI World Imagery, custom WMTS/XYZ). It is deliberately
+ * separate from [soy.engindearing.omnitak.mobile.data.uas.TerrainSampler],
+ * which speaks the *WGS84* 2·2^z grid TAK Terrain publishes — a different
+ * projection that would plot the wrong tiles for these basemaps.
+ *
+ * Formulae per the OSM slippy-map tilenames spec:
+ *   x = floor((lon + 180) / 360 · 2^z)
+ *   y = floor((1 − asinh(tan(lat)) / π) / 2 · 2^z)
+ */
+object TileMath {
+
+    /** Hard cap on download zoom. z19 is the practical max for raster XYZ
+     *  sources (OSM/Topo stop there); going deeper explodes tile counts. */
+    const val MAX_ZOOM = 19
+
+    /** Web-Mercator latitude clamp — the projection is undefined past this. */
+    private const val MAX_LAT = 85.05112878
+    private const val MIN_LAT = -85.05112878
+
+    /** Average compressed bytes per 256px raster tile, used for the
+     *  pre-download size estimate. ~22 KB is a realistic mean across mixed
+     *  PNG/JPEG basemap tiles (empty ocean tiles are tiny, dense urban PNGs
+     *  run 50–100 KB). The estimate is advisory, not a guarantee. */
+    const val AVG_TILE_BYTES = 22_000L
+
+    // --- lon/lat/z -> x/y -------------------------------------------------
+
+    fun lonToTileX(lonDeg: Double, z: Int): Int {
+        val zc = z.coerceIn(0, MAX_ZOOM)
+        val n = 1 shl zc
+        val x = Math.floor((lonDeg + 180.0) / 360.0 * n).toInt()
+        return x.coerceIn(0, n - 1)
+    }
+
+    fun latToTileY(latDeg: Double, z: Int): Int {
+        val zc = z.coerceIn(0, MAX_ZOOM)
+        val n = 1 shl zc
+        val lat = latDeg.coerceIn(MIN_LAT, MAX_LAT)
+        val latRad = lat * PI / 180.0
+        val y = Math.floor((1.0 - asinh(tan(latRad)) / PI) / 2.0 * n).toInt()
+        return y.coerceIn(0, n - 1)
+    }
+
+    // --- enumeration ------------------------------------------------------
+
+    /**
+     * All tiles covering [bbox] across the inclusive zoom range
+     * [minZoom]..[maxZoom]. Zoom bounds are order-independent and clamped
+     * to 0..[MAX_ZOOM]. North/west map to the min tile indices, south/east
+     * to the max (XYZ y grows southward).
+     */
+    fun enumerateTiles(bbox: BoundingBox, minZoom: Int, maxZoom: Int): List<Tile> {
+        val (lo, hi) = zoomRange(minZoom, maxZoom)
+        val out = ArrayList<Tile>()
+        for (z in lo..hi) {
+            val xMin = lonToTileX(bbox.normW, z)
+            val xMax = lonToTileX(bbox.normE, z)
+            val yMin = latToTileY(bbox.normN, z) // north = smaller y
+            val yMax = latToTileY(bbox.normS, z) // south = larger y
+            for (x in xMin..xMax) for (y in yMin..yMax) out.add(Tile(z, x, y))
+        }
+        return out
+    }
+
+    /** Tile count for [bbox] over [minZoom]..[maxZoom] without materializing
+     *  the list (cheap enough to call on every UI slider move). */
+    fun tileCount(bbox: BoundingBox, minZoom: Int, maxZoom: Int): Long {
+        val (lo, hi) = zoomRange(minZoom, maxZoom)
+        var total = 0L
+        for (z in lo..hi) {
+            val xMin = lonToTileX(bbox.normW, z)
+            val xMax = lonToTileX(bbox.normE, z)
+            val yMin = latToTileY(bbox.normN, z)
+            val yMax = latToTileY(bbox.normS, z)
+            total += (xMax - xMin + 1).toLong() * (yMax - yMin + 1).toLong()
+        }
+        return total
+    }
+
+    /** Rough download size in bytes = tile count × [AVG_TILE_BYTES]. */
+    fun estimateBytes(bbox: BoundingBox, minZoom: Int, maxZoom: Int): Long =
+        tileCount(bbox, minZoom, maxZoom) * AVG_TILE_BYTES
+
+    private fun zoomRange(a: Int, b: Int): Pair<Int, Int> {
+        val lo = minOf(a, b).coerceIn(0, MAX_ZOOM)
+        val hi = maxOf(a, b).coerceIn(0, MAX_ZOOM)
+        return lo to hi
+    }
+
+    // --- URL template fill ------------------------------------------------
+
+    /**
+     * Substitute a tile's z/x/y into an XYZ/TMS URL template, respecting the
+     * literal token order ({z}/{y}/{x} for ESRI is handled correctly). If a
+     * `{s}` subdomain token is present, [subdomains] are rotated
+     * deterministically by (x + y) so retries hit a stable host.
+     */
+    fun fillTemplate(template: String, tile: Tile, subdomains: List<String> = emptyList()): String {
+        var url = template
+            .replace("{z}", tile.z.toString())
+            .replace("{x}", tile.x.toString())
+            .replace("{y}", tile.y.toString())
+        if (url.contains("{s}") && subdomains.isNotEmpty()) {
+            val s = subdomains[Math.floorMod(tile.x + tile.y, subdomains.size)]
+            url = url.replace("{s}", s)
+        }
+        return url
+    }
+
+    // --- provider -> template ---------------------------------------------
+
+    /**
+     * Resolve the active [MapProvider] to the concrete XYZ tile-URL template
+     * to download from. Mirrors the basemap URLs baked into
+     * [soy.engindearing.omnitak.mobile.ui.components.styleJsonForProvider] so
+     * the cached tiles match what the live map renders.
+     *
+     * Returns null when no fixed raster template exists — i.e. WMTS_CUSTOM
+     * with a blank/invalid URL (the caller blocks the download and tells the
+     * operator to set a tile source first).
+     */
+    fun templateForProvider(provider: MapProvider, customTileUrl: String): String? = when (provider) {
+        MapProvider.OSM_RASTER -> "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+        MapProvider.TOPO_HINT -> "https://a.tile.opentopomap.org/{z}/{x}/{y}.png"
+        MapProvider.SATELLITE_HINT ->
+            "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+        MapProvider.WMTS_CUSTOM -> {
+            val url = normalizeTemplate(customTileUrl)
+            if (url.startsWith("http") && url.contains("{z}") && url.contains("{x}") && url.contains("{y}")) url
+            else null
+        }
+    }
+
+    /**
+     * Normalize ATAK/CivTAK `{$z}` and shell `${z}` placeholder forms to the
+     * MapLibre `{z}` convention and trim stray whitespace. Kept in sync with
+     * the map's `normalizeTileUrlPlaceholders`; duplicated here so the math
+     * layer carries no UI dependency.
+     */
+    internal fun normalizeTemplate(raw: String): String {
+        if (raw.isEmpty()) return raw
+        var out = raw.trim()
+        for (t in listOf("z", "x", "y", "s", "q", "r")) {
+            out = out.replace("\${$t}", "{$t}").replace("{\$$t}", "{$t}")
+        }
+        return out
+    }
+
+    // --- humanize ---------------------------------------------------------
+
+    /** Human-readable byte size, e.g. 1536 -> "1.5 KB". */
+    fun humanizeBytes(bytes: Long): String {
+        if (bytes < 1024) return "$bytes B"
+        val units = listOf("KB", "MB", "GB", "TB")
+        var value = bytes.toDouble() / 1024.0
+        var idx = 0
+        while (value >= 1024.0 && idx < units.size - 1) {
+            value /= 1024.0; idx++
+        }
+        return String.format("%.1f %s", value, units[idx])
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/KmlOverlayRenderer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/KmlOverlayRenderer.kt
@@ -188,4 +188,47 @@ object KmlOverlayRenderer {
             )
         }
     }
+
+    // Downloaded offline regions (#120). Each region is an MBTiles file
+    // served by the same in-app tile server, so it renders exactly like an
+    // imported MBTiles overlay — just a raster source/layer. The
+    // OfflineTilePolicy decision controls whether these sit above the live
+    // basemap (offline → cache wins) or are simply present (online).
+    private val installedOffline = mutableSetOf<String>()
+
+    fun applyOfflineRegions(
+        style: Style,
+        regions: List<soy.engindearing.omnitak.mobile.data.offline.OfflineRegion>,
+        store: soy.engindearing.omnitak.mobile.data.offline.OfflineRegionStore,
+        decision: soy.engindearing.omnitak.mobile.data.offline.OfflineDecision,
+    ) {
+        val wanted = decision.activeRegionIds.toSet()
+        for (id in installedOffline - wanted) {
+            style.removeLayer("offlinelyr-$id")
+            style.removeSource("offlinesrc-$id")
+        }
+        installedOffline.clear()
+        installedOffline.addAll(wanted)
+
+        for (region in regions) {
+            if (region.id !in wanted) continue
+            val sourceId = "offlinesrc-${region.id}"
+            val layerId = "offlinelyr-${region.id}"
+            if (style.getSource(sourceId) == null) {
+                val template = store.tileUrlTemplate(region) ?: continue
+                val tileSet = TileSet("2.1.0", template).apply {
+                    minZoom = region.minZoom.toFloat()
+                    maxZoom = region.maxZoom.toFloat()
+                }
+                style.addSource(RasterSource(sourceId, tileSet, 256))
+                // When offline, draw cached tiles on top so they win over the
+                // (unreachable) live basemap; online, let it layer normally.
+                style.addLayer(RasterLayer(layerId, sourceId))
+            }
+            style.getLayerAs<RasterLayer>(layerId)?.setProperties(
+                PropertyFactory.visibility(Property.VISIBLE),
+                PropertyFactory.rasterOpacity(1.0f),
+            )
+        }
+    }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/LayersDialog.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/LayersDialog.kt
@@ -44,6 +44,7 @@ fun LayersDialog(
     onToggleCallsignCard: (Boolean) -> Unit,
     onToggleMeshNodes: (Boolean) -> Unit = {},
     onToggle3d: (Boolean) -> Unit = {},
+    onOpenOfflineMaps: (() -> Unit)? = null,
     onDismiss: () -> Unit,
 ) {
     AlertDialog(
@@ -65,6 +66,20 @@ fun LayersDialog(
                 LayerRow("Aircraft (ADSB)", aircraftVisible, onToggleAircraft)
                 LayerRow("Lat/Lon grid", gridEnabled, onToggleGrid)
                 LayerRow("Callsign card", callsignCardVisible, onToggleCallsignCard)
+                if (onOpenOfflineMaps != null) {
+                    TextButton(
+                        onClick = onOpenOfflineMaps,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp),
+                    ) {
+                        Text(
+                            "Offline maps…",
+                            color = TacticalAccent,
+                            fontFamily = FontFamily.Monospace,
+                        )
+                    }
+                }
             }
         },
         confirmButton = {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/OfflineMapsSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/OfflineMapsSheet.kt
@@ -1,0 +1,284 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RangeSlider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+import soy.engindearing.omnitak.mobile.OmniTAKApp
+import soy.engindearing.omnitak.mobile.data.MapProvider
+import soy.engindearing.omnitak.mobile.data.offline.BoundingBox
+import soy.engindearing.omnitak.mobile.data.offline.OfflineRegion
+import soy.engindearing.omnitak.mobile.data.offline.TileMath
+import soy.engindearing.omnitak.mobile.ui.theme.TacticalAccent
+import kotlin.math.roundToInt
+
+/**
+ * ATAK-style offline map download (#120). The operator picks a region — by
+ * default the current viewport [initialBbox] — and a min/max zoom range, sees
+ * a live tile-count + estimated-size readout, then downloads those tiles from
+ * the active basemap into a local MBTiles cache that serves with no network.
+ *
+ * Drag-a-rectangle region selection and the on-map render of cached tiles are
+ * device-pending; this sheet ships the viewport-based selection, the
+ * count/size estimate, the download with progress + cancel, and region
+ * management (list / delete).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OfflineMapsSheet(
+    initialBbox: BoundingBox?,
+    provider: MapProvider,
+    customTileUrl: String,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val app = context.applicationContext as OmniTAKApp
+    val store = app.offlineRegionStore
+    val scope = rememberCoroutineScope()
+    val sheet = rememberModalBottomSheetState()
+
+    val regions by store.regions.collectAsState()
+    val progress by store.progress.collectAsState()
+    val error by store.lastError.collectAsState()
+
+    val template = remember(provider, customTileUrl) {
+        TileMath.templateForProvider(provider, customTileUrl)
+    }
+    val sourceLabel = when (provider) {
+        MapProvider.OSM_RASTER -> "OSM"
+        MapProvider.TOPO_HINT -> "Topo"
+        MapProvider.SATELLITE_HINT -> "Satellite"
+        MapProvider.WMTS_CUSTOM -> "Custom"
+    }
+
+    var zoomRange by remember { mutableStateOf(10f..15f) }
+    val minZoom = zoomRange.start.roundToInt()
+    val maxZoom = zoomRange.endInclusive.roundToInt()
+
+    val tileCount = remember(initialBbox, minZoom, maxZoom) {
+        if (initialBbox == null) 0L else TileMath.tileCount(initialBbox, minZoom, maxZoom)
+    }
+    val sizeText = remember(tileCount) { TileMath.humanizeBytes(tileCount * TileMath.AVG_TILE_BYTES) }
+
+    val downloading = progress != null
+    val canDownload = initialBbox != null && template != null && tileCount > 0 && !downloading
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheet, containerColor = Color(0xFF0F1115)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp),
+        ) {
+            Text(
+                "Offline maps",
+                color = Color.White,
+                fontFamily = FontFamily.Monospace,
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Download the current map view for use with no network.",
+                color = Color.White.copy(alpha = 0.6f),
+                fontSize = 13.sp,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            if (template == null) {
+                Text(
+                    "Set a tile source first (a custom WMTS/XYZ URL needs a value before it can be cached).",
+                    color = Color(0xFFFF9F0A),
+                    fontSize = 13.sp,
+                )
+            } else if (initialBbox == null) {
+                Text(
+                    "Pan the map to the area you want, then reopen this sheet.",
+                    color = Color(0xFFFF9F0A),
+                    fontSize = 13.sp,
+                )
+            } else {
+                Text("Source: $sourceLabel", color = Color.White.copy(alpha = 0.8f), fontSize = 13.sp)
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    "Zoom $minZoom – $maxZoom",
+                    color = Color.White,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 14.sp,
+                )
+                RangeSlider(
+                    value = zoomRange,
+                    onValueChange = { zoomRange = it },
+                    valueRange = 0f..TileMath.MAX_ZOOM.toFloat(),
+                    // Snap to integer zoom levels (MAX_ZOOM-1 internal stops).
+                    steps = TileMath.MAX_ZOOM - 1,
+                    enabled = !downloading,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "$tileCount tiles · ~$sizeText",
+                    color = TacticalAccent,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 14.sp,
+                )
+                if (tileCount > 50_000) {
+                    Text(
+                        "Large download — consider a tighter area or lower max zoom.",
+                        color = Color(0xFFFF9F0A),
+                        fontSize = 12.sp,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            if (downloading) {
+                val p = progress!!
+                LinearProgressIndicator(
+                    progress = { p.fraction },
+                    modifier = Modifier.fillMaxWidth(),
+                    color = TacticalAccent,
+                )
+                Spacer(Modifier.height(6.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text(
+                        "${p.processed} / ${p.total}",
+                        color = Color.White.copy(alpha = 0.8f),
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 13.sp,
+                    )
+                    TextButton(onClick = { store.cancel() }) {
+                        Text("Cancel", color = Color(0xFFFF453A))
+                    }
+                }
+            } else {
+                Button(
+                    onClick = {
+                        val bbox = initialBbox ?: return@Button
+                        val tpl = template ?: return@Button
+                        scope.launch {
+                            store.download(
+                                name = "$sourceLabel z$minZoom-$maxZoom",
+                                bbox = bbox, minZoom = minZoom, maxZoom = maxZoom,
+                                template = tpl, sourceLabel = sourceLabel,
+                            )
+                        }
+                    },
+                    enabled = canDownload,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = TacticalAccent),
+                ) {
+                    Text("Download this region", color = Color(0xFF0A1628), fontWeight = FontWeight.Bold)
+                }
+            }
+
+            if (error != null) {
+                Spacer(Modifier.height(8.dp))
+                Text(error!!, color = Color(0xFFFF453A), fontSize = 12.sp)
+            }
+
+            Spacer(Modifier.height(20.dp))
+            HorizontalDivider(color = Color.White.copy(alpha = 0.12f))
+            Spacer(Modifier.height(12.dp))
+
+            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "Downloaded regions (${regions.size})",
+                    color = Color.White,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 14.sp,
+                    modifier = Modifier.weight(1f),
+                )
+                if (regions.isNotEmpty()) {
+                    TextButton(onClick = { store.removeAll() }) {
+                        Text("Clear all", color = Color(0xFFFF453A), fontSize = 13.sp)
+                    }
+                }
+            }
+
+            if (regions.isEmpty()) {
+                Text(
+                    "No regions yet.",
+                    color = Color.White.copy(alpha = 0.5f),
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            } else {
+                LazyColumn(modifier = Modifier.height(180.dp)) {
+                    items(regions, key = { it.id }) { region ->
+                        RegionRow(
+                            region = region,
+                            onZoom = {
+                                KmlOverlayEvents.requestZoomBounds(region.north, region.south, region.east, region.west)
+                                onDismiss()
+                            },
+                            onDelete = { store.remove(region.id) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RegionRow(region: OfflineRegion, onZoom: () -> Unit, onDelete: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(region.name, color = Color.White, fontSize = 14.sp)
+            Text(
+                "z${region.minZoom}-${region.maxZoom} · ${region.tileCount} tiles · ${TileMath.humanizeBytes(region.sizeBytes)}",
+                color = Color.White.copy(alpha = 0.55f),
+                fontFamily = FontFamily.Monospace,
+                fontSize = 12.sp,
+            )
+        }
+        TextButton(onClick = onZoom) { Text("View", color = TacticalAccent, fontSize = 13.sp) }
+        IconButton(onClick = onDelete) {
+            Icon(Icons.Filled.Delete, contentDescription = "Delete region", tint = Color(0xFFFF453A))
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -219,6 +219,9 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     // callsignCardVisible, followMeActive are now read from userPrefs (above)
     // so they survive relaunch.
     var layersSheetOpen by remember { mutableStateOf(false) }
+    // #120 — offline map download sheet.
+    var offlineMapsOpen by remember { mutableStateOf(false) }
+    val offlineRegions by app.offlineRegionStore.regions.collectAsState()
     var teamsPanelOpen by remember { mutableStateOf(false) }
     var panTarget by remember { mutableStateOf<LatLng?>(null) }
     var panTargetTick by remember { mutableStateOf(0) }
@@ -337,6 +340,18 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         mapboxMap?.getStyle { style ->
             soy.engindearing.omnitak.mobile.ui.components.KmlOverlayRenderer
                 .applyRaster(style, rasterImagery, app.rasterOverlayStore)
+        }
+    }
+    // #120 — re-apply downloaded offline regions (cached MBTiles) when the
+    // set changes. OfflineTilePolicy decides whether cache wins (offline) or
+    // simply layers in (online). Device-pending: the on-map render itself.
+    LaunchedEffect(offlineRegions) {
+        mapboxMap?.getStyle { style ->
+            val decision = soy.engindearing.omnitak.mobile.data.offline.OfflineTilePolicy.decide(
+                offlineRegions, app.offlineRegionStore.networkAvailable(),
+            )
+            soy.engindearing.omnitak.mobile.ui.components.KmlOverlayRenderer
+                .applyOfflineRegions(style, offlineRegions, app.offlineRegionStore, decision)
         }
     }
     // Frame raster/MBTiles bounds on request.
@@ -2004,7 +2019,31 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                     scope.launch { app.userPrefsStore.setMeshNodesLayerVisible(v) }
                 },
                 onToggle3d = { v -> mutatePref { it.copy(map3dEnabled = v) } },
+                onOpenOfflineMaps = {
+                    layersSheetOpen = false
+                    offlineMapsOpen = true
+                },
                 onDismiss = { layersSheetOpen = false },
+            )
+        }
+
+        // #120 — offline map download. The default region is the current
+        // viewport (read from the live map projection); null until the map
+        // is ready, which the sheet handles gracefully.
+        if (offlineMapsOpen) {
+            val viewportBbox = remember(offlineMapsOpen) {
+                mapboxMap?.projection?.visibleRegion?.latLngBounds?.let { b ->
+                    soy.engindearing.omnitak.mobile.data.offline.BoundingBox(
+                        north = b.getLatNorth(), south = b.getLatSouth(),
+                        east = b.getLonEast(), west = b.getLonWest(),
+                    )
+                }
+            }
+            soy.engindearing.omnitak.mobile.ui.components.OfflineMapsSheet(
+                initialBbox = viewportBbox,
+                provider = userPrefs.mapProvider,
+                customTileUrl = userPrefs.customTileUrl,
+                onDismiss = { offlineMapsOpen = false },
             )
         }
 

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/OfflineTilePolicyTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/OfflineTilePolicyTest.kt
@@ -1,0 +1,74 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * "Serve from cache when offline" decision logic (#120).
+ *
+ * Given the set of downloaded regions and whether the network is up, decide
+ * whether a downloaded region's cached raster layer should be shown and
+ * whether it should sit *above* the live basemap (so it wins) or below.
+ *
+ * Pure policy — no Android — so it unit-tests directly. The on-map MapLibre
+ * wiring that consumes these decisions is device-verified.
+ */
+class OfflineTilePolicyTest {
+
+    private fun region(
+        id: String = "r1",
+        n: Double = 47.7, s: Double = 47.5, e: Double = -122.2, w: Double = -122.5,
+        minZ: Int = 8, maxZ: Int = 15,
+    ) = OfflineRegion(
+        id = id, name = id, fileName = "$id.mbtiles",
+        north = n, south = s, east = e, west = w,
+        minZoom = minZ, maxZoom = maxZ, tileCount = 0, sizeBytes = 0, createdAt = 0,
+    )
+
+    @Test fun no_regions_means_nothing_to_serve() {
+        val d = OfflineTilePolicy.decide(regions = emptyList(), networkAvailable = true)
+        assertTrue(d.activeRegionIds.isEmpty())
+        assertFalse(d.cachePreferred)
+    }
+
+    @Test fun offline_prefers_cache_over_live_basemap() {
+        // Network down + a downloaded region -> cache must win (drawn above
+        // the live source, which can't load anyway).
+        val d = OfflineTilePolicy.decide(regions = listOf(region()), networkAvailable = false)
+        assertTrue(d.cachePreferred)
+        assertEquals(listOf("r1"), d.activeRegionIds)
+    }
+
+    @Test fun online_still_serves_cache_but_does_not_force_it_on_top() {
+        // Online: cached regions stay available (free + fast) but don't
+        // override the live basemap globally — the live source renders areas
+        // outside any downloaded region.
+        val d = OfflineTilePolicy.decide(regions = listOf(region()), networkAvailable = true)
+        assertFalse(d.cachePreferred)
+        assertEquals(listOf("r1"), d.activeRegionIds)
+    }
+
+    @Test fun all_downloaded_regions_are_active() {
+        val regions = listOf(region("a"), region("b"), region("c"))
+        val d = OfflineTilePolicy.decide(regions = regions, networkAvailable = false)
+        assertEquals(listOf("a", "b", "c"), d.activeRegionIds)
+        assertTrue(d.cachePreferred)
+    }
+
+    @Test fun region_contains_point_inside_its_bbox() {
+        val r = region(n = 47.7, s = 47.5, e = -122.2, w = -122.5)
+        assertTrue(r.contains(47.6, -122.35))   // inside
+        assertFalse(r.contains(48.0, -122.35))  // north of bbox
+        assertFalse(r.contains(47.6, -121.0))   // east of bbox
+    }
+
+    @Test fun region_covers_zoom_within_its_range() {
+        val r = region(minZ = 8, maxZ = 15)
+        assertTrue(r.coversZoom(8))
+        assertTrue(r.coversZoom(15))
+        assertFalse(r.coversZoom(7))
+        assertFalse(r.coversZoom(16))
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/RegionDownloaderTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/RegionDownloaderTest.kt
@@ -1,0 +1,159 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Download orchestration for an offline region (#120): enumerate the tiles,
+ * fetch each from the active source template, write into the cache, report
+ * progress, and stop on cancel / skip tiles already cached.
+ *
+ * The real network fetch is an injected suspend lambda (device-pending — it
+ * hits the tile server over HTTP). Here it's faked so the *orchestration*
+ * (planning, progress accounting, concurrency bound, cancel, resume-skip) is
+ * exercised as plain JVM logic.
+ */
+class RegionDownloaderTest {
+
+    private fun bbox() = BoundingBox(north = 47.62, south = 47.60, east = -122.32, west = -122.34)
+
+    /** A sink that records every written XYZ-equivalent tile. */
+    private class CountingSink : TileSink {
+        val store = HashMap<Triple<Int, Int, Int>, ByteArray>()
+        override fun put(z: Int, column: Int, tmsRow: Int, data: ByteArray) {
+            store[Triple(z, column, tmsRow)] = data
+        }
+        override fun get(z: Int, column: Int, tmsRow: Int): ByteArray? = store[Triple(z, column, tmsRow)]
+    }
+
+    @Test fun downloads_every_tile_in_region_and_writes_to_cache() = runTest {
+        val sink = CountingSink()
+        val template = "https://tiles.test/{z}/{x}/{y}.png"
+        val expected = TileMath.tileCount(bbox(), 12, 14)
+        val fetched = AtomicInteger(0)
+
+        val downloader = RegionDownloader(
+            sink = sink,
+            fetch = { _ -> fetched.incrementAndGet(); byteArrayOf(0x1) },
+        )
+        val result = downloader.download(
+            bbox = bbox(), minZoom = 12, maxZoom = 14, template = template,
+        )
+
+        assertEquals(expected, result.total)
+        assertEquals(expected, result.downloaded.toLong())
+        assertEquals(0, result.skipped)
+        assertEquals(0, result.failed)
+        assertEquals(expected.toInt(), fetched.get())
+        assertEquals(expected.toInt(), sink.store.size)
+        assertTrue(result.completed)
+    }
+
+    @Test fun progress_is_reported_monotonically_up_to_total() = runTest {
+        val seen = ArrayList<Int>()
+        val downloader = RegionDownloader(
+            sink = CountingSink(),
+            fetch = { _ -> byteArrayOf(1) },
+            concurrency = 1,
+        )
+        val result = downloader.download(
+            bbox = bbox(), minZoom = 12, maxZoom = 13, template = "https://t/{z}/{x}/{y}",
+            onProgress = { done, _ -> seen.add(done) },
+        )
+        assertFalse(seen.isEmpty())
+        // non-decreasing, last == total (every tile processed exactly once)
+        for (i in 1 until seen.size) assertTrue(seen[i] >= seen[i - 1])
+        assertEquals(result.total.toInt(), seen.last())
+        assertEquals(result.total.toInt(), result.processed)
+    }
+
+    @Test fun cancel_stops_before_finishing() = runTest {
+        val sink = CountingSink()
+        val total = TileMath.tileCount(bbox(), 12, 15)
+        assertTrue("region must be large enough to observe a partial stop", total > 4)
+
+        lateinit var downloader: RegionDownloader
+        val fetched = AtomicInteger(0)
+        downloader = RegionDownloader(
+            sink = sink,
+            fetch = { _ ->
+                // cancel partway through
+                if (fetched.incrementAndGet() == 2) downloader.cancel()
+                byteArrayOf(1)
+            },
+            concurrency = 1,
+        )
+        val result = downloader.download(
+            bbox = bbox(), minZoom = 12, maxZoom = 15, template = "https://t/{z}/{x}/{y}",
+        )
+        assertFalse("cancelled run must not report completed", result.completed)
+        assertTrue("must not have processed the whole region", result.processed < result.total)
+    }
+
+    @Test fun already_cached_tiles_are_skipped_on_resume() = runTest {
+        val sink = CountingSink()
+        // Pre-seed the cache with the whole region as if a prior run finished.
+        val tiles = TileMath.enumerateTiles(bbox(), 12, 13)
+        val writer = TileCacheWriter(sink)
+        tiles.forEach { writer.writeXyz(it, byteArrayOf(7)) }
+
+        val fetched = AtomicInteger(0)
+        val downloader = RegionDownloader(
+            sink = sink,
+            fetch = { _ -> fetched.incrementAndGet(); byteArrayOf(0x2) },
+            skipExisting = true,
+        )
+        val result = downloader.download(
+            bbox = bbox(), minZoom = 12, maxZoom = 13, template = "https://t/{z}/{x}/{y}",
+        )
+        assertEquals("nothing should be re-fetched", 0, fetched.get())
+        assertEquals(tiles.size.toLong(), result.total)
+        // all tiles already present -> all skipped, none freshly downloaded,
+        // but progress still reaches 100% (processed == total).
+        assertEquals(0, result.downloaded)
+        assertEquals(tiles.size, result.skipped)
+        assertEquals(tiles.size, result.processed)
+        assertTrue(result.completed)
+    }
+
+    @Test fun fetch_failures_are_counted_not_fatal() = runTest {
+        val sink = CountingSink()
+        val downloader = RegionDownloader(
+            sink = sink,
+            fetch = { _ -> null }, // every fetch fails (e.g. 404 / offline)
+        )
+        val result = downloader.download(
+            bbox = bbox(), minZoom = 12, maxZoom = 12, template = "https://t/{z}/{x}/{y}",
+        )
+        assertEquals(result.total, result.failed.toLong())
+        assertEquals(0, sink.store.size)
+        // a run where everything failed still terminates (completed=true) but
+        // surfaces the failure count for the UI to warn on. Nothing cached.
+        assertTrue(result.completed)
+        assertEquals(0, result.downloaded)
+        assertEquals(0, result.skipped)
+    }
+
+    @Test fun template_is_filled_with_each_tile_coordinate() = runTest {
+        val urls = java.util.Collections.synchronizedList(ArrayList<String>())
+        val downloader = RegionDownloader(
+            sink = CountingSink(),
+            fetch = { url -> urls.add(url); byteArrayOf(1) },
+            concurrency = 1,
+        )
+        downloader.download(
+            bbox = BoundingBox(47.61, 47.605, -122.33, -122.335),
+            minZoom = 12, maxZoom = 12,
+            template = "https://tiles.test/{z}/{x}/{y}.png",
+        )
+        assertTrue(urls.isNotEmpty())
+        urls.forEach {
+            assertTrue("URL must be fully substituted: $it", !it.contains("{") && !it.contains("}"))
+            assertTrue(it.startsWith("https://tiles.test/12/"))
+        }
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/TileMathTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/TileMathTest.kt
@@ -1,0 +1,190 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure Web-Mercator slippy-map math + tile enumeration for offline region
+ * download (#120). No Android dependencies — runs as a plain JVM test.
+ *
+ * Reference values cross-checked against the OSM slippy-map tilenames spec
+ * (wiki.openstreetmap.org/wiki/Slippy_map_tilenames).
+ */
+class TileMathTest {
+
+    // --- lon/lat/z -> x/y (the canonical OSM formula) ---------------------
+
+    @Test fun origin_zoom0_is_single_tile() {
+        // Whole world at z0 is one tile (0,0).
+        assertEquals(0, TileMath.lonToTileX(-180.0, 0))
+        assertEquals(0, TileMath.latToTileY(85.0511, 0))
+    }
+
+    @Test fun greenwich_equator_zoom1_is_tile_1_1_lower_left_quadrant_boundary() {
+        // 0,0 sits on the seam of the four z1 tiles; the formula floors to the
+        // upper-right tile of the lower-left = (1,1) for lon just below 0.
+        assertEquals(1, TileMath.lonToTileX(0.0, 1))
+        assertEquals(1, TileMath.latToTileY(0.0, 1))
+    }
+
+    @Test fun known_seattle_tile_zoom12() {
+        // Seattle ~ (47.6062, -122.3321). Canonical OSM tile at z12 is
+        // x=656, y=1430 (cross-checked against the slippy-map spec).
+        assertEquals(656, TileMath.lonToTileX(-122.3321, 12))
+        assertEquals(1430, TileMath.latToTileY(47.6062, 12))
+    }
+
+    @Test fun x_is_clamped_into_valid_range() {
+        // Beyond the antimeridian / poles, indices clamp to [0, 2^z - 1].
+        assertEquals(0, TileMath.lonToTileX(-181.0, 3))
+        assertEquals((1 shl 3) - 1, TileMath.lonToTileX(181.0, 3))
+        assertEquals(0, TileMath.latToTileY(89.9, 3))
+        assertEquals((1 shl 3) - 1, TileMath.latToTileY(-89.9, 3))
+    }
+
+    // --- bbox x zoom enumeration ------------------------------------------
+
+    @Test fun single_tile_bbox_single_zoom_enumerates_one_tile() {
+        // A pinpoint bbox at one zoom = exactly one tile.
+        val bbox = BoundingBox(north = 47.61, south = 47.60, east = -122.33, west = -122.34)
+        val tiles = TileMath.enumerateTiles(bbox, minZoom = 12, maxZoom = 12)
+        assertEquals(1, tiles.size)
+        assertEquals(Tile(12, 656, 1430), tiles.first())
+    }
+
+    @Test fun count_matches_enumerated_list_size() {
+        val bbox = BoundingBox(north = 47.7, south = 47.5, east = -122.2, west = -122.5)
+        for (z in 8..14) {
+            val list = TileMath.enumerateTiles(bbox, z, z)
+            val count = TileMath.tileCount(bbox, z, z)
+            assertEquals("z=$z count must equal list size", list.size.toLong(), count)
+        }
+    }
+
+    @Test fun multizoom_count_is_sum_of_per_zoom_counts() {
+        val bbox = BoundingBox(north = 47.7, south = 47.5, east = -122.2, west = -122.5)
+        val total = TileMath.tileCount(bbox, 8, 12)
+        val perZoomSum = (8..12).sumOf { TileMath.tileCount(bbox, it, it) }
+        assertEquals(perZoomSum, total)
+    }
+
+    @Test fun enumeration_covers_a_2x2_block() {
+        // A bbox wide/tall enough to straddle a tile boundary at z12 yields a
+        // contiguous rectangular block; verify the corners + the count.
+        val bbox = BoundingBox(north = 47.70, south = 47.55, east = -122.25, west = -122.45)
+        val tiles = TileMath.enumerateTiles(bbox, 12, 12)
+        val xs = tiles.map { it.x }.toSortedSet()
+        val ys = tiles.map { it.y }.toSortedSet()
+        // contiguous range, no gaps
+        assertEquals((xs.first()..xs.last()).toList(), xs.toList())
+        assertEquals((ys.first()..ys.last()).toList(), ys.toList())
+        assertEquals(xs.size * ys.size, tiles.size)
+    }
+
+    @Test fun swapped_bbox_corners_are_normalized() {
+        // Operator-drawn rectangles can come in with min/max swapped; the
+        // math must normalize rather than return an empty set.
+        val normal = BoundingBox(north = 47.7, south = 47.5, east = -122.2, west = -122.5)
+        val swapped = BoundingBox(north = 47.5, south = 47.7, east = -122.5, west = -122.2)
+        assertEquals(
+            TileMath.tileCount(normal, 10, 12),
+            TileMath.tileCount(swapped, 10, 12),
+        )
+    }
+
+    @Test fun zoom_range_is_order_independent() {
+        val bbox = BoundingBox(north = 47.7, south = 47.5, east = -122.2, west = -122.5)
+        assertEquals(
+            TileMath.tileCount(bbox, 10, 13),
+            TileMath.tileCount(bbox, 13, 10),
+        )
+    }
+
+    // --- size estimate ----------------------------------------------------
+
+    @Test fun size_estimate_scales_with_tile_count() {
+        val bbox = BoundingBox(north = 47.7, south = 47.5, east = -122.2, west = -122.5)
+        val count = TileMath.tileCount(bbox, 8, 12)
+        val est = TileMath.estimateBytes(bbox, 8, 12)
+        // Estimate = count * avg-bytes-per-tile; must be positive and a clean
+        // multiple of the count.
+        assertTrue(est > 0)
+        assertEquals(count * TileMath.AVG_TILE_BYTES, est)
+    }
+
+    @Test fun zoom_is_clamped_to_world_cap() {
+        // A requested zoom above MAX_ZOOM is clamped so we never enumerate an
+        // absurd tile count or fill a template with an out-of-range z.
+        val bbox = BoundingBox(north = 47.7, south = 47.5, east = -122.2, west = -122.5)
+        val clampedTop = TileMath.tileCount(bbox, TileMath.MAX_ZOOM, TileMath.MAX_ZOOM + 5)
+        val justTop = TileMath.tileCount(bbox, TileMath.MAX_ZOOM, TileMath.MAX_ZOOM)
+        assertEquals(justTop, clampedTop)
+    }
+
+    // --- humanize helper --------------------------------------------------
+
+    @Test fun bytes_humanize_to_readable_units() {
+        assertEquals("0 B", TileMath.humanizeBytes(0))
+        assertEquals("512 B", TileMath.humanizeBytes(512))
+        assertEquals("1.0 KB", TileMath.humanizeBytes(1024))
+        assertEquals("1.5 MB", TileMath.humanizeBytes((1.5 * 1024 * 1024).toLong()))
+        assertTrue(TileMath.humanizeBytes(5L * 1024 * 1024 * 1024).endsWith("GB"))
+    }
+
+    // --- URL template fill ------------------------------------------------
+
+    @Test fun fills_xyz_template() {
+        val url = TileMath.fillTemplate("https://tile.openstreetmap.org/{z}/{x}/{y}.png", Tile(12, 654, 1428))
+        assertEquals("https://tile.openstreetmap.org/12/654/1428.png", url)
+    }
+
+    @Test fun fills_tms_style_template_with_y_in_middle() {
+        // ESRI World Imagery uses {z}/{y}/{x} order — fill must respect the
+        // literal token positions, not assume an order.
+        val url = TileMath.fillTemplate(
+            "https://server.arcgisonline.com/.../tile/{z}/{y}/{x}",
+            Tile(5, 9, 12),
+        )
+        assertEquals("https://server.arcgisonline.com/.../tile/5/12/9", url)
+    }
+
+    @Test fun rotates_subdomain_token() {
+        // {s} subdomain rotation: deterministic, cycles a..c.
+        val t = Tile(3, 2, 5)
+        val u0 = TileMath.fillTemplate("https://{s}.tile.osm.org/{z}/{x}/{y}.png", t, subdomains = listOf("a", "b", "c"))
+        assertTrue(u0.startsWith("https://a.") || u0.startsWith("https://b.") || u0.startsWith("https://c."))
+        assertTrue(u0.contains("/3/2/5.png"))
+    }
+
+    // --- provider -> template ---------------------------------------------
+
+    @Test fun osm_provider_resolves_to_osm_template() {
+        val tpl = TileMath.templateForProvider(
+            soy.engindearing.omnitak.mobile.data.MapProvider.OSM_RASTER, "",
+        )
+        assertNotNull(tpl)
+        assertTrue(tpl!!.contains("{z}") && tpl.contains("{x}") && tpl.contains("{y}"))
+        assertTrue(tpl.contains("openstreetmap"))
+    }
+
+    @Test fun custom_provider_resolves_to_custom_url_normalized() {
+        val tpl = TileMath.templateForProvider(
+            soy.engindearing.omnitak.mobile.data.MapProvider.WMTS_CUSTOM,
+            "https://lan.local/tiles/{\$z}/{\$x}/{\$y}.png",
+        )
+        // ATAK $-brace form normalized to MapLibre form.
+        assertEquals("https://lan.local/tiles/{z}/{x}/{y}.png", tpl)
+    }
+
+    @Test fun custom_provider_with_blank_url_is_null() {
+        // Can't download from an empty custom source — caller must block it.
+        assertNull(
+            TileMath.templateForProvider(
+                soy.engindearing.omnitak.mobile.data.MapProvider.WMTS_CUSTOM, "",
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/TileStoreRoundTripTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/TileStoreRoundTripTest.kt
@@ -1,0 +1,101 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Cache key + write→read round-trip for the offline tile store (#120).
+ *
+ * Downloaded regions are persisted as standard MBTiles SQLite files so they
+ * reuse the existing [soy.engindearing.omnitak.mobile.data.MBTilesDb] read
+ * path + [soy.engindearing.omnitak.mobile.data.MBTilesServer] HTTP serve.
+ * MBTiles stores rows in TMS order (y grows north), while the map requests
+ * XYZ (y grows south) — so the write path must flip Y to TMS exactly as
+ * MBTilesDb flips it back on read.
+ *
+ * SQLite itself is an Android API (no JVM impl in this module's test
+ * config), so these tests exercise the *key derivation + flip + round-trip*
+ * over an in-memory [TileSink] that stores the same (z, column, tmsRow)
+ * tuple the SQLite rows hold. The real SQLite-backed writer is verified on
+ * device (see [OfflineMbtilesWriter]).
+ */
+class TileStoreRoundTripTest {
+
+    /** In-memory stand-in keyed exactly like the MBTiles `tiles` table. */
+    private class MemSink : TileSink {
+        data class Row(val z: Int, val col: Int, val tmsRow: Int)
+        val rows = HashMap<Row, ByteArray>()
+        override fun put(z: Int, column: Int, tmsRow: Int, data: ByteArray) {
+            rows[Row(z, column, tmsRow)] = data
+        }
+        override fun get(z: Int, column: Int, tmsRow: Int): ByteArray? = rows[Row(z, column, tmsRow)]
+        fun rawGet(z: Int, column: Int, tmsRow: Int): ByteArray? = rows[Row(z, column, tmsRow)]
+    }
+
+    @Test fun xyz_y_is_flipped_to_tms_on_write() {
+        // The TMS row for an XYZ tile is (2^z - 1 - y) — the same identity
+        // MBTilesDb uses on read. Verify the writer stores under that row.
+        val sink = MemSink()
+        val w = TileCacheWriter(sink)
+        val payload = byteArrayOf(1, 2, 3)
+        w.writeXyz(Tile(z = 4, x = 5, y = 6), payload)
+
+        val expectedTmsRow = (1 shl 4) - 1 - 6 // = 9
+        assertArrayEquals(payload, sink.rawGet(4, 5, expectedTmsRow))
+        // and NOT stored under the un-flipped row
+        assertNull(sink.rawGet(4, 5, 6))
+    }
+
+    @Test fun write_then_read_back_same_bytes_via_xyz() {
+        // End-to-end at the XYZ layer: what we write at (z,x,y) is exactly
+        // what an XYZ read at (z,x,y) returns — proving the flip is its own
+        // inverse across write+read.
+        val sink = MemSink()
+        val w = TileCacheWriter(sink)
+        val a = "tileA".toByteArray()
+        val b = "tileB".toByteArray()
+        w.writeXyz(Tile(10, 163, 395), a)
+        w.writeXyz(Tile(10, 163, 396), b)
+
+        assertArrayEquals(a, w.readXyz(Tile(10, 163, 395)))
+        assertArrayEquals(b, w.readXyz(Tile(10, 163, 396)))
+        assertNull(w.readXyz(Tile(10, 163, 999))) // never written
+    }
+
+    @Test fun top_and_bottom_rows_round_trip_at_low_zoom() {
+        // The flip is most error-prone at the extremes. At z1 (2x2 grid):
+        // XYZ y=0 (north) -> TMS row 1; XYZ y=1 (south) -> TMS row 0.
+        val sink = MemSink()
+        val w = TileCacheWriter(sink)
+        w.writeXyz(Tile(1, 0, 0), byteArrayOf(0))
+        w.writeXyz(Tile(1, 0, 1), byteArrayOf(1))
+        assertArrayEquals(byteArrayOf(1), sink.rawGet(1, 0, 0)) // south -> row 0
+        assertArrayEquals(byteArrayOf(0), sink.rawGet(1, 0, 1)) // north -> row 1
+        assertArrayEquals(byteArrayOf(0), w.readXyz(Tile(1, 0, 0)))
+        assertArrayEquals(byteArrayOf(1), w.readXyz(Tile(1, 0, 1)))
+    }
+
+    @Test fun written_count_tracks_unique_tiles() {
+        val sink = MemSink()
+        val w = TileCacheWriter(sink)
+        w.writeXyz(Tile(8, 1, 1), byteArrayOf(1))
+        w.writeXyz(Tile(8, 1, 2), byteArrayOf(2))
+        w.writeXyz(Tile(8, 1, 1), byteArrayOf(9)) // overwrite same coord
+        assertEquals(2, sink.rows.size)
+    }
+
+    @Test fun tms_flip_is_self_inverse_for_arbitrary_tiles() {
+        // Property: flip(flip(y)) == y for every valid y at a zoom.
+        for (z in 0..18) {
+            val n = 1 shl z
+            for (y in intArrayOf(0, 1, n / 2, n - 2, n - 1).filter { it in 0 until n }) {
+                val tms = MbtilesRow.xyzToTms(z, y)
+                assertEquals(y, MbtilesRow.tmsToXyz(z, tms))
+                assertTrue(tms in 0 until n)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

ATAK-style offline map download. The operator selects a region (the current map viewport bbox) plus a min/max zoom range, the app downloads those tiles from the active basemap source, caches them locally, and the map serves from cache when offline — mirroring ATAK's Map Manager (the design call on #120).

## Design

A downloaded region is written as a **standard MBTiles SQLite file**, so it reuses the existing tile infrastructure rather than duplicating it:

- `MBTilesDb` reads it back (TMS row order, same Y-flip).
- `MBTilesServer` serves it over the in-app HTTP tile path (`127.0.0.1:port/<id>/{z}/{x}/{y}`).
- It registers as a raster source/layer exactly like an imported MBTiles overlay (#33).

So "serve from cache offline" needed **no new read or serve path** — a region is just another tile source on the map. `OfflineTilePolicy` decides whether cached layers sit above the live basemap (offline → cache wins) or simply layer in (online).

Web-Mercator tile math is new and deliberately separate from `TerrainSampler` (which speaks the WGS84 `2·2^z` grid TAK Terrain publishes — a different projection that would plot the wrong tiles for these basemaps).

## Files

- `data/offline/TileMath.kt` — Web-Mercator `lon/lat/z → x/y`, bbox×zoom enumeration + count, size estimate, URL-template fill, provider→template.
- `data/offline/TileCache.kt` — `TileSink` + `TileCacheWriter` (XYZ↔TMS row flip).
- `data/offline/RegionDownloader.kt` — enumerate → fetch (injected) → write, bounded concurrency, progress, cancel, resume-skip; `HttpTileFetcher` (HttpURLConnection).
- `data/offline/OfflineMbtilesWriter.kt` — writable MBTiles `TileSink` (SQLite).
- `data/offline/OfflineRegion.kt` — region model + `OfflineTilePolicy`.
- `data/offline/OfflineRegionStore.kt` — runs downloads, persists metadata, registers with `MBTilesServer`, list/delete, network state.
- `ui/components/OfflineMapsSheet.kt` — region select + live tile-count/size readout + download progress/cancel + manage. Reached from the Map layers dialog ("Offline maps…").
- `KmlOverlayRenderer.applyOfflineRegions(...)`, `OmniTAKApp.offlineRegionStore`, `MapScreen` wiring.

## Tested vs device-pending

**Unit-verified (36 new JVM tests, `:app:testDebugUnitTest`):**
- Tile math: `lon/lat/z → x/y` (cross-checked vs the OSM slippy-map spec, incl. Seattle z12 = 656/1430), bbox×zoom enumeration + count parity, multi-zoom sum, swapped-corner / reversed-zoom normalization, zoom clamp, size estimate, byte humanize, template fill (incl. `{z}/{y}/{x}` order + `{s}` rotation), provider→template (incl. blank-custom → null).
- Cache: XYZ↔TMS flip is self-inverse, write→read round-trip via XYZ, top/bottom-row extremes, overwrite-dedupe.
- Downloader: full-region write, monotonic progress to total, mid-run cancel stops early, resume skips cached tiles (0 re-fetch), fetch failures counted not fatal, template filled per tile.
- Policy: offline→cachePreferred, online→present-but-not-forced, all-regions-active, bbox contains / zoom covers.

**Implemented, needs a device to verify end-to-end:**
- The real HTTP tile fetch (`HttpTileFetcher`) against a live/LAN tile server.
- The writable SQLite MBTiles binding (`OfflineMbtilesWriter`) — the key/flip logic it relies on is unit-covered over an in-memory sink.
- The on-map render of cached tiles (MapLibre raster source/layer ordering).
- Region selection currently uses the **current viewport** bbox; a drag-a-rectangle selector is the follow-up polish.

`:app:assembleDebug` + `:app:testDebugUnitTest` green (matches CI). Tile-server usage respected: bounded concurrency (default 4) + zoom capped at 19, with a large-download warning in the UI.

Closes #120