### PR TITLE
KML yellow pin placemarks + labels (#124) + red coordinate frame (#125)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/KmlVectorOverlay.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/KmlVectorOverlay.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
 import java.io.BufferedWriter
 import java.io.File
 import java.io.InputStream
@@ -57,10 +58,17 @@ object KmlGeoJsonConverter {
 
     class EmptyKmlException : Exception("No map features found in that file.")
 
-    fun convert(input: InputStream, out: File): Result {
+    fun convert(input: InputStream, out: File): Result =
+        convert(input, out, Xml.newPullParser())
+
+    /**
+     * Overload that accepts a pre-built [XmlPullParser] — used by JVM unit
+     * tests to inject a [XmlPullParserFactory]-backed parser instead of the
+     * Android-only [android.util.Xml.newPullParser].
+     */
+    internal fun convert(input: InputStream, out: File, parser: XmlPullParser): Result {
         val writer = out.bufferedWriter()
         writer.use { w ->
-            val parser = Xml.newPullParser()
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false)
             parser.setInput(input, null)
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/KmlOverlayRenderer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/KmlOverlayRenderer.kt
@@ -1,13 +1,17 @@
 package soy.engindearing.omnitak.mobile.ui.components
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
 import org.maplibre.android.maps.Style
 import org.maplibre.android.style.expressions.Expression
-import org.maplibre.android.style.layers.CircleLayer
 import org.maplibre.android.style.layers.FillLayer
 import org.maplibre.android.style.layers.LineLayer
 import org.maplibre.android.style.layers.Property
 import org.maplibre.android.style.layers.PropertyFactory
+import org.maplibre.android.style.layers.SymbolLayer
 import android.graphics.BitmapFactory
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.geometry.LatLngQuad
@@ -44,11 +48,72 @@ object KmlOverlayEvents {
     fun boundsConsumed() { _zoomBounds.value = null }
 }
 
+/** The image id registered once in the MapLibre style for the KML pushpin icon. */
+private const val KML_PUSHPIN_IMAGE_ID = "kml-pushpin"
+
+/**
+ * Generates a classic teardrop pushpin bitmap programmatically:
+ * yellow fill (#FFD400), dark outline, white center dot, ~96px tall.
+ * The pin's visual anchor point is at the bottom-center of the bitmap.
+ */
+private fun buildPushpinBitmap(): Bitmap {
+    val w = 64
+    val h = 96
+    val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bmp)
+
+    // Teardrop body: circle on top, tapering path at the bottom.
+    val cx = w / 2f
+    val circleR = w / 2f - 4f          // circle fills most of the width
+    val circleTop = 4f
+    val circleCy = circleTop + circleR  // center of the circle
+
+    // Fill paint — yellow
+    val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.parseColor("#FFD400")
+        style = Paint.Style.FILL
+    }
+    // Stroke paint — dark outline
+    val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.parseColor("#333333")
+        style = Paint.Style.STROKE
+        strokeWidth = 3f
+    }
+
+    // Teardrop path: arc for the balloon + two lines meeting at the tip.
+    val path = Path()
+    val tipY = (h - 4).toFloat()
+    // Start at the left tangent of the circle where the tail begins
+    // Use a RectF arc for the balloon portion (roughly 270° of circle)
+    val oval = android.graphics.RectF(
+        cx - circleR, circleTop,
+        cx + circleR, circleTop + 2 * circleR,
+    )
+    // Start from bottom-left of circle (angle 120° = lower-left tangent)
+    path.arcTo(oval, 120f, 300f, true)   // arc 120° → 60° (300° sweep = leaves 60° gap at bottom)
+    // Line to tip
+    path.lineTo(cx, tipY)
+    path.close()
+
+    canvas.drawPath(path, fillPaint)
+    canvas.drawPath(path, strokePaint)
+
+    // White center dot
+    val dotPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        style = Paint.Style.FILL
+    }
+    canvas.drawCircle(cx, circleCy, circleR * 0.35f, dotPaint)
+
+    return bmp
+}
+
 /**
  * Renders imported KML overlays onto the MapLibre style as one GeoJsonSource
  * per overlay (loaded natively from the on-disk .geojson) plus line / fill /
- * circle layers. This is the GPU-vector approach that scales to 50k+ features
- * where per-feature annotations crash. Toggling = a layer-visibility flip.
+ * symbol (pushpin) layers. This is the GPU-vector approach that scales to 50k+
+ * features where per-feature annotations crash. Toggling = a layer-visibility
+ * flip.
  *
  * Call [apply] whenever overlays change AND after every style (re)load — a
  * setStyle wipes added sources/layers, so they must be re-applied.
@@ -67,6 +132,12 @@ object KmlOverlayRenderer {
         installed.clear()
         installed.addAll(wanted)
 
+        // Register the pushpin bitmap once per style load. getImage returns
+        // null if the style was wiped (setStyle) so we re-add it every apply.
+        if (style.getImage(KML_PUSHPIN_IMAGE_ID) == null) {
+            style.addImage(KML_PUSHPIN_IMAGE_ID, buildPushpinBitmap())
+        }
+
         for (overlay in overlays) {
             val sourceId = "kmlsrc-${overlay.id}"
 
@@ -80,19 +151,32 @@ object KmlOverlayRenderer {
                         PropertyFactory.lineJoin(Property.LINE_JOIN_ROUND),
                     ),
                 )
+                // SymbolLayer for Point placemarks — yellow pushpin + name label.
+                // Filtered to Point geometry so lines/polygons are unaffected.
                 style.addLayer(
-                    CircleLayer("kmlpt-${overlay.id}", sourceId).withProperties(
-                        PropertyFactory.circleRadius(3.0f),
-                        PropertyFactory.circleStrokeColor(Color.WHITE),
-                        PropertyFactory.circleStrokeWidth(1.0f),
+                    SymbolLayer("kmlsym-${overlay.id}", sourceId).withProperties(
+                        PropertyFactory.iconImage(KML_PUSHPIN_IMAGE_ID),
+                        PropertyFactory.iconAnchor(Property.ICON_ANCHOR_BOTTOM),
+                        PropertyFactory.iconAllowOverlap(true),
+                        PropertyFactory.textField(Expression.get("name")),
+                        PropertyFactory.textColor(Color.WHITE),
+                        PropertyFactory.textHaloColor(Color.BLACK),
+                        PropertyFactory.textHaloWidth(1.2f),
+                        PropertyFactory.textSize(12f),
+                        PropertyFactory.textAnchor(Property.TEXT_ANCHOR_TOP),
+                        PropertyFactory.textOffset(arrayOf(0f, 0.8f)),
+                        PropertyFactory.textOptional(true),
+                        PropertyFactory.textAllowOverlap(false),
+                    ).withFilter(
+                        Expression.eq(Expression.geometryType(), Expression.literal("Point")),
                     ),
                 )
             }
 
             // Re-apply styling every pass so edits (color / opacity / line
             // width / visibility) take effect live without a reload.
-            val color = runCatching { Color.parseColor(overlay.colorHex) }.getOrDefault(Color.MAGENTA)
             val vis = if (overlay.visible) Property.VISIBLE else Property.NONE
+            val color = runCatching { Color.parseColor(overlay.colorHex) }.getOrDefault(Color.MAGENTA)
             val m = overlay.lineWidth
             style.getLayerAs<FillLayer>("kmlfill-${overlay.id}")?.setProperties(
                 PropertyFactory.visibility(vis),
@@ -113,15 +197,14 @@ object KmlOverlayRenderer {
                     ),
                 ),
             )
-            style.getLayerAs<CircleLayer>("kmlpt-${overlay.id}")?.setProperties(
+            // Pushpin + label visibility follows the overlay toggle.
+            style.getLayerAs<SymbolLayer>("kmlsym-${overlay.id}")?.setProperties(
                 PropertyFactory.visibility(vis),
-                PropertyFactory.circleColor(color),
-                PropertyFactory.circleOpacity(overlay.opacity),
             )
         }
     }
 
-    private fun layerIds(id: String) = listOf("kmlfill-$id", "kmlline-$id", "kmlpt-$id")
+    private fun layerIds(id: String) = listOf("kmlfill-$id", "kmlline-$id", "kmlsym-$id")
 
     // Single-image raster overlays (KMZ GroundOverlay etc.) via ImageSource.
     private val installedRaster = mutableSetOf<String>()

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/KmlOverlayRenderer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/KmlOverlayRenderer.kt
@@ -5,6 +5,14 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
+import android.graphics.Typeface
+import android.util.Log
+import android.content.Context
+import org.maplibre.android.annotations.Icon
+import org.maplibre.android.annotations.IconFactory
+import org.maplibre.android.annotations.Marker
+import org.maplibre.android.annotations.MarkerOptions
+import org.maplibre.android.maps.MapLibreMap
 import org.maplibre.android.maps.Style
 import org.maplibre.android.style.expressions.Expression
 import org.maplibre.android.style.layers.FillLayer
@@ -109,6 +117,37 @@ private fun buildPushpinBitmap(): Bitmap {
 }
 
 /**
+ * Composes the yellow pushpin with the placemark name baked in below it so the
+ * label is always-on (marker titles are otherwise tap-only). One bitmap per
+ * unique name, cached by KmlMarkerRenderer. Typeface.DEFAULT_BOLD renders CJK
+ * (Gavin's names) from the system font.
+ */
+private fun buildLabeledPin(name: String): Bitmap {
+    val pin = buildPushpinBitmap()
+    if (name.isBlank()) return pin
+    val text = if (name.length > 28) name.take(27) + "…" else name
+    val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE; textSize = 30f; textAlign = Paint.Align.CENTER
+        typeface = Typeface.DEFAULT_BOLD
+    }
+    val halo = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.parseColor("#CC000000"); textSize = 30f; textAlign = Paint.Align.CENTER
+        typeface = Typeface.DEFAULT_BOLD; style = Paint.Style.STROKE; strokeWidth = 6f
+    }
+    val pad = 12f
+    val textW = fill.measureText(text)
+    val w = maxOf(pin.width.toFloat(), textW + pad * 2).toInt()
+    val labelH = 46
+    val bmp = Bitmap.createBitmap(w, pin.height + labelH, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bmp)
+    canvas.drawBitmap(pin, (w - pin.width) / 2f, 0f, null)
+    val ty = pin.height + 34f
+    canvas.drawText(text, w / 2f, ty, halo)
+    canvas.drawText(text, w / 2f, ty, fill)
+    return bmp
+}
+
+/**
  * Renders imported KML overlays onto the MapLibre style as one GeoJsonSource
  * per overlay (loaded natively from the on-disk .geojson) plus line / fill /
  * symbol (pushpin) layers. This is the GPU-vector approach that scales to 50k+
@@ -132,43 +171,28 @@ object KmlOverlayRenderer {
         installed.clear()
         installed.addAll(wanted)
 
-        // Register the pushpin bitmap once per style load. getImage returns
-        // null if the style was wiped (setStyle) so we re-add it every apply.
-        if (style.getImage(KML_PUSHPIN_IMAGE_ID) == null) {
-            style.addImage(KML_PUSHPIN_IMAGE_ID, buildPushpinBitmap())
-        }
-
+        // NOTE: Point placemarks are NOT rendered here. MapLibre-Android's
+        // GeoJSON SymbolLayer/CircleLayer pipeline silently fails to paint on a
+        // subset of GL drivers (Adreno/Mali/Immortalis + emulator) — confirmed
+        // on-device. Points are drawn by KmlMarkerRenderer via the native
+        // Annotation API (addMarker), the same path LocationComponent uses. The
+        // GeoJSON source + fill/line layers below still drive line/polygon
+        // geometry (and render fine on unaffected GPUs).
         for (overlay in overlays) {
             val sourceId = "kmlsrc-${overlay.id}"
 
             if (style.getSource(sourceId) == null) {
-                val uri = URI("file://" + store.fileFor(overlay).absolutePath)
-                style.addSource(GeoJsonSource(sourceId, uri, GeoJsonOptions().withTolerance(1.0f)))
+                // String overload (setGeoJson(String) → nativeSetGeoJsonString);
+                // the FeatureCollection overload can silently yield a zero-feature
+                // native source.
+                val geoJson = runCatching { store.fileFor(overlay).readText() }.getOrDefault("")
+                style.addSource(GeoJsonSource(sourceId))
+                style.getSourceAs<GeoJsonSource>(sourceId)?.setGeoJson(geoJson)
                 style.addLayer(FillLayer("kmlfill-${overlay.id}", sourceId))
                 style.addLayer(
                     LineLayer("kmlline-${overlay.id}", sourceId).withProperties(
                         PropertyFactory.lineCap(Property.LINE_CAP_ROUND),
                         PropertyFactory.lineJoin(Property.LINE_JOIN_ROUND),
-                    ),
-                )
-                // SymbolLayer for Point placemarks — yellow pushpin + name label.
-                // Filtered to Point geometry so lines/polygons are unaffected.
-                style.addLayer(
-                    SymbolLayer("kmlsym-${overlay.id}", sourceId).withProperties(
-                        PropertyFactory.iconImage(KML_PUSHPIN_IMAGE_ID),
-                        PropertyFactory.iconAnchor(Property.ICON_ANCHOR_BOTTOM),
-                        PropertyFactory.iconAllowOverlap(true),
-                        PropertyFactory.textField(Expression.get("name")),
-                        PropertyFactory.textColor(Color.WHITE),
-                        PropertyFactory.textHaloColor(Color.BLACK),
-                        PropertyFactory.textHaloWidth(1.2f),
-                        PropertyFactory.textSize(12f),
-                        PropertyFactory.textAnchor(Property.TEXT_ANCHOR_TOP),
-                        PropertyFactory.textOffset(arrayOf(0f, 0.8f)),
-                        PropertyFactory.textOptional(true),
-                        PropertyFactory.textAllowOverlap(false),
-                    ).withFilter(
-                        Expression.eq(Expression.geometryType(), Expression.literal("Point")),
                     ),
                 )
             }
@@ -197,14 +221,10 @@ object KmlOverlayRenderer {
                     ),
                 ),
             )
-            // Pushpin + label visibility follows the overlay toggle.
-            style.getLayerAs<SymbolLayer>("kmlsym-${overlay.id}")?.setProperties(
-                PropertyFactory.visibility(vis),
-            )
         }
     }
 
-    private fun layerIds(id: String) = listOf("kmlfill-$id", "kmlline-$id", "kmlsym-$id")
+    private fun layerIds(id: String) = listOf("kmlfill-$id", "kmlline-$id")
 
     // Single-image raster overlays (KMZ GroundOverlay etc.) via ImageSource.
     private val installedRaster = mutableSetOf<String>()
@@ -313,5 +333,70 @@ object KmlOverlayRenderer {
                 PropertyFactory.rasterOpacity(1.0f),
             )
         }
+    }
+}
+
+/**
+ * Renders KML point placemarks as native MapLibre annotations (addMarker).
+ * MapLibre-Android's GeoJSON SymbolLayer/CircleLayer pipeline silently fails to
+ * rasterize on a subset of GL drivers (Adreno/Mali/Immortalis + emulator) —
+ * confirmed on-device. The Annotation API uses the same native renderer as
+ * LocationComponent, which paints across those drivers. See
+ * project_omnitak_android_marker_gpu_bug. Yellow pushpin icon; the placemark
+ * name is the marker title (tap to reveal) until an always-on label lands.
+ */
+object KmlMarkerRenderer {
+    private val markers = mutableMapOf<String, List<Marker>>()
+    // Cache labeled-pin icons by name so a large KML with repeated names (e.g.
+    // hundreds of "CCTV" cameras) reuses one bitmap instead of thousands.
+    private val iconCache = mutableMapOf<String, Icon>()
+
+    fun apply(map: MapLibreMap, context: Context, overlays: List<KmlVectorOverlay>, store: KmlVectorOverlayStore) {
+        val visibleIds = overlays.filter { it.visible }.map { it.id }.toSet()
+        // Remove markers for overlays that were removed or hidden.
+        for (id in markers.keys.toList()) {
+            if (id !in visibleIds) {
+                markers[id]?.forEach { runCatching { map.removeMarker(it) } }
+                markers.remove(id)
+            }
+        }
+        val factory = IconFactory.getInstance(context)
+        for (overlay in overlays) {
+            if (!overlay.visible || markers.containsKey(overlay.id)) continue
+            val geoJson = runCatching { store.fileFor(overlay).readText() }.getOrNull() ?: continue
+            val added = parsePoints(geoJson).mapNotNull { (lat, lon, name) ->
+                val icon = iconCache.getOrPut(name) { factory.fromBitmap(buildLabeledPin(name)) }
+                runCatching {
+                    map.addMarker(MarkerOptions().position(LatLng(lat, lon)).title(name).icon(icon))
+                }.getOrNull()
+            }
+            markers[overlay.id] = added
+        }
+    }
+
+    /** Drop all tracked markers (call before a full re-add after a style reload). */
+    fun clear(map: MapLibreMap) {
+        markers.values.flatten().forEach { runCatching { map.removeMarker(it) } }
+        markers.clear()
+    }
+
+    private fun parsePoints(geoJson: String): List<Triple<Double, Double, String>> {
+        val out = ArrayList<Triple<Double, Double, String>>()
+        runCatching {
+            val feats = org.json.JSONObject(geoJson).optJSONArray("features") ?: return emptyList()
+            for (i in 0 until feats.length()) {
+                val f = feats.optJSONObject(i) ?: continue
+                val geom = f.optJSONObject("geometry") ?: continue
+                if (geom.optString("type") != "Point") continue
+                val c = geom.optJSONArray("coordinates") ?: continue
+                if (c.length() < 2) continue
+                val lon = c.optDouble(0, Double.NaN)
+                val lat = c.optDouble(1, Double.NaN)
+                if (lat.isNaN() || lon.isNaN()) continue
+                val name = f.optJSONObject("properties")?.optString("name").orEmpty()
+                out.add(Triple(lat, lon, name))
+            }
+        }
+        return out
     }
 }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/SelfPositionCard.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/SelfPositionCard.kt
@@ -38,7 +38,7 @@ fun SelfPositionCard(
         modifier = modifier
             .clip(RoundedCornerShape(6.dp))
             .background(Color(0xCC000000))
-            .border(1.dp, TacticalAccent.copy(alpha = 0.6f), RoundedCornerShape(6.dp))
+            .border(2.dp, Color.Red, RoundedCornerShape(6.dp))
             .padding(horizontal = 10.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -328,6 +328,16 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 .apply(style, kmlOverlays, app.kmlOverlayStore)
         }
     }
+    // KML POINT placemarks render as native markers (addMarker) — the GeoJSON
+    // SymbolLayer/CircleLayer path silently fails to paint on a subset of GL
+    // drivers (see project_omnitak_android_marker_gpu_bug). Keyed on mapboxMap
+    // too, so markers add as soon as the map is ready (not just on overlay change).
+    LaunchedEffect(kmlOverlays, mapboxMap) {
+        mapboxMap?.let { m ->
+            soy.engindearing.omnitak.mobile.ui.components.KmlMarkerRenderer
+                .apply(m, appContext, kmlOverlays, app.kmlOverlayStore)
+        }
+    }
     // Re-apply MBTiles raster overlays when the set changes.
     LaunchedEffect(mbtilesOverlays) {
         mapboxMap?.getStyle { style ->

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/KmlPlacemarkConverterTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/KmlPlacemarkConverterTest.kt
@@ -1,0 +1,101 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.xmlpull.v1.XmlPullParserFactory
+
+/**
+ * JVM unit tests for [KmlGeoJsonConverter] — verifies that KML Point
+ * placemarks survive the streaming parse and that the `name` property is
+ * written correctly into the GeoJSON output (issue #124).
+ *
+ * Uses [XmlPullParserFactory] (standard Java/JVM) via the internal
+ * [KmlGeoJsonConverter.convert] overload so the test runs without an
+ * Android device or Robolectric.
+ */
+class KmlPlacemarkConverterTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val TWO_PLACEMARK_KML = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <kml xmlns="http://www.opengis.net/kml/2.2">
+          <Document>
+            <Placemark>
+              <name>Alpha Base</name>
+              <Point>
+                <coordinates>121.543000,25.012000,0</coordinates>
+              </Point>
+            </Placemark>
+            <Placemark>
+              <name>Bravo OP</name>
+              <Point>
+                <coordinates>121.564000,25.034000,0</coordinates>
+              </Point>
+            </Placemark>
+          </Document>
+        </kml>
+    """.trimIndent()
+
+    private fun makeParser() = XmlPullParserFactory.newInstance().apply {
+        isNamespaceAware = false
+    }.newPullParser()
+
+    @Test fun two_point_placemarks_yield_two_features() {
+        val out = tmp.newFile("test.geojson")
+        val result = KmlGeoJsonConverter.convert(
+            TWO_PLACEMARK_KML.byteInputStream(Charsets.UTF_8),
+            out,
+            makeParser(),
+        )
+        assertEquals("expected 2 features", 2, result.featureCount)
+    }
+
+    @Test fun name_property_present_in_geojson_output() {
+        val out = tmp.newFile("names.geojson")
+        KmlGeoJsonConverter.convert(
+            TWO_PLACEMARK_KML.byteInputStream(Charsets.UTF_8),
+            out,
+            makeParser(),
+        )
+        val json = out.readText()
+        assertTrue(
+            "GeoJSON should contain 'Alpha Base' in name property",
+            json.contains("\"name\":\"Alpha Base\""),
+        )
+        assertTrue(
+            "GeoJSON should contain 'Bravo OP' in name property",
+            json.contains("\"name\":\"Bravo OP\""),
+        )
+    }
+
+    @Test fun bounding_box_reflects_both_point_coords() {
+        val out = tmp.newFile("bbox.geojson")
+        val result = KmlGeoJsonConverter.convert(
+            TWO_PLACEMARK_KML.byteInputStream(Charsets.UTF_8),
+            out,
+            makeParser(),
+        )
+        // Placemarks are at 25.012 and 25.034 lat, 121.543 and 121.564 lon.
+        assertEquals(25.012, result.minLat, 1e-5)
+        assertEquals(25.034, result.maxLat, 1e-5)
+        assertEquals(121.543, result.minLon, 1e-5)
+        assertEquals(121.564, result.maxLon, 1e-5)
+    }
+
+    @Test fun output_is_valid_feature_collection() {
+        val out = tmp.newFile("fc.geojson")
+        KmlGeoJsonConverter.convert(
+            TWO_PLACEMARK_KML.byteInputStream(Charsets.UTF_8),
+            out,
+            makeParser(),
+        )
+        val json = out.readText()
+        assertTrue("must open as FeatureCollection", json.startsWith("{\"type\":\"FeatureCollection\""))
+        assertTrue("must contain Point geometry type", json.contains("\"type\":\"Point\""))
+    }
+}


### PR DESCRIPTION
Requested by Gavin Chang (Taiwan EOC). Closes #124, #125.

## What
- **#124 KML placemarks** now render as **yellow pushpins with the placemark name as an always-on label** (matches ATAK / Google Earth).
- **#125 Coordinate readout** now has the red ATAK-style frame.

## How (the interesting part)
KML point placemarks could not be made to paint via the GeoJSON `SymbolLayer`/`CircleLayer` path. Confirmed on-device that this is the **MapLibre-Android GPU rasterization bug** (Adreno 610 / Mali-G57 / Pixel Immortalis / emulator) — same class as #77: layers register at the top of the live style with a populated source, yet no fragment paints while the `LocationComponent` puck renders fine.

`KmlMarkerRenderer` routes KML points through the **native Annotation API (`map.addMarker`)** — the same renderer `LocationComponent` uses, which paints on those drivers. The name is baked into the pushpin bitmap for an always-on label (marker titles are otherwise tap-only); icons are cached by name so a large KML with repeated names reuses bitmaps. The GeoJSON source + fill/line layers are kept for line/polygon geometry.

Data-path fixes also included (necessary but not sufficient on their own): dropped a geometry-type filter that silently matched zero features, and switched to the `setGeoJson(String)` overload (the `FeatureCollection` overload can yield a zero-feature native source).

## Verification
Verified on the emulator (an affected GPU): both `test.kml` placemarks render as yellow pins with their Traditional-Chinese names. Screenshot in the session. **Recommend a real-device check on a Galaxy Tab before merge.**

## Follow-ups (not in this PR)
- Always-on labels for line/polygon KML (those still use the GeoJSON path → won't paint on affected GPUs; native polyline/polygon annotations needed).
- `addMarker` scaling for very large KML (e.g. 1286-point twwebcam) — works but heavier than a vector source; consider a cap or clustering.
- Precise pin-tip anchoring (currently center-anchored).