### PR TITLE
fix(map): render contacts via SymbolManager annotation path (#77)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,12 @@ dependencies {
 
     // MapLibre Android (open-source fork of Mapbox) — parallel to iOS
     implementation("org.maplibre.gl:android-sdk:11.8.0")
+    // Annotation plugin (SymbolManager) — issue #77. Contacts render through
+    // this annotation/bitmap pipeline, the same render-path family as
+    // LocationComponent (which paints reliably on Adreno/Mali/Immortalis),
+    // instead of the GeoJSON CircleLayer/SymbolLayer that is "queryable but
+    // never draws pixels" on those drivers. v3.x line targets MapLibre 11.x.
+    implementation("org.maplibre.gl:android-plugin-annotation-v9:3.0.2")
 
     // NGA's tested MGRS / UTM converter. Operators rely on grid coords
     // for navigation; rolling our own would risk silent miscalculation.

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolDiff.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolDiff.kt
@@ -1,0 +1,77 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+/**
+ * Issue #77 — pure add / update / remove diff for the contact
+ * [org.maplibre.android.plugins.annotation.SymbolManager].
+ *
+ * Recreating every [org.maplibre.android.plugins.annotation.Symbol] on each
+ * contact-store change (delete-all + re-add) churns the annotation source on
+ * every CoT tick and makes taps race the rebuild. Instead we diff the desired
+ * [ContactSymbolSpec] set against what is currently on the map, keyed by
+ * [ContactSymbolSpec.uid], and emit the minimal mutation set.
+ *
+ * This is the testable heart of the fix: no MapLibre / Android types are in
+ * scope, so the whole add/update/remove decision is verified in pure JVM. The
+ * live [ContactSymbolManager] is then a thin adapter that applies these ops to
+ * the real SymbolManager.
+ */
+object ContactSymbolDiff {
+
+    /**
+     * @param current spec currently rendered for each live symbol, keyed by uid.
+     *   ([ContactSymbolManager] holds the matching uid→Symbol handles.)
+     * @param target  spec the contact store now wants on the map.
+     */
+    data class Result(
+        /** uids present in [target] but not [current] — create a new Symbol. */
+        val toAdd: List<ContactSymbolSpec>,
+        /** uids whose spec changed (position / icon / callsign / color) — restyle
+         *  the existing Symbol in place rather than add+remove. */
+        val toUpdate: List<ContactSymbolSpec>,
+        /** uids present in [current] but gone from [target] — remove the Symbol. */
+        val toRemove: List<String>,
+    ) {
+        /** True when nothing changed — lets the caller skip a SymbolManager
+         *  round-trip (and the implicit source re-upload) entirely. */
+        val isEmpty: Boolean
+            get() = toAdd.isEmpty() && toUpdate.isEmpty() && toRemove.isEmpty()
+    }
+
+    /**
+     * Compute the minimal mutation set to take the map from [current] to [target].
+     *
+     * Update detection is a structural equality check on [ContactSymbolSpec]:
+     * any change to position, icon image, callsign, team color, or tint flag
+     * yields an update; an unchanged spec is omitted so we don't re-push a
+     * Symbol that already matches. If a uid appears more than once in [target]
+     * the last occurrence wins (mirrors a `Map` collapse — a contact store
+     * should not hold duplicate uids, but we must not emit two adds for one).
+     */
+    fun compute(
+        current: Map<String, ContactSymbolSpec>,
+        target: Collection<ContactSymbolSpec>,
+    ): Result {
+        // Collapse duplicate uids (last wins) and preserve first-seen order so
+        // the add/update output is deterministic for tests and stable on screen.
+        val targetByUid = LinkedHashMap<String, ContactSymbolSpec>(target.size)
+        for (spec in target) targetByUid[spec.uid] = spec
+
+        val toAdd = ArrayList<ContactSymbolSpec>()
+        val toUpdate = ArrayList<ContactSymbolSpec>()
+        for ((uid, spec) in targetByUid) {
+            val existing = current[uid]
+            when {
+                existing == null -> toAdd.add(spec)
+                existing != spec -> toUpdate.add(spec)
+                // else: identical — no-op, intentionally skipped.
+            }
+        }
+
+        val toRemove = ArrayList<String>()
+        for (uid in current.keys) {
+            if (uid !in targetByUid) toRemove.add(uid)
+        }
+
+        return Result(toAdd = toAdd, toUpdate = toUpdate, toRemove = toRemove)
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolManager.kt
@@ -1,0 +1,287 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import android.content.Context
+import android.util.Log
+import com.google.gson.JsonObject
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
+import org.maplibre.android.plugins.annotation.Symbol
+import org.maplibre.android.plugins.annotation.SymbolManager
+import org.maplibre.android.plugins.annotation.SymbolOptions
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.symbology.IconPackRegistry
+import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconCache
+import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
+import soy.engindearing.omnitak.mobile.data.symbology.TakIconRegistry
+
+/**
+ * Issue #77 — renders CoT contacts through MapLibre's [SymbolManager]
+ * (the `android-plugin-annotation-v9` annotation pipeline), NOT a GeoJSON
+ * [org.maplibre.android.style.layers.SymbolLayer] / CircleLayer.
+ *
+ * ## Why
+ * Contacts previously rendered only through GeoJSON-source layers
+ * ([ContactLayer]'s inline `contacts-src` CircleLayer + [ContactSymbolLayer]'s
+ * runtime `addImage` SymbolLayer). On Adreno 610 / Mali-G57 / Pixel Immortalis
+ * those point layers are *queryable but never draw pixels* — a MapLibre-Android
+ * fragment-pipeline failure (the codebase had already reverted a CircleLayer over
+ * it; see [ContactSymbolLayer]'s history note). A full style reload does **not**
+ * fix it (confirmed on-device, issue #77), ruling out repaint/atlas timing — it
+ * is the layer *type*. The self-marker renders fine because it is a
+ * [org.maplibre.android.location.LocationComponent] (annotation/bitmap path).
+ *
+ * The annotation plugin's [SymbolManager] is the same render-path family as
+ * LocationComponent, so it shares the pipeline that *does* paint on these
+ * drivers. Drawings (Fill/Line layers) paint fine and are untouched — this is
+ * only the contact point markers.
+ *
+ * ## Design
+ *  - One [SymbolManager] for all contacts, created against the live [MapView] +
+ *    [MapLibreMap] + [Style] once the style is loaded.
+ *  - The contact → render mapping ([ContactSymbolSpec]) and the add/update/remove
+ *    diff ([ContactSymbolDiff]) are pure, unit-tested classes; this class is the
+ *    thin device adapter that applies their output to real [Symbol]s.
+ *  - Bitmaps are registered via [Style.addImage] using the *exact* keys + caches
+ *    ([MilStdIconCache] / [TakIconRegistry] / [IconPackRegistry]) that
+ *    [ContactSymbolLayer] used, so the icon glyphs are identical to before — only
+ *    the layer carrying them changed.
+ *  - Team color is preserved: MIL-STD frames are tinted via `iconColor`, the
+ *    callsign is drawn as `textField` with a halo, and TAK-suite glyphs keep
+ *    their baked-in colors (no tint). This guards against the historic
+ *    "all blue, no callsign" regression the GeoJSON path was added to fix.
+ *  - Single-style-scoped, mirroring [ContactSymbolLayer]: a style reload wipes
+ *    annotation layers, so the caller constructs a fresh instance per style.
+ */
+class ContactSymbolManager(
+    private val onContactTap: ((CoTEvent) -> Unit)?,
+) {
+    companion object {
+        private const val TAG = "ContactSymbolManager"
+
+        // Same 64 px raster the legacy Marker path + ContactSymbolLayer use.
+        private const val ICON_PIXEL_SIZE = 64
+
+        // Icon scale-down so the 64 px raster reads as a marker, not a sticker —
+        // matches ContactSymbolLayer.iconSize(0.6f) and the legacy MarkerOptions.
+        private const val ICON_SIZE = 0.6f
+        private const val TEXT_SIZE = 10f
+        private const val TEXT_HALO_WIDTH = 1.2f
+
+        // gson data key — lets the click listener map a tapped Symbol back to the
+        // contact uid (SymbolManager hands back a Symbol, not the CoTEvent).
+        private const val DATA_UID = "uid"
+    }
+
+    private var manager: SymbolManager? = null
+    private var installed = false
+
+    /** Live render state, keyed by contact uid: the spec last applied and the
+     *  Symbol handle for it. [ContactSymbolDiff] consumes [specByUid]; [symbolByUid]
+     *  is how we update/delete the matching annotation. */
+    private val specByUid = LinkedHashMap<String, ContactSymbolSpec>()
+    private val symbolByUid = HashMap<String, Symbol>()
+
+    /** uid → contact, so the tap listener resolves the original [CoTEvent] for
+     *  [onContactTap] without re-deriving it from the Symbol's geometry. */
+    private val contactByUid = HashMap<String, CoTEvent>()
+
+    /** Image ids already registered on the current style — addImage is idempotent
+     *  but skipping the re-raster keeps updates cheap. */
+    private val registeredImages = HashSet<String>()
+
+    /**
+     * Create the [SymbolManager] on [style] and wire the tap listener. Idempotent.
+     * Mirrors [ContactSymbolLayer.installInto]'s contract: call once per style.
+     */
+    fun installInto(mapView: MapView, map: MapLibreMap, style: Style) {
+        if (installed) return
+        installed = true
+
+        val mgr = SymbolManager(mapView, map, style).apply {
+            // Tactical markers must never be decluttered away — every contact is
+            // load-bearing. Matches ContactSymbolLayer's icon overlap flags.
+            iconAllowOverlap = true
+            iconIgnorePlacement = true
+            // Labels may collide-hide (matches ContactSymbolLayer's label layer):
+            // overlapping callsigns are illegible, the icon still shows.
+            textAllowOverlap = false
+            textIgnorePlacement = false
+        }
+        mgr.addClickListener { symbol ->
+            val cb = onContactTap
+            val uid = symbol.data?.asJsonObject?.get(DATA_UID)?.asString
+            val contact = uid?.let { contactByUid[it] }
+            if (cb != null && contact != null) {
+                cb(contact)
+                true // consume — this tap hit a contact
+            } else {
+                false
+            }
+        }
+        manager = mgr
+    }
+
+    /**
+     * Diff [contacts] against the current symbols and apply the minimal mutation
+     * set. Skips contacts with NaN lat/lon (same guard as the GeoJSON path).
+     * Registers any not-yet-seen icon image via [Style.addImage] before its
+     * Symbol references it, so SymbolManager never points at a missing image.
+     *
+     * @return number of symbols created on this call (diagnostics + tests).
+     */
+    fun update(context: Context, style: Style, contacts: Collection<CoTEvent>): Int {
+        val mgr = manager
+        if (mgr == null || !installed) {
+            Log.w(TAG, "update() before installInto() — no-op")
+            return 0
+        }
+
+        // Build the desired spec set, registering each contact's icon bitmap.
+        // contactByUid is rebuilt so the tap listener always resolves the current
+        // CoTEvent (position/callsign may have changed since last tick).
+        val target = ArrayList<ContactSymbolSpec>(contacts.size)
+        val freshContacts = HashMap<String, CoTEvent>(contacts.size)
+        for (c in contacts) {
+            if (c.lat.isNaN() || c.lon.isNaN()) continue
+            val spec = resolveAndRegister(context, style, c)
+            target.add(spec)
+            freshContacts[c.uid] = c
+        }
+        contactByUid.clear()
+        contactByUid.putAll(freshContacts)
+
+        val diff = ContactSymbolDiff.compute(current = specByUid, target = target)
+        if (diff.isEmpty) return 0
+
+        for (uid in diff.toRemove) {
+            symbolByUid.remove(uid)?.let { mgr.delete(it) }
+            specByUid.remove(uid)
+        }
+        for (spec in diff.toUpdate) {
+            val symbol = symbolByUid[spec.uid]
+            if (symbol != null) {
+                applyTo(symbol, spec)
+                mgr.update(symbol)
+            } else {
+                // Defensive: spec said update but we lost the handle — recreate.
+                symbolByUid[spec.uid] = mgr.create(optionsFor(spec))
+            }
+            specByUid[spec.uid] = spec
+        }
+        var created = 0
+        for (spec in diff.toAdd) {
+            symbolByUid[spec.uid] = mgr.create(optionsFor(spec))
+            specByUid[spec.uid] = spec
+            created++
+        }
+        return created
+    }
+
+    /** Tear down all symbols (e.g. before a style reload). */
+    fun clear() {
+        manager?.deleteAll()
+        symbolByUid.clear()
+        specByUid.clear()
+        contactByUid.clear()
+        registeredImages.clear()
+    }
+
+    // ── icon resolution + image registration ────────────────────────────────
+    // Mirrors ContactSymbolLayer's resolution order exactly so the glyphs are
+    // byte-identical — only the layer carrying them changed.
+
+    private fun resolveAndRegister(context: Context, style: Style, c: CoTEvent): ContactSymbolSpec {
+        val takImageId = registerTakIconImage(style, context, c)
+        if (takImageId != null) {
+            return ContactSymbolSpec.from(c, resolvedImageId = takImageId)
+        }
+        val sidc = MilStdIconService.getSidc(c.type)
+        registerSidcImage(style, context, sidc)
+        return ContactSymbolSpec.from(c, resolvedImageId = ContactSymbolLayer.ICON_IMAGE_PREFIX + sidc)
+    }
+
+    /** Issue #98 resolution order: imported pack → bundled TAK suite → null. */
+    private fun registerTakIconImage(style: Style, context: Context, c: CoTEvent): String? {
+        val registry = IconPackRegistry.get(context)
+        val imported = registry.resolve(c.iconsetPath)
+        if (imported != null) {
+            val (pack, icon) = imported
+            val imageId = registry.styleImageId(c.iconsetPath!!)
+            if (imageId !in registeredImages) {
+                val bitmap = registry.loadBitmap(pack, icon)
+                if (bitmap != null) {
+                    style.addImage(imageId, bitmap)
+                    registeredImages.add(imageId)
+                }
+            }
+            if (imageId in registeredImages) return imageId
+        }
+
+        if (!TakIconRegistry.handles(c.type, c.iconsetPath)) return null
+        val argb = c.colorArgb?.let { TakIconRegistry.normalizeArgb(it) }
+        val imageId = TakIconRegistry.styleImageId(c.type, c.iconsetPath, argb) ?: return null
+        if (imageId in registeredImages) return imageId
+        val bitmap = TakIconRegistry.resolveBitmap(
+            cotType = c.type,
+            iconsetPath = c.iconsetPath,
+            argb = argb,
+            sizePx = ICON_PIXEL_SIZE,
+            context = context,
+        ) ?: return null
+        style.addImage(imageId, bitmap)
+        registeredImages.add(imageId)
+        return imageId
+    }
+
+    private fun registerSidcImage(style: Style, context: Context, sidc: String) {
+        val imageId = ContactSymbolLayer.ICON_IMAGE_PREFIX + sidc
+        if (imageId in registeredImages) return
+        val cotType = MilStdIconService.getDefinitionBySidc(sidc)?.value ?: "a-u-A"
+        val bitmap = MilStdIconCache.bitmapFor(context, cotType, ICON_PIXEL_SIZE)
+            ?: MilStdIconCache.bitmapFor(context, "a-u-A", ICON_PIXEL_SIZE)
+            ?: run {
+                Log.w(TAG, "no bitmap for sidc=$sidc; symbol will hide rather than crash")
+                return
+            }
+        style.addImage(imageId, bitmap)
+        registeredImages.add(imageId)
+    }
+
+    // ── spec → SymbolOptions / Symbol ───────────────────────────────────────
+
+    private fun optionsFor(spec: ContactSymbolSpec): SymbolOptions =
+        SymbolOptions()
+            .withLatLng(LatLng(spec.lat, spec.lon))
+            .withIconImage(spec.imageId)
+            .withIconSize(ICON_SIZE)
+            .withTextField(spec.callsign)
+            .withTextSize(TEXT_SIZE)
+            // Team color rides on the callsign label — icon-color only tints SDF
+            // icons, and our MIL-STD / TAK-suite glyphs are full-color rasters
+            // (see ContactSymbolSpec). A dark halo keeps any team color legible on
+            // light or dark basemaps.
+            .withTextColor(argbToCssHex(spec.teamColorArgb))
+            .withTextHaloColor("#000000")
+            .withTextHaloWidth(TEXT_HALO_WIDTH)
+            .withTextOffset(arrayOf(0f, 1.4f))
+            .withTextAnchor("top")
+            .withData(dataFor(spec))
+
+    private fun applyTo(symbol: Symbol, spec: ContactSymbolSpec) {
+        symbol.latLng = LatLng(spec.lat, spec.lon)
+        symbol.iconImage = spec.imageId
+        symbol.textField = spec.callsign
+        symbol.textColor = argbToCssHex(spec.teamColorArgb)
+        symbol.data = dataFor(spec)
+    }
+
+    private fun dataFor(spec: ContactSymbolSpec): JsonObject =
+        JsonObject().apply { addProperty(DATA_UID, spec.uid) }
+}
+
+/** ARGB int → `#RRGGBB` CSS hex (alpha dropped) for MapLibre color strings.
+ *  Same conversion [ContactLayer.argbToHex] uses; kept here so this file has no
+ *  cross-class call into the GeoJSON path we are replacing. */
+internal fun argbToCssHex(argb: Int): String = String.format("#%06X", argb and 0x00FFFFFF)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolSpec.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolSpec.kt
@@ -1,0 +1,100 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+import soy.engindearing.omnitak.mobile.data.symbology.MilStdIconService
+
+/**
+ * Issue #77 — pure, device-free description of one contact marker as it should
+ * appear on the MapLibre [org.maplibre.android.plugins.annotation.SymbolManager]
+ * render path (the annotation/bitmap pipeline LocationComponent uses, NOT a
+ * GeoJSON [org.maplibre.android.style.layers.SymbolLayer]).
+ *
+ * Why this exists as a plain data class: the GeoJSON CircleLayer / SymbolLayer
+ * contact path is "queryable but never draws pixels" on Adreno 610 / Mali-G57 /
+ * Pixel Immortalis — a MapLibre-Android fragment-pipeline failure a full style
+ * reload does not fix (confirmed on-device, issue #77). The self-marker renders
+ * because it is a [org.maplibre.android.location.LocationComponent] (annotation
+ * path). [ContactSymbolManager] moves contacts onto that same proven path.
+ *
+ * Splitting the contact→symbol mapping out here lets us TDD the load-bearing
+ * logic (icon-image id resolution, callsign, team color, coordinates) in pure
+ * JVM. The only thing left for on-device verification is whether the annotation
+ * pipeline paints — which is exactly the part a unit test cannot assert.
+ *
+ * @property uid        stable contact identity — the diff key, so updates
+ *                      move/restyle the existing [org.maplibre.android.plugins.annotation.Symbol]
+ *                      instead of churning add+remove.
+ * @property lat        latitude in degrees. Finite (NaN rows are dropped upstream).
+ * @property lon        longitude in degrees. Finite.
+ * @property imageId    the MapLibre style image name registered via
+ *                      [org.maplibre.android.maps.Style.addImage] and referenced
+ *                      by [org.maplibre.android.plugins.annotation.SymbolOptions.withIconImage].
+ *                      Either `milstd-<sidc>` or a TAK-icon-suite id
+ *                      (`takicon-spot-…`) — mirrors [ContactSymbolLayer] exactly.
+ * @property callsign   visible text label. Falls back to uid when no callsign —
+ *                      so a marker is never anonymous (regression guard against
+ *                      the "all blue, no callsign" report the GeoJSON path was
+ *                      added to fix).
+ * @property teamColorArgb ARGB team / affiliation color from [CoTEvent.displayColor].
+ *                      Applied to the **callsign text label** (see note below) so
+ *                      the team-color signal the GeoJSON CircleLayer carried is
+ *                      preserved — Red-1's label reads red, Orange-Chef's orange.
+ *
+ * ### Why team color goes on the label, not the icon
+ * MapLibre's `icon-color` / [org.maplibre.android.plugins.annotation.Symbol.setIconColor]
+ * only tints **SDF** icons (single-channel alpha masks). Our MIL-STD frames and
+ * TAK-suite glyphs are full-color raster bitmaps, so an icon tint would be a
+ * silent no-op on them — and registering them as SDF would flatten the
+ * affiliation frame (friend-blue rectangle, hostile-red diamond) and the
+ * multi-color FEMA/spot glyphs to a single hue. The icon therefore keeps its own
+ * baked colors (the MIL-STD bitmap already encodes friend/hostile/neutral), and
+ * the team color rides on the callsign label text, which IS rendered from SDF
+ * glyphs and tints reliably. This mirrors the GeoJSON path's split (icon + a
+ * separately-colored element) without its never-painting CircleLayer.
+ */
+data class ContactSymbolSpec(
+    val uid: String,
+    val lat: Double,
+    val lon: Double,
+    val imageId: String,
+    val callsign: String,
+    val teamColorArgb: Int,
+) {
+    companion object {
+        /**
+         * Build the [ContactSymbolSpec] for [c]. [resolvedImageId] is the image
+         * name the caller already registered via [org.maplibre.android.maps.Style.addImage]
+         * (TAK-suite id when [c] resolved to a bundled iconset, else the MIL-STD
+         * `milstd-<sidc>` name).
+         *
+         * Kept out of the live [ContactSymbolManager] so the whole mapping is
+         * exercised in pure JVM with no MapLibre / Android types in scope.
+         */
+        fun from(
+            c: CoTEvent,
+            resolvedImageId: String,
+        ): ContactSymbolSpec = ContactSymbolSpec(
+            uid = c.uid,
+            lat = c.lat,
+            lon = c.lon,
+            imageId = resolvedImageId,
+            // Never anonymous: a blank callsign would reintroduce the "no
+            // callsign" half of the P-E regression — fall back to the uid.
+            callsign = c.callsign?.takeIf { it.isNotBlank() } ?: c.uid,
+            // displayColor = TAK team palette when teamName is set, else the
+            // MIL-STD affiliation color. Either way it is the team-color signal
+            // we paint the label with.
+            teamColorArgb = c.displayColor,
+        )
+
+        /**
+         * Convenience for the MIL-STD path: resolve the SIDC and build the
+         * `milstd-<sidc>` image id the same way [ContactSymbolLayer] does, so the
+         * registration key and the spec never drift.
+         */
+        fun milStd(c: CoTEvent): ContactSymbolSpec {
+            val sidc = MilStdIconService.getSidc(c.type)
+            return from(c = c, resolvedImageId = ContactSymbolLayer.ICON_IMAGE_PREFIX + sidc)
+        }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -152,12 +152,16 @@ fun TacticalMap(
     // off it; the effects below read/write it imperatively.
     val puckAppearance = remember { PuckAppearance() }
 
-    // ContactSymbolLayer uses Style.addImage (bitmap) + SymbolLayer — the path
-    // LocationComponent uses and that renders on Adreno 610 / SwiftShader when
-    // CircleLayer circle-color expressions silently fail (GL fragment pipeline bug).
-    // Keyed on styleJson so a basemap swap (style reload) gets a fresh instance
-    // with a clean installed=false state.
-    val contactSymbolLayer = remember(styleJson) { ContactSymbolLayer() }
+    // Issue #77 — contacts render via the SymbolManager annotation plugin (the
+    // same render-path family as LocationComponent, which paints reliably on
+    // Adreno/Mali/Immortalis), NOT a GeoJSON CircleLayer/SymbolLayer (those are
+    // "queryable but never draw pixels" on those drivers — a full style reload
+    // does not fix it). Keyed on styleJson so a basemap swap (style reload) gets
+    // a fresh instance with a clean installed=false state; a reload wipes
+    // annotation layers, same as the old GeoJSON path.
+    val contactSymbolManager = remember(styleJson, onContactTap) {
+        ContactSymbolManager(onContactTap)
+    }
 
     val mapView = remember {
         MapLibre.getInstance(context)
@@ -174,13 +178,12 @@ fun TacticalMap(
                     .bearing(initialBearing)
                     .build()
                 map.setStyle(Style.Builder().fromJson(styleJson)) { style ->
-                    ContactLayer.update(map, context, currentContacts)
-                    // Install bitmap-icon symbol layer alongside the inline circle layer.
-                    // The CircleLayer circle-color expression silently fails on Adreno 610
-                    // and SwiftShader — ContactSymbolLayer uses Style.addImage (the same
-                    // path LocationComponent uses) which renders correctly on both drivers.
-                    contactSymbolLayer.installInto(style, context)
-                    contactSymbolLayer.update(map, context, currentContacts)
+                    // Issue #77 — contacts go through the SymbolManager annotation
+                    // pipeline (LocationComponent's render-path family), which paints
+                    // on Adreno/Mali/Immortalis where the GeoJSON circle/symbol layer
+                    // is queryable-but-never-drawn even after a full style reload.
+                    contactSymbolManager.installInto(this@apply, map, style)
+                    contactSymbolManager.update(context, style, currentContacts)
                     MeasurementLayer.update(map, currentMeasurementPoints)
                     DrawingLayer.update(map, currentDrawings)
                     currentGridCenter?.let { GridLayer.update(map, it) }
@@ -249,9 +252,12 @@ fun TacticalMap(
                     currentMapSingleTap?.let { handler ->
                         if (handler(latLng)) return@addOnMapClickListener true
                     }
-                    val cb = currentContactTap ?: return@addOnMapClickListener false
                     val tapPx = map.projection.toScreenLocation(latLng)
-                    // #82 — tap on self-marker opens reposition sheet
+                    // #82 — tap on self-marker opens reposition sheet. The self
+                    // marker is a LocationComponent (not a contact Symbol), so it
+                    // is hit-tested here; contact taps are owned by the
+                    // SymbolManager click listener (issue #77) and never reach
+                    // this loop.
                     val selfTapCb = currentOnSelfMarkerTap
                     if (selfTapCb != null) {
                         val fix = currentSelfFix
@@ -267,25 +273,10 @@ fun TacticalMap(
                             }
                         }
                     }
-                    var best: CoTEvent? = null
-                    var bestDist = Float.MAX_VALUE
-                    currentContacts.forEach { c ->
-                        val px = map.projection.toScreenLocation(LatLng(c.lat, c.lon))
-                        val d = kotlin.math.hypot(
-                            (px.x - tapPx.x).toDouble(),
-                            (px.y - tapPx.y).toDouble(),
-                        ).toFloat()
-                        if (d < bestDist) {
-                            bestDist = d
-                            best = c
-                        }
-                    }
-                    if (best != null && bestDist < TAP_HIT_RADIUS_PX) {
-                        cb(best!!)
-                        true
-                    } else {
-                        false
-                    }
+                    // Contact taps are handled by ContactSymbolManager's click
+                    // listener (registered in installInto). A non-symbol tap that
+                    // misses the self-marker is not ours to consume.
+                    false
                 }
             }
             // Issue #80 — re-anchor drawing (and all other overlay) layers on
@@ -314,9 +305,13 @@ fun TacticalMap(
             addOnDidFinishLoadingStyleListener {
                 getMapAsync { map ->
                     map.getStyle { style ->
-                        ContactLayer.update(map, context, currentContacts)
-                        contactSymbolLayer.installInto(style, context)
-                        contactSymbolLayer.update(map, context, currentContacts)
+                        // Issue #77 — re-install the contact SymbolManager on the
+                        // (re)loaded style and re-push, same as the explicit
+                        // callbacks. installInto is idempotent; if this is a NEW
+                        // style the styleJson-keyed remember already handed us a
+                        // fresh manager with installed=false.
+                        contactSymbolManager.installInto(this@apply, map, style)
+                        contactSymbolManager.update(context, style, currentContacts)
                         MeasurementLayer.update(map, currentMeasurementPoints)
                         DrawingLayer.update(map, currentDrawings)
                         currentGridCenter?.let { GridLayer.update(map, it) }
@@ -483,9 +478,11 @@ fun TacticalMap(
             // getMapAsync block during MapView construction (line ~88).
             if (map.style != null && map.style?.json != styleJson) {
                 map.setStyle(Style.Builder().fromJson(styleJson)) { style ->
-                    ContactLayer.update(map, context, currentContacts)
-                    contactSymbolLayer.installInto(style, context)
-                    contactSymbolLayer.update(map, context, currentContacts)
+                    // Issue #77 — basemap swap reloads the style (wiping annotation
+                    // layers). The styleJson-keyed remember gave us a fresh
+                    // ContactSymbolManager; install it on the new style + re-push.
+                    contactSymbolManager.installInto(mapView, map, style)
+                    contactSymbolManager.update(context, style, currentContacts)
                     MeasurementLayer.update(map, currentMeasurementPoints)
                     DrawingLayer.update(map, currentDrawings)
                     currentGridCenter?.let { GridLayer.update(map, it) }
@@ -671,9 +668,13 @@ fun TacticalMap(
         factory = { mapView },
         update = {
             mapView.getMapAsync { map ->
-                map.getStyle { _ ->
-                    ContactLayer.update(map, context, currentContacts)
-                    contactSymbolLayer.update(map, context, currentContacts)
+                map.getStyle { style ->
+                    // Issue #77 — push the current contacts through the SymbolManager
+                    // on every recomposition (same cadence the Cesium engine uses).
+                    // installInto is a no-op once installed; the initial install
+                    // happens in the setStyle callback during MapView construction.
+                    contactSymbolManager.installInto(mapView, map, style)
+                    contactSymbolManager.update(context, style, currentContacts)
                 }
             }
         },

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolDiffTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolDiffTest.kt
@@ -1,0 +1,118 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #77 — add / update / remove diff that lets the contact SymbolManager
+ * mutate only what changed instead of recreating every Symbol on each CoT tick.
+ */
+class ContactSymbolDiffTest {
+
+    private fun spec(
+        uid: String,
+        lat: Double = 1.0,
+        lon: Double = 2.0,
+        imageId: String = "milstd-SFGP",
+        callsign: String = uid,
+        teamColorArgb: Int = 0xFF00FFFF.toInt(),
+    ) = ContactSymbolSpec(uid, lat, lon, imageId, callsign, teamColorArgb)
+
+    @Test fun `empty to empty is a no-op`() {
+        val r = ContactSymbolDiff.compute(current = emptyMap(), target = emptyList())
+        assertTrue(r.isEmpty)
+    }
+
+    @Test fun `new uids are added`() {
+        val r = ContactSymbolDiff.compute(
+            current = emptyMap(),
+            target = listOf(spec("a"), spec("b")),
+        )
+        assertEquals(listOf("a", "b"), r.toAdd.map { it.uid })
+        assertTrue(r.toUpdate.isEmpty())
+        assertTrue(r.toRemove.isEmpty())
+    }
+
+    @Test fun `disappeared uids are removed`() {
+        val r = ContactSymbolDiff.compute(
+            current = mapOf("a" to spec("a"), "b" to spec("b")),
+            target = listOf(spec("a")),
+        )
+        assertEquals(listOf("b"), r.toRemove)
+        assertTrue(r.toAdd.isEmpty())
+        assertTrue(r.toUpdate.isEmpty())
+    }
+
+    @Test fun `identical spec produces no update (no needless re-push)`() {
+        val s = spec("a")
+        val r = ContactSymbolDiff.compute(current = mapOf("a" to s), target = listOf(s))
+        assertTrue("unchanged contact must not churn the SymbolManager", r.isEmpty)
+    }
+
+    @Test fun `moved contact is an update, not add+remove`() {
+        val r = ContactSymbolDiff.compute(
+            current = mapOf("a" to spec("a", lat = 1.0, lon = 2.0)),
+            target = listOf(spec("a", lat = 9.0, lon = 8.0)),
+        )
+        assertEquals(listOf("a"), r.toUpdate.map { it.uid })
+        assertEquals(9.0, r.toUpdate.single().lat, 0.0)
+        assertTrue(r.toAdd.isEmpty())
+        assertTrue(r.toRemove.isEmpty())
+    }
+
+    @Test fun `changed callsign is an update`() {
+        val r = ContactSymbolDiff.compute(
+            current = mapOf("a" to spec("a", callsign = "Old")),
+            target = listOf(spec("a", callsign = "New")),
+        )
+        assertEquals("New", r.toUpdate.single().callsign)
+    }
+
+    @Test fun `changed team color is an update (team reassignment)`() {
+        val r = ContactSymbolDiff.compute(
+            current = mapOf("a" to spec("a", teamColorArgb = 0xFF00FFFF.toInt())),
+            target = listOf(spec("a", teamColorArgb = 0xFFFF0000.toInt())),
+        )
+        assertEquals(0xFFFF0000.toInt(), r.toUpdate.single().teamColorArgb)
+    }
+
+    @Test fun `changed icon image is an update (type change re-symbolizes)`() {
+        val r = ContactSymbolDiff.compute(
+            current = mapOf("a" to spec("a", imageId = "milstd-SFGP")),
+            target = listOf(spec("a", imageId = "milstd-SHGP")),
+        )
+        assertEquals("milstd-SHGP", r.toUpdate.single().imageId)
+    }
+
+    @Test fun `mixed add update remove in one pass`() {
+        val r = ContactSymbolDiff.compute(
+            current = mapOf(
+                "keep" to spec("keep"),
+                "move" to spec("move", lat = 0.0),
+                "drop" to spec("drop"),
+            ),
+            target = listOf(
+                spec("keep"),                  // unchanged → skipped
+                spec("move", lat = 5.0),       // moved → update
+                spec("add"),                   // new → add
+            ),
+        )
+        assertEquals(listOf("add"), r.toAdd.map { it.uid })
+        assertEquals(listOf("move"), r.toUpdate.map { it.uid })
+        assertEquals(listOf("drop"), r.toRemove)
+        assertFalse(r.isEmpty)
+    }
+
+    @Test fun `duplicate uid in target collapses to one with last wins`() {
+        // A contact store should not hold duplicate uids, but if it does we must
+        // emit exactly one Symbol per uid (last spec wins), never two adds.
+        val r = ContactSymbolDiff.compute(
+            current = emptyMap(),
+            target = listOf(spec("a", callsign = "First"), spec("a", callsign = "Last")),
+        )
+        assertEquals(1, r.toAdd.size)
+        assertEquals("Last", r.toAdd.single().callsign)
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolSpecTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactSymbolSpecTest.kt
@@ -1,0 +1,107 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.CoTEvent
+
+/**
+ * Issue #77 — contact → [ContactSymbolSpec] mapping for the SymbolManager
+ * (annotation/bitmap) render path that replaces the never-painting GeoJSON
+ * CircleLayer/SymbolLayer on Adreno/Mali/Immortalis GPUs.
+ *
+ * These cover the load-bearing, device-free half of the fix: that each contact
+ * yields the right icon-image id, a non-empty callsign label, the correct team
+ * color, lat/lon, and the right tint decision. The actual on-GPU paint is the
+ * only thing left for on-device verification.
+ */
+class ContactSymbolSpecTest {
+
+    private fun contact(
+        uid: String = "uid-1",
+        type: String = "a-f-G-U-C",
+        lat: Double = 47.6588,
+        lon: Double = -117.4260,
+        callsign: String? = "Alpha",
+        teamName: String? = null,
+    ) = CoTEvent(uid = uid, type = type, lat = lat, lon = lon, callsign = callsign, teamName = teamName)
+
+    // ── icon-image id resolution ─────────────────────────────────────────────
+
+    @Test fun `milStd spec uses milstd prefix plus resolved sidc as image id`() {
+        val spec = ContactSymbolSpec.milStd(contact(type = "a-f-G-U-C"))
+        assertTrue(
+            "image id must be the milstd-<sidc> name ContactSymbolLayer registers, was ${spec.imageId}",
+            spec.imageId.startsWith(ContactSymbolLayer.ICON_IMAGE_PREFIX),
+        )
+        // Image id must not be blank past the prefix — a blank SIDC would make
+        // SymbolManager reference an unregistered image and silently hide.
+        assertTrue(
+            "resolved SIDC portion must be non-empty",
+            spec.imageId.length > ContactSymbolLayer.ICON_IMAGE_PREFIX.length,
+        )
+    }
+
+    @Test fun `from carries through the explicit TAK-suite image id verbatim`() {
+        val takId = "takicon-spot-${0xFFFFFFFF.toInt()}"
+        val spec = ContactSymbolSpec.from(contact(), resolvedImageId = takId)
+        assertEquals(takId, spec.imageId)
+    }
+
+    // ── callsign label (regression guard: "all blue, NO CALLSIGN") ───────────
+
+    @Test fun `callsign is preserved when present`() {
+        val spec = ContactSymbolSpec.milStd(contact(callsign = "Bravo-6"))
+        assertEquals("Bravo-6", spec.callsign)
+    }
+
+    @Test fun `blank or null callsign falls back to uid so no marker is anonymous`() {
+        assertEquals("uid-x", ContactSymbolSpec.milStd(contact(uid = "uid-x", callsign = null)).callsign)
+        assertEquals("uid-y", ContactSymbolSpec.milStd(contact(uid = "uid-y", callsign = "")).callsign)
+        assertEquals("uid-z", ContactSymbolSpec.milStd(contact(uid = "uid-z", callsign = "   ")).callsign)
+    }
+
+    // ── team color (regression guard: "ALL BLUE, no callsign") ───────────────
+    // The team color is carried on teamColorArgb and painted onto the callsign
+    // label (icon-color only tints SDF icons; our glyphs are full-color rasters —
+    // see ContactSymbolSpec). These assert the right color is carried.
+
+    @Test fun `team color overrides affiliation color when a team name is set`() {
+        // displayColor: TakTeamColor.forName("Red") = 0xFFFF0000 wins over the
+        // friendly-affiliation green — exactly the Red-1 case from the P-E report.
+        val spec = ContactSymbolSpec.milStd(contact(type = "a-f-G-U-C", teamName = "Red"))
+        assertEquals(0xFFFF0000.toInt(), spec.teamColorArgb)
+    }
+
+    @Test fun `hostile affiliation color is carried when no team name`() {
+        val spec = ContactSymbolSpec.milStd(contact(type = "a-h-G-U-C", teamName = null))
+        assertEquals(0xFFF44336.toInt(), spec.teamColorArgb)
+    }
+
+    @Test fun `friendly affiliation color is carried when no team name`() {
+        val spec = ContactSymbolSpec.milStd(contact(type = "a-f-G-U-C", teamName = null))
+        assertEquals(0xFF4ADE80.toInt(), spec.teamColorArgb)
+    }
+
+    @Test fun `team color survives the TAK-suite icon path too`() {
+        // Even when the icon is a baked-color TAK-suite glyph, the team color is
+        // still carried so the label tint reflects the operator's team.
+        val spec = ContactSymbolSpec.from(
+            contact(type = "a-f-G-U-C", teamName = "Orange"),
+            resolvedImageId = "takicon-spot-x",
+        )
+        assertEquals(0xFFFF6600.toInt(), spec.teamColorArgb)
+    }
+
+    // ── coordinates ─────────────────────────────────────────────────────────
+
+    @Test fun `lat lon are carried through unchanged`() {
+        val spec = ContactSymbolSpec.milStd(contact(lat = 12.34, lon = -56.78))
+        assertEquals(12.34, spec.lat, 0.0)
+        assertEquals(-56.78, spec.lon, 0.0)
+    }
+
+    @Test fun `uid is the diff key and is carried through`() {
+        assertEquals("contact-42", ContactSymbolSpec.milStd(contact(uid = "contact-42")).uid)
+    }
+}


### PR DESCRIPTION
## Issue #77 — dropped/contact markers don't paint on the 2D map (Adreno/Mali/Immortalis)

> **DRAFT — candidate fix. Needs on-device verification before merge** (see checklist). The GPU-paint behavior this targets cannot be reproduced or confirmed in CI / on an emulator that doesn't hit the driver bug.

### Root cause
Contacts rendered **only** through GeoJSON-source point layers:
- `ContactLayer` — a CircleLayer keyed on `color` in the inline style (`contacts-src`)
- `ContactSymbolLayer` — a runtime GeoJSON `SymbolLayer` with `addImage` icons

On **Adreno 610 / Mali-G57 / Pixel Immortalis** these point-symbol/circle GeoJSON layers are *queryable but never draw pixels* — a known MapLibre-Android fragment-pipeline failure (the codebase had already reverted a CircleLayer over the same bug; see the history note in `ContactSymbolLayer.kt`). A **full style reload does NOT fix it** (confirmed on-device, per the issue's device-test comment: dropping a marker then toggling 3D Terrain still doesn't paint it). That rules out repaint/atlas timing — it's the **layer type**.

The self-marker renders fine because it's a **`LocationComponent`** (annotation/bitmap path), not a GeoJSON layer. Drawings are Fill/Line layers and paint fine — untouched here. This is only the contact **point** markers.

### The fix — SymbolManager (annotation plugin), not a GeoJSON layer
Render contacts via MapLibre's **`SymbolManager`** (`org.maplibre.gl:android-plugin-annotation-v9`), the same proven render-path family as `LocationComponent`:

- **`ContactSymbolManager`** — one `SymbolManager` for all contacts. Registers the **exact same** MIL-STD / TAK-suite bitmaps under the **same image keys** as `ContactSymbolLayer` did (`MilStdIconCache`, `TakIconRegistry`, `IconPackRegistry`, `milstd-<sidc>` / `takicon-…`), so the glyphs are byte-identical — only the carrying layer changed. Diffs the contact collection against current symbols (add/update/remove) each update instead of recreating every symbol per tick.
- **Contact tap** now routes through the `SymbolManager` click listener → `onContactTap` (uid stashed in the symbol's `data`). The old manual nearest-contact hit-test loop in `TacticalMap` is removed. The self-marker (a `LocationComponent`, not a contact symbol) keeps its own hit-test.
- **Team color + callsign** (regression guard for the historic *"all blue, no callsign"* report): the callsign is drawn as `textField` with a dark halo, and the **team/affiliation color is painted on the label text**. Why not the icon: MapLibre `icon-color` only tints **SDF** icons; our MIL-STD frames and TAK-suite glyphs are full-color raster bitmaps, so an icon tint is a silent no-op and registering them SDF would flatten the multi-color frame to one hue. The icon keeps its own baked affiliation/suite colors; the team color rides on the (SDF-glyph) label, which tints reliably. This mirrors the GeoJSON path's icon-plus-separately-colored-element split without its never-painting CircleLayer.
- **Dependency added:** `org.maplibre.gl:android-plugin-annotation-v9:3.0.2` (the v9 plugin 3.x line targets MapLibre Native Android 11.x, matching the project's `android-sdk:11.8.0`).
- **GeoJSON path retired:** `ContactLayer` / `ContactSymbolLayer` are no longer fed from `TacticalMap` (install/update/safety-net/basemap-swap/AndroidView.update all switched to the SymbolManager). `ContactLayer.previewColor` (used by `MarkerEditSheet`) and the `ICON_IMAGE_PREFIX` constant remain referenced; the classes are otherwise unused. **Only one path pushes contacts now** — no competing pushes.

### What's unit-tested (pure JVM)
The load-bearing, device-free logic is extracted and TDD'd — the on-GPU paint is the only part a unit test can't assert:
- **`ContactSymbolSpecTest`** (10) — contact→symbol-spec mapping: `milstd-<sidc>` image-id resolution, callsign preserved, blank/null callsign falls back to uid (never anonymous), team-name color overrides affiliation color (Red-1 case), affiliation colors carried, team color carried through both MIL-STD and TAK-suite paths, lat/lon + uid pass-through.
- **`ContactSymbolDiffTest`** (10) — add/update/remove diff: new→add, gone→remove, identical→no-op (no needless re-push), moved/recolored/renamed/re-iconed→update (not add+remove), mixed pass, duplicate-uid collapse (last wins).

### Build / test status
- `./gradlew :app:testDebugUnitTest` — green (full module: **615 tests, 0 failures**; the 20 new tests included)
- `./gradlew :app:assembleDebug` — green (annotation-v9 resolves; APK assembles)

### ⚠️ Needs on-device verification (Mali / Adreno / Immortalis)
A real device exhibiting the bug is required — please confirm:
- [ ] **Drop a marker → it paints on the 2D map immediately**, with **no** 3D Terrain toggle / style reload needed (the exact failure from the issue).
- [ ] **Callsign renders** next to the icon (legible halo on light + dark basemaps).
- [ ] **Team color renders** on the callsign label — set a team (e.g. Red, Orange) and confirm the label reflects it (no "all blue").
- [ ] **MIL-STD icon glyph** is correct (friend/hostile/neutral/unknown frame) and matches what the 3D globe shows.
- [ ] **TAK-suite / FEMA / spot markers** render with their baked colors intact (not flattened).
- [ ] **Tap a marker → opens it** (`onContactTap` fires; reposition/edit sheet shows the right contact).
- [ ] **Tap the self-marker** still opens the reposition sheet (LocationComponent hit-test unaffected).
- [ ] **Basemap swap + 3D terrain toggle**: contacts survive the style reload (re-install path).
- [ ] Many contacts (CoT feed) update smoothly — diff path, no churn/flicker on each tick.