### PR TITLE
fix(map): self-position card + status-bar consistency + GPS precision (#145)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/SelfPositionCard.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/SelfPositionCard.kt
@@ -38,7 +38,10 @@ fun SelfPositionCard(
         modifier = modifier
             .clip(RoundedCornerShape(6.dp))
             .background(Color(0xCC000000))
-            .border(2.dp, Color.Red, RoundedCornerShape(6.dp))
+            // The operator's own PPLI readout is friendly — frame it in the
+            // brand accent (matching the callsign text), not hostile red
+            // (red = hostile in TAK affiliation semantics).
+            .border(2.dp, TacticalAccent, RoundedCornerShape(6.dp))
             .padding(horizontal = 10.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -140,7 +140,15 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         is ConnectionState.Connected -> s.serverName
         is ConnectionState.Connecting -> "Connecting…"
         is ConnectionState.Failed -> "Failed"
-        ConnectionState.Disconnected -> active?.name ?: "Offline"
+        // #145 — never read "Offline" while a server is actually connected.
+        // The dot/badge come from connectedIds and the text used to come only
+        // from the active server's connState, so the two could disagree
+        // (green badge + "Offline" text). Fall back to a connected server's
+        // name before "Offline" so all three signals stay consistent.
+        ConnectionState.Disconnected ->
+            allServers.firstOrNull { connectedIds.contains(it.id) }?.name
+                ?: active?.name
+                ?: "Offline"
     }
 
     var nowLabel by remember { mutableStateOf(timeLabel()) }
@@ -1353,10 +1361,14 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
         ) {
             ATAKStatusBar(
                 serverName = headerLabel,
-                isConnected = connState is ConnectionState.Connected,
+                // #145 — green when ANY server is connected, matching the
+                // header text + multi-server badge (all keyed off connectedIds).
+                isConnected = connState is ConnectionState.Connected || connectedIds.isNotEmpty(),
                 messagesReceived = msgReceived,
                 messagesSent = msgSent,
-                gpsAccuracyMeters = selfFix?.accuracyM?.toInt() ?: 0,
+                // Pass null (not 0) with no fix so the status bar hides the
+                // GPS readout instead of showing a false "±0m" lock.
+                gpsAccuracyMeters = effectiveSelfFix?.accuracyM?.toInt(),
                 timeLabel = nowLabel,
                 // GAP-102 — wire the previously dead status-bar taps to
                 // their natural destinations. Server icon goes to the
@@ -1386,15 +1398,18 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 } else {
                     "Acquiring fix…"
                 },
-                altitudeLabel = soy.engindearing.omnitak.mobile.data.CoordFormatter.altitude(
-                    fix?.altitudeM ?: 0.0, userPrefs.distanceUnit,
-                ),
-                speedLabel = soy.engindearing.omnitak.mobile.data.CoordFormatter.speed(
-                    fix?.speedKmh ?: 0.0, userPrefs.distanceUnit,
-                ),
-                accuracyLabel = soy.engindearing.omnitak.mobile.data.CoordFormatter.accuracy(
-                    fix?.accuracyM?.toInt() ?: 0, userPrefs.distanceUnit,
-                ),
+                // Show "—" (not formatted zeros) until a real fix lands, so the
+                // card can't read "Acquiring fix…" next to a perfect 0 m / 0
+                // km/h / ±0 m telemetry block.
+                altitudeLabel = fix?.altitudeM?.let {
+                    soy.engindearing.omnitak.mobile.data.CoordFormatter.altitude(it, userPrefs.distanceUnit)
+                } ?: "—",
+                speedLabel = fix?.speedKmh?.let {
+                    soy.engindearing.omnitak.mobile.data.CoordFormatter.speed(it, userPrefs.distanceUnit)
+                } ?: "—",
+                accuracyLabel = fix?.accuracyM?.let {
+                    soy.engindearing.omnitak.mobile.data.CoordFormatter.accuracy(it.toInt(), userPrefs.distanceUnit)
+                } ?: "—",
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
                     .padding(end = 12.dp, bottom = 96.dp),


### PR DESCRIPTION
Map self-position / status-bar polish from J's Android UI audit. Addresses #145 (J: "connected to an OpenTAK server, the indicator was green but the text said Offline") plus false-precision and brand/semantic issues.

### Status bar — one source of truth (#145)
Dot, multi-server badge, and header text were drawn from two sources that could disagree (`connState` vs `connectedServerIds`). Now all three key off `connectedIds`:
- `isConnected = connState is Connected || connectedIds.isNotEmpty()` — dot green whenever anything is connected (matches the badge).
- `headerLabel`'s `Disconnected` branch falls back to a connected server's name before "Offline", so it can't read "Offline" while a server is live.

### GPS false precision
- Status bar passed `accuracyMeters ?: 0` → showed a flawless "±0m" with **no** fix. Now passes `null` → the readout hides (`ATAKStatusBar` already guards on null). Uses `effectiveSelfFix` for parity with the self card.
- `SelfPositionCard` showed "Acquiring fix…" next to "0 m / 0 km/h / ±0 m". Altitude/speed/accuracy now show "—" until a real fix lands.

### Self-position card border: friendly-green, not hostile-red
The operator's own PPLI card was framed in `Color.Red`. Red = hostile in TAK affiliation semantics, so the friendly self readout reading "hostile red" was a semantic clash (and clashed with its own green callsign text). Now uses the brand `TacticalAccent`.

### Verification (emulator, on-device)
- `compileDebug` + full `testDebugUnitTest` green.
- Status bar shows true ±Nm with a real fix; map renders unchanged.
- Self-position card border verified **green** (was red) — screenshot diff confirmed.
- Live multi-server repro for the green-while-connected path tracked in #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)