### PR TITLE
fix(map): identifying User-Agent so OSM/OpenTopoMap serve real tiles (#139)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,6 +165,15 @@ dependencies {
     // MapLibre Android (open-source fork of Mapbox) — parallel to iOS
     implementation("org.maplibre.gl:android-sdk:11.8.0")
 
+    // OkHttp — used ONLY to install a custom HTTP client into MapLibre via
+    // HttpRequestUtil.setOkHttpClient(), so we can send an identifying
+    // User-Agent on tile requests. OpenStreetMap (and OpenTopoMap) serve a
+    // "403 Access blocked" placeholder tile to clients with a generic UA;
+    // an app-identifying UA is required by their tile usage policy (#139).
+    // MapLibre 11.x already bundles OkHttp 4.x; we pin the same major so the
+    // resolved version stays compatible.
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
     // NGA's tested MGRS / UTM converter. Operators rely on grid coords
     // for navigation; rolling our own would risk silent miscalculation.
     // Pure-Java, ~250 KB, no Android resources.

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -46,6 +46,12 @@ class OmniTAKApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // #139 — give MapLibre an HTTP client that sends an app-identifying
+        // User-Agent. OSM/OpenTopoMap serve a "403 Access blocked" tile to
+        // clients with a generic UA. Must run before any MapView is created so
+        // the first tile fetch already carries it.
+        soy.engindearing.omnitak.mobile.data.MapTileHttp.install(this)
+
         // Restore the operator's UI language (or match the device locale)
         // before any Activity composes, so the first frame renders in the
         // right language. Mirrors iOS's LocalizationManager init.

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MapTileHttp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MapTileHttp.kt
@@ -1,0 +1,82 @@
+package soy.engindearing.omnitak.mobile.data
+
+import android.content.Context
+import android.os.Build
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import org.maplibre.android.MapLibre
+import org.maplibre.android.module.http.HttpRequestUtil
+import soy.engindearing.omnitak.mobile.BuildConfig
+
+/**
+ * Installs a custom HTTP client into MapLibre so every tile request carries an
+ * app-identifying `User-Agent`.
+ *
+ * Why this exists (#139): OpenStreetMap's and OpenTopoMap's volunteer tile
+ * servers enforce a tile usage policy that *requires* a valid User-Agent
+ * identifying the application. Clients that send a generic UA (the default
+ * okhttp/Dalvik string MapLibre ships with) are served a "403 Access blocked"
+ * placeholder tile pointing at osm.wiki/Blocked instead of real map data — the
+ * map looks broken. A UA that starts with `OmniTAK/<version>` gets real tiles.
+ *
+ * Verified empirically against tile.openstreetmap.org: empty / `okhttp/4.x` /
+ * `Dalvik/...` UAs all return the 6987-byte "Access blocked" tile, while
+ * `OmniTAK/0.38.0 (+https://omnitak.engindearing.soy)` returns the real tile.
+ *
+ * Satellite (Esri) was unaffected because Esri's imagery endpoint does not
+ * enforce a UA policy — which is exactly why the reporter saw Satellite work
+ * while OSM did not.
+ */
+object MapTileHttp {
+
+    /**
+     * Builds the User-Agent string. Pure + side-effect free so it can be unit
+     * tested. OSM policy asks for something that identifies the app and offers
+     * a way to make contact; the project URL serves as that contact point.
+     *
+     * Example: `OmniTAK/0.38.0 (+https://omnitak.engindearing.soy; Android 14)`
+     */
+    fun buildUserAgent(
+        versionName: String = BuildConfig.VERSION_NAME,
+        androidRelease: String = Build.VERSION.RELEASE ?: "",
+    ): String {
+        val version = versionName.ifBlank { "dev" }
+        val androidPart = if (androidRelease.isBlank()) "Android" else "Android $androidRelease"
+        return "OmniTAK/$version (+https://omnitak.engindearing.soy; $androidPart)"
+    }
+
+    /**
+     * Build the OkHttp client MapLibre should use. Adds the User-Agent header to
+     * every request; otherwise leans on okhttp defaults (MapLibre keeps its own
+     * SQLite tile cache, so an HTTP cache here is unnecessary).
+     */
+    fun buildClient(userAgent: String = buildUserAgent()): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(userAgentInterceptor(userAgent))
+            .build()
+
+    /** Interceptor that sets `User-Agent` on the outgoing request. */
+    fun userAgentInterceptor(userAgent: String): Interceptor =
+        Interceptor { chain ->
+            val request = chain.request().newBuilder()
+                .header("User-Agent", userAgent)
+                .build()
+            chain.proceed(request)
+        }
+
+    /**
+     * Install the identifying client into MapLibre. Call once at app start,
+     * before any [org.maplibre.android.maps.MapView] is created so the very
+     * first tile fetch already carries the UA.
+     *
+     * [MapLibre.getInstance] must run first: MapLibre's HTTP layer
+     * (`HttpRequestImpl`) statically initializes against the MapLibre singleton
+     * via `HttpIdentifier`, so calling [HttpRequestUtil.setOkHttpClient] before
+     * the singleton exists throws MapLibreConfigurationException. getInstance is
+     * idempotent, so the lazy call inside the map composable stays a no-op.
+     */
+    fun install(context: Context) {
+        MapLibre.getInstance(context)
+        HttpRequestUtil.setOkHttpClient(buildClient())
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MapTileHttpTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MapTileHttpTest.kt
@@ -1,0 +1,95 @@
+package soy.engindearing.omnitak.mobile.data
+
+import okhttp3.Call
+import okhttp3.Connection
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #139 — OSM/OpenTopoMap serve a "403 Access blocked" tile to clients with a
+ * generic User-Agent. These lock in that MapLibre's tile requests carry an
+ * app-identifying UA (`OmniTAK/<version>`), which the curl repro proved gets
+ * real tiles instead of the blocked placeholder.
+ */
+class MapTileHttpTest {
+
+    @Test fun userAgent_startsWith_OmniTAK_slash_version() {
+        // OSM keys its block on the leading token — it MUST be "OmniTAK/<ver>".
+        val ua = MapTileHttp.buildUserAgent(versionName = "0.38.0", androidRelease = "14")
+        assertTrue("UA must start with OmniTAK/<version>, was: $ua",
+            ua.startsWith("OmniTAK/0.38.0"))
+    }
+
+    @Test fun userAgent_includes_contact_url() {
+        // Policy asks for a way to make contact; the project URL is it.
+        val ua = MapTileHttp.buildUserAgent(versionName = "0.38.0", androidRelease = "14")
+        assertTrue("UA must carry a contact URL, was: $ua",
+            ua.contains("https://omnitak.engindearing.soy"))
+    }
+
+    @Test fun userAgent_includes_android_release() {
+        val ua = MapTileHttp.buildUserAgent(versionName = "1.0.0", androidRelease = "13")
+        assertTrue("UA should mention Android 13, was: $ua", ua.contains("Android 13"))
+    }
+
+    @Test fun userAgent_blankVersion_fallsBackToDev() {
+        val ua = MapTileHttp.buildUserAgent(versionName = "", androidRelease = "14")
+        assertTrue("blank version should degrade to OmniTAK/dev, was: $ua",
+            ua.startsWith("OmniTAK/dev"))
+    }
+
+    @Test fun userAgent_blankAndroidRelease_stillValid() {
+        // Plain JVM unit tests have Build.VERSION.RELEASE == null → blank; the UA
+        // must still be well-formed and identifying.
+        val ua = MapTileHttp.buildUserAgent(versionName = "0.38.0", androidRelease = "")
+        assertTrue("must still start with OmniTAK/, was: $ua", ua.startsWith("OmniTAK/0.38.0"))
+        assertTrue("must still contain 'Android', was: $ua", ua.contains("Android"))
+    }
+
+    @Test fun interceptor_setsUserAgentHeader_onOutgoingRequest() {
+        val ua = "OmniTAK/9.9.9 (+https://omnitak.engindearing.soy; Android test)"
+        val interceptor = MapTileHttp.userAgentInterceptor(ua)
+        val chain = CapturingChain(Request.Builder().url("https://tile.openstreetmap.org/0/0/0.png").build())
+
+        interceptor.intercept(chain)
+
+        assertEquals(ua, chain.lastRequest?.header("User-Agent"))
+    }
+
+    @Test fun buildClient_installsExactlyOneInterceptor() {
+        assertEquals(1, MapTileHttp.buildClient("OmniTAK/test").interceptors.size)
+    }
+
+    /**
+     * Minimal Interceptor.Chain that records the request the interceptor
+     * forwards. Our interceptor only touches request() and proceed(); the rest
+     * throw because they must never be reached.
+     */
+    private class CapturingChain(private val request: Request) : Interceptor.Chain {
+        var lastRequest: Request? = null
+        override fun request(): Request = request
+        override fun proceed(request: Request): Response {
+            lastRequest = request
+            // Return a throwaway 200 so intercept() completes; the test only
+            // inspects the forwarded request's headers.
+            return Response.Builder()
+                .request(request)
+                .protocol(okhttp3.Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .build()
+        }
+        override fun connection(): Connection? = null
+        override fun call(): Call = throw UnsupportedOperationException()
+        override fun connectTimeoutMillis(): Int = 0
+        override fun withConnectTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+        override fun readTimeoutMillis(): Int = 0
+        override fun withReadTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+        override fun writeTimeoutMillis(): Int = 0
+        override fun withWriteTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+    }
+}


### PR DESCRIPTION
Fixes #139.

## Symptom
@pjcoyle57: with **OpenStreetMap** as the map source, tiles show a placeholder reading *"Access Blocked — App is not following the tile usage policy of OpenStreetMap's volunteer-run servers: osm.wiki/Blocked"*. **Satellite (Esri) works fine.**

## Root cause
MapLibre's default HTTP client sends a generic `User-Agent`. OSM's (and OpenTopoMap's) tile usage policy **requires a User-Agent that identifies the application** — generic clients are served a "403 Access blocked" placeholder tile instead of map data. Esri's imagery endpoint has no such policy, which is exactly why Satellite was unaffected.

## Repro (curl against `tile.openstreetmap.org/0/0/0.png`)
| User-Agent | Result |
|---|---|
| *(empty)* | 6987 B **"Access blocked"** tile |
| `okhttp/4.9.0` | 6987 B **"Access blocked"** tile |
| `Dalvik/2.1.0 (Linux; U; Android 14)` | 6987 B **"Access blocked"** tile |
| `OmniTAK/0.38.0 (+https://omnitak.engindearing.soy)` | 6927 B **real tile** |

## Fix
Install an OkHttp client into MapLibre via `HttpRequestUtil.setOkHttpClient()` with an interceptor that sets:
```
User-Agent: OmniTAK/<version> (+https://omnitak.engindearing.soy; Android <release>)
```
`MapLibre.getInstance()` must run before the swap (MapLibre's HTTP layer static-inits against the singleton via `HttpIdentifier`), so `MapTileHttp.install(context)` initializes it first — getInstance is idempotent, so the lazy call in the map composable stays a no-op. New `okhttp` dependency (MapLibre 11.x already bundles 4.x; pinned to the same major).

## Tests
`MapTileHttpTest` (7): UA starts with `OmniTAK/<version>`, carries the contact URL + Android release, degrades gracefully on blank version/release, and the interceptor actually rewrites the outgoing header.

## On-device verification (emulator, SwiftShader)
Switched source to **OSM**: world view **and** region/street zoom now paint real OSM cartography (borders, forests, lakes, place labels) instead of the blocked tile. Default **OpenTopoMap** source verified rendering too. App launches clean (caught + fixed a `MapLibreConfigurationException` from ordering during testing — getInstance now runs first).

## Note on offline bulk download
This restores *interactive* tile loading. True offline **bulk** download from OSM's public servers is separately discouraged by their policy regardless of UA — that remains a later-release concern (the Settings copy already says "Offline tile cache lands in a later release").

🤖 Generated with [Claude Code](https://claude.com/claude-code)