### PR TITLE
chore(release): OmniTAK Android 0.38.0 (versionCode 97)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 96
-        versionName = "0.37.0"
+        versionCode = 97
+        versionName = "0.38.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }


### PR DESCRIPTION
Version bump for the 0.38.0 release (signed AAB built at versionCode 97, monotonic past the released vc96).

**What's in 0.38.0** — 2D map rendering batch (all merged to main):
- Native render of contacts/dropped markers (#77/#135), drawings (#80/#138), KML lines+polygons (#136/#137), KML clustering (#128/#134) — fixes the GeoJSON GL paint bug that left these invisible on Adreno/Mali/emulator
- Contacts as centered dots so tap-to-edit + lasso select/delete hit (#140)
- Map refreshes on marker/drawing create/edit/delete — no 2D/3D toggle (#141)

AAB staged at `playstore-assets/OmniTAK-0.38.0-vc97.aab` for Play upload. README download links + a GitHub release (sideload APK) are a follow-up once the release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)