### PR TITLE
chore(release): sync versionCode to 96

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 95
+        versionCode = 96
         versionName = "0.37.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
0.37.0 shipped as vc96 (Play Console already had vc95). Syncing main's versionCode so the next release bumps from 96, not re-computing 95/96. Going forward, build-release.sh's floor should track Play's actual max — Play can be ahead of the git-tracked code.