### PR TITLE
build: MapLibre 13.3.0 (Vulkan) + Kotlin 2.2.10 — root-fix 2D GPU paint bug (#77/#80/#124)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
-    kotlin("plugin.serialization") version "2.0.21"
+    kotlin("plugin.serialization") version "2.2.10"
 }
 
 android {
@@ -162,8 +162,11 @@ dependencies {
     // only non-secret fields; see SecureCredentialStore.
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
-    // MapLibre Android (open-source fork of Mapbox) — parallel to iOS
-    implementation("org.maplibre.gl:android-sdk:11.8.0")
+    // MapLibre Android (open-source fork of Mapbox) — parallel to iOS.
+    // 13.x switched the renderer from OpenGL ES to Vulkan, which fixes the
+    // GeoJSON SymbolLayer/CircleLayer GPU paint failure on Adreno/Mali
+    // (#77 / #80 / #124). Requires Kotlin 2.2.x (see root build.gradle.kts).
+    implementation("org.maplibre.gl:android-sdk:13.3.0")
 
     // NGA's tested MGRS / UTM converter. Operators rely on grid coords
     // for navigation; rolling our own would risk silent miscalculation.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,6 @@ plugins {
     id("com.android.application") version "8.7.3" apply false
     // Library plugin for the :plugins:* modules (SDK + bundled plugins).
     id("com.android.library") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
 }


### PR DESCRIPTION
## What
Bump `org.maplibre.gl:android-sdk` **11.8.0 → 13.3.0** (Vulkan backend) and the Kotlin toolchain **2.0.21 → 2.2.10** (required by 13.x).

## Why — root-fix the GeoJSON-layer GPU paint bug (#77 / #80 / #124)
MapLibre-Android 13.x replaced the OpenGL ES renderer with **Vulkan**. The long-standing bug where GeoJSON `SymbolLayer` / `CircleLayer` / `LineLayer` silently fail to rasterize on Adreno 610 / Mali-G57 (markers, drawings, KML invisible on the 2D map) is a GL-driver paint failure — Vulkan sidesteps it. Fixing it at the renderer level would let us drop the per-feature native-marker workarounds and re-enable native clustering/decluttering (obsoleting #128).

## Scope
- `app/build.gradle.kts`: MapLibre `13.3.0`; `plugin.serialization` `2.2.10`
- `build.gradle.kts`: `kotlin.android` + `plugin.compose` `2.2.10`
- No KSP; Compose compiler rides lockstep with Kotlin. **AGP 8.7.3 / Gradle 8.11.1 / Java 17 unchanged.**
- **Zero MapLibre API changes** — the app compiles against 13.3.0 as-is.

## Validation
- ✅ `:app:compileDebugKotlin` + `:app:assembleDebug` — BUILD SUCCESSFUL, full APK, no MapLibre API errors.
- ✅ **On-device render (emulator):** `engie_emulator` exposes Vulkan 1.2 — the *same* surface where the GL build failed to paint. A seeded KML GeoJSON overlay's **LineLayer + CircleLayer render** (Vulkan backend confirmed active via `libvulkan` load). Proof: `omnitak-gavin-features-shots/vulkan-emu-geojson-paints.png`.

## ⚠️ Draft — before merge
- [ ] **Real-device confirmation** on actual Adreno/Mali hardware (Galaxy Tab A9+, Mali-G57). Emulator Vulkan (ranchu→Metal) is a strong signal but not identical to vendor drivers. *(Currently blocked on adb access to the Tab.)*
- [ ] Native-marker workarounds (`map.addMarker`) intentionally **left intact** here as belt-and-suspenders; remove in a follow-up once real-device confirms.
- [ ] Non-blocking: Kotlin 2.2 surfaces `jvmTarget` DSL + a few Compose `AutoMirrored` / `LocalLifecycleOwner` deprecation **warnings** — cosmetic, follow-up.

Refs #129
