### PR TITLE
fix(ui): stale offline-maps copy + hard-coded takv version (Android UI audit)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreCoTConverter.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshCoreCoTConverter.kt
@@ -105,7 +105,7 @@ object MeshCoreCoTConverter {
             append("<battery>$battery</battery>")
             append("<last_heard>$lastHeardIso</last_heard>")
             append("</__meshcore__>")
-            append("<takv device=\"MeshCore\" platform=\"OmniTAK\" os=\"Android\" version=\"0.1.0\"/>")
+            append("<takv device=\"MeshCore\" platform=\"OmniTAK\" os=\"Android\" version=\"${soy.engindearing.omnitak.mobile.BuildConfig.VERSION_NAME}\"/>")
             append("</detail>")
         }
         return CotXml.buildEvent(

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticCoTConverter.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticCoTConverter.kt
@@ -122,7 +122,7 @@ object MeshtasticCoTConverter {
             append("<battery>$battery</battery>")
             append("<last_heard>$lastHeardIso</last_heard>")
             append("</__meshtastic__>")
-            append("<takv device=\"Meshtastic\" platform=\"OmniTAK\" os=\"Android\" version=\"0.1.0\"/>")
+            append("<takv device=\"Meshtastic\" platform=\"OmniTAK\" os=\"Android\" version=\"${soy.engindearing.omnitak.mobile.BuildConfig.VERSION_NAME}\"/>")
             append("</detail>")
         }
         return CotXml.buildEvent(

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
@@ -81,7 +81,7 @@ internal object LocStrings {
         "settings.map.satellite" to "Satellite",
         "settings.map.topo" to "Topo",
         "settings.map.custom" to "Custom",
-        "settings.mapTiles.desc" to "OSM (street), Topo (OpenTopoMap), Satellite (Esri imagery), or a custom WMTS / XYZ tile URL. Picks apply immediately. Offline tile cache lands in a later release.",
+        "settings.mapTiles.desc" to "OSM (street), Topo (OpenTopoMap), Satellite (Esri imagery), or a custom WMTS / XYZ tile URL. Picks apply immediately. Download regions for offline use from the map's layers menu.",
         "settings.tileUrl" to "Tile URL",
         "settings.customTile.help" to "Must be an XYZ-style URL with {z}, {x}, {y} placeholders (ATAK-style {\$z}/{\$x}/{\$y} also works). WMTS endpoints from agency / private servers usually expose this. Falls back to OSM if invalid.",
 
@@ -248,7 +248,7 @@ internal object LocStrings {
         "settings.map.satellite" to "衛星",
         "settings.map.topo" to "地形",
         "settings.map.custom" to "自訂",
-        "settings.mapTiles.desc" to "OSM（街道）、地形（OpenTopoMap）、衛星（Esri 影像），或自訂 WMTS / XYZ 圖磚網址。選擇即時套用。離線圖磚快取將於後續版本推出。",
+        "settings.mapTiles.desc" to "OSM（街道）、地形（OpenTopoMap）、衛星（Esri 影像），或自訂 WMTS / XYZ 圖磚網址。選擇即時套用。可從地圖圖層選單下載區域以供離線使用。",
         "settings.tileUrl" to "圖磚網址",
         "settings.customTile.help" to "必須是包含 {z}、{x}、{y} 預留位置的 XYZ 樣式網址（ATAK 樣式的 {\$z}/{\$x}/{\$y} 亦可）。機關／私人伺服器的 WMTS 端點通常會提供此格式。若無效則回退至 OSM。",
 


### PR DESCRIPTION
First batch from the Android UI audit J requested ("ensure nothing is hard coded and the UI/UX is smooth"). These are the unambiguous, zero-risk fixes.

### 1. Stale Settings copy lies about a shipped feature (HIGH)
`i18n/LocStrings.kt` map-tiles description said *"Offline tile cache lands in a later release"* — but offline region download **shipped** (#120): `data/offline/*` (TileCache, OfflineRegion, RegionDownloader, OfflineMbtilesWriter) + `OfflineMapsSheet`, opened from the map's layers menu (`MapScreen.kt` `onOpenOfflineMaps`). Rewrote EN + zh-Hant to describe the real feature. (PL/DE/FR only translate onboarding keys, so they fall back to the EN string.)

### 2. Hard-coded `version="0.1.0"` in mesh CoT broadcasts (MED)
`MeshtasticCoTConverter.kt:125` and `MeshCoreCoTConverter.kt:108` emit a `<takv … version="0.1.0"/>` element. That's **OmniTAK's own app version**, broadcast in CoT detail and visible to peers in their contact-detail view — it would never match the real shipped build (~0.38.0). Now reads `BuildConfig.VERSION_NAME` (the same pattern `MapTileHttp` already uses for the tile User-Agent).

### Verification
Full `testDebugUnitTest` suite green; `compileDebugKotlin` clean.

### Not in this PR (reported separately)
The audit also surfaced: the green-indicator/"Offline"-text status-bar mismatch (#145, fix incoming), GPS `±0m`/"Acquiring fix…"-with-zeros false precision, a 37-file off-brand electric-cyan accent in the UAS subsystem, an almost-empty typography theme (~108 hard-coded `.sp`), inconsistent back/dismiss conventions, and two confirmed-dead artifacts (`ContactSymbolLayer.kt`, `RadialCaption`). These are larger or need on-device verification — coming as follow-ups / a tiered plan for J.

🤖 Generated with [Claude Code](https://claude.com/claude-code)