### PR TITLE
docs: README download → v0.38.0 (vc97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ OmniTAK for Android is in **Google Play closed testing**, and every tester helps
 
 [![Latest release](https://img.shields.io/github/v/release/engindearing-projects/OmniTAK-Android?label=latest&sort=semver)](https://github.com/engindearing-projects/OmniTAK-Android/releases/latest)
 
-**Current release: [v0.37.0 (versionCode 96)](https://github.com/engindearing-projects/OmniTAK-Android/releases/tag/v0.37.0)** — KML placemarks as labeled yellow pins + a red-framed coordinate readout, offline map regions, custom icon-pack import + full FEMA/ICS-237 symbols, TAK/ATAK QR enrollment, keepalive + auto-reconnect, self-marker upgrades (reposition / triangle / heading / team color), and EN/PL/DE/FR localization.
+**Current release: [v0.38.0 (versionCode 97)](https://github.com/engindearing-projects/OmniTAK-Android/releases/tag/v0.38.0)** — 2D map rendering batch: dropped markers, contacts, and operator drawings now render on the 2D map across all GPUs, imported KML renders fully (points, lines, and polygons) with clustering for large files, markers refresh instantly on create/edit/delete, and tap-to-edit + lasso select/delete reliably hit dropped markers. Builds on 0.37.0 (KML pins, red-framed coords, offline regions, icon-pack import, FEMA symbols, QR enrollment, EN/PL/DE/FR).
 
-- **Signed APK (sideload):** [OmniTAK-0.37.0-vc96.apk](https://github.com/engindearing-projects/OmniTAK-Android/releases/download/v0.37.0/OmniTAK-0.37.0-vc96.apk)
+- **Signed APK (sideload):** [OmniTAK-0.38.0-vc97.apk](https://github.com/engindearing-projects/OmniTAK-Android/releases/download/v0.38.0/OmniTAK-0.38.0-vc97.apk)
 - **Always-latest APK:** [releases/latest](https://github.com/engindearing-projects/OmniTAK-Android/releases/latest)
 - **Google Play (closed testing):** [sign up at omnitak.engindearing.soy](https://omnitak.engindearing.soy) with your Google-account email
 
@@ -29,7 +29,7 @@ OmniTAK for Android is in **Google Play closed testing**, and every tester helps
 Verify the APK before installing — signing cert SHA-256 should be `9f3b1fd54ad4eb1dc5b45d91deac4699869617d3d2ac425a1b70337aa0eb13af`:
 
 ```bash
-apksigner verify --print-certs OmniTAK-0.37.0-vc96.apk
+apksigner verify --print-certs OmniTAK-0.38.0-vc97.apk
 ```
 
 ## Screenshots


### PR DESCRIPTION
Point the README current-release / sideload-APK / apksigner-verify references at the new v0.38.0 release (now live with the signed APK).