### PR TITLE
chore(release): Android 0.37.0 (versionCode 95)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 94
-        versionName = "0.36.0"
+        versionCode = 95
+        versionName = "0.37.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }


### PR DESCRIPTION
Version bump for the 0.37.0 release (KML pins/coords #127, already merged). AAB OmniTAK-0.37.0-vc95.aab built + staged for Play upload.