### PR TITLE
chore(release): Android 0.39.0 (versionCode 98)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 97
-        versionName = "0.38.0"
+        versionCode = 98
+        versionName = "0.39.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }


### PR DESCRIPTION
Version bump for the 0.39.0 bug-fix release (OSM tiles #144, copy/version #146, status/GPS/self-card #147). Signed AAB+APK built, cert verified (9f3b1fd5…), release build smoke-tested on-device (real OpenTopoMap tiles render under R8 → UA fix survives minification; self-card green border confirmed). 🤖 Generated with [Claude Code](https://claude.com/claude-code)