### PR TITLE
fix(offline): identifying UA + reject blocked-tile placeholder on region downloads (#139)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/RegionDownloader.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/RegionDownloader.kt
@@ -133,23 +133,43 @@ class RegionDownloader(
  * Production tile fetch over HTTP — a thin HttpURLConnection GET, mirroring
  * the proven pattern in
  * [soy.engindearing.omnitak.mobile.data.uas.TerrainSampler]. Returns the raw
- * tile bytes on 200, null on any non-200 / IO error (the downloader counts
- * those as failures without aborting the whole region).
+ * tile bytes on a real 200, null on any non-200 / IO error / policy block (the
+ * downloader counts those as failures without aborting the whole region).
  *
  * User-Agent (#139): OSM/OpenTopoMap's tile usage policy *requires* a UA that
- * identifies the app; a generic one gets a 403 "Access blocked" response. The
+ * identifies the app; a generic one gets the "Access blocked" placeholder. The
  * interactive map fixed this by installing an OkHttp client into MapLibre
  * ([soy.engindearing.omnitak.mobile.data.MapTileHttp]), but the offline region
  * download runs through this fetcher, not MapLibre — so it must send the same
- * identifying UA, otherwise "Download this region" 403s on OSM while satellite
- * (Esri, no UA policy) works. Reuse the one builder so both paths stay in sync.
+ * identifying UA, otherwise "Download this region" is blocked on OSM while
+ * satellite (Esri, no UA policy) works. Reuse the one builder so both paths
+ * stay in sync.
  *
- * Device-pending: exercised against a real tile server on device, not in JVM
- * unit tests (which inject a fake fetch into [RegionDownloader]).
+ * Blocked-tile guard (#139): OSM serves its "Access blocked" placeholder as
+ * HTTP **200** with an `X-Blocked` header — verified against
+ * tile.openstreetmap.org, the body is a 6987-byte text PNG, *not* a 4xx — so a
+ * status-code check alone caches the placeholder as if it were a real tile. A
+ * *bulk* region pull trips this even with a valid UA, because OSM rate-limits
+ * bulk downloads with the same blocked response. Drop any block-marked response
+ * so the offline cache is never poisoned with "Access blocked" placeholders.
+ *
+ * Device-pending: the live HTTP round-trip is exercised against a real tile
+ * server on device; the pure [isBlocked] decision and [RegionDownloader] (which
+ * injects a fake fetch) are covered by JVM unit tests.
  */
 object HttpTileFetcher {
     private const val TIMEOUT_MS = 8_000
     private val USER_AGENT = MapTileHttp.buildUserAgent()
+
+    /**
+     * True when a 200 response is actually OSM/OpenTopoMap's "Access blocked"
+     * placeholder rather than a real tile. OSM marks it with an `X-Blocked`
+     * header (its value points at the tile-usage policy). Pure over a header
+     * lookup so it unit-tests without a network round-trip; [header] mirrors
+     * [java.net.HttpURLConnection.getHeaderField] (case-insensitive name).
+     */
+    internal fun isBlocked(header: (name: String) -> String?): Boolean =
+        header("X-Blocked") != null
 
     suspend fun fetch(url: String): ByteArray? = withContext(Dispatchers.IO) {
         val conn = (java.net.URL(url).openConnection() as java.net.HttpURLConnection).apply {
@@ -160,6 +180,7 @@ object HttpTileFetcher {
         }
         try {
             if (conn.responseCode != 200) return@withContext null
+            if (isBlocked { conn.getHeaderField(it) }) return@withContext null
             conn.inputStream.use { it.readBytes() }
         } catch (e: java.io.IOException) {
             null

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/RegionDownloader.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/offline/RegionDownloader.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import soy.engindearing.omnitak.mobile.data.MapTileHttp
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -135,12 +136,20 @@ class RegionDownloader(
  * tile bytes on 200, null on any non-200 / IO error (the downloader counts
  * those as failures without aborting the whole region).
  *
+ * User-Agent (#139): OSM/OpenTopoMap's tile usage policy *requires* a UA that
+ * identifies the app; a generic one gets a 403 "Access blocked" response. The
+ * interactive map fixed this by installing an OkHttp client into MapLibre
+ * ([soy.engindearing.omnitak.mobile.data.MapTileHttp]), but the offline region
+ * download runs through this fetcher, not MapLibre — so it must send the same
+ * identifying UA, otherwise "Download this region" 403s on OSM while satellite
+ * (Esri, no UA policy) works. Reuse the one builder so both paths stay in sync.
+ *
  * Device-pending: exercised against a real tile server on device, not in JVM
  * unit tests (which inject a fake fetch into [RegionDownloader]).
  */
 object HttpTileFetcher {
     private const val TIMEOUT_MS = 8_000
-    private const val USER_AGENT = "OmniTAK-Android offline-tile-cache"
+    private val USER_AGENT = MapTileHttp.buildUserAgent()
 
     suspend fun fetch(url: String): ByteArray? = withContext(Dispatchers.IO) {
         val conn = (java.net.URL(url).openConnection() as java.net.HttpURLConnection).apply {

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/HttpTileFetcherTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/offline/HttpTileFetcherTest.kt
@@ -1,0 +1,49 @@
+package soy.engindearing.omnitak.mobile.data.offline
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #139 — OSM serves its "Access blocked" placeholder tile as HTTP 200 with an
+ * `X-Blocked` header (not a 4xx), so the offline downloader must reject it by
+ * marker, not by status code; otherwise a bulk region pull caches the
+ * placeholder PNG as if it were real map data. These lock the
+ * [HttpTileFetcher.isBlocked] decision against the exact headers observed from
+ * tile.openstreetmap.org.
+ */
+class HttpTileFetcherTest {
+
+    /** Mirror HttpURLConnection.getHeaderField: case-insensitive name lookup. */
+    private fun headers(vararg pairs: Pair<String, String>): (String) -> String? =
+        { name -> pairs.firstOrNull { it.first.equals(name, ignoreCase = true) }?.second }
+
+    @Test fun blocked_when_xblocked_header_present() {
+        // Exact response observed from tile.openstreetmap.org for a generic UA.
+        val h = headers(
+            "Content-Type" to "image/png",
+            "Cache-Control" to "no-cache",
+            "X-Blocked" to "Access denied. See https://operations.osmfoundation.org/policies/tiles/",
+        )
+        assertTrue(HttpTileFetcher.isBlocked(h))
+    }
+
+    @Test fun blocked_detection_is_case_insensitive() {
+        // HTTP/2 lower-cases header names; getHeaderField looks up case-insensitively.
+        assertTrue(HttpTileFetcher.isBlocked(headers("x-blocked" to "Access denied.")))
+    }
+
+    @Test fun not_blocked_for_real_tile_headers() {
+        // Exact response observed for a real tile (OmniTAK UA): no X-Blocked.
+        val h = headers(
+            "Content-Type" to "image/png",
+            "X-Tilerender" to "orm.openstreetmap.org",
+            "ETag" to "\"8445651b6e17b9905333a90831cb3557\"",
+        )
+        assertFalse(HttpTileFetcher.isBlocked(h))
+    }
+
+    @Test fun not_blocked_when_no_headers() {
+        assertFalse(HttpTileFetcher.isBlocked { null })
+    }
+}


### PR DESCRIPTION
## Why

Issue #139 ("Access Blocked" tiles when downloading OSM regions for offline use) was closed by #144, which installed an app-identifying `User-Agent` into MapLibre's HTTP client. That fixed **interactive** OSM/OpenTopoMap viewing — but the reporter ([comment](https://github.com/engindearing-projects/OmniTAK-Android/issues/139#issuecomment-4739689639)) is still hitting it on 0.39 when clicking **"Download this region."**

## Root cause

"Download this region" does **not** go through MapLibre. It runs `OfflineRegionStore` → `RegionDownloader` → `HttpTileFetcher`, a separate `HttpURLConnection` path that was still sending a generic UA (`"OmniTAK-Android offline-tile-cache"`).

Reproduced directly against `tile.openstreetmap.org`:

| User-Agent | HTTP | Body | Result |
|---|---|---|---|
| `OmniTAK-Android offline-tile-cache` (old offline UA) | **200** | 6987 B + `X-Blocked` header | "Access blocked" placeholder |
| empty / `Dalvik/...` | **200** | 6987 B + `X-Blocked` | "Access blocked" placeholder |
| `OmniTAK/0.39.0 (+https://omnitak.engindearing.soy; Android 14)` | **200** | 25412 B, `X-Tilerender` + `ETag` | real tile |

Two bugs, not one:
1. **Generic UA → blocked.** The offline UA wasn't the validated `OmniTAK/<ver>` format the interactive map uses, so OSM served the placeholder.
2. **The block is HTTP `200`, not `403`.** `HttpTileFetcher` only guarded `responseCode != 200`, so the 6987-byte "Access blocked" PNG would be **written into the offline cache as if it were a real tile.** A *bulk* region pull trips this even with a valid UA, because OSM rate-limits bulk downloads with the same blocked response — which would bake "Access blocked" permanently into the downloaded map. (Satellite/Esri has no UA policy, which is why it always worked — matching the original #139 symptom.)

## Fix

- **UA** — reuse `MapTileHttp.buildUserAgent()` in `HttpTileFetcher` so the offline downloader and the interactive map send the same identifying UA and stay in sync.
- **Blocked-tile guard** — reject any response carrying OSM's `X-Blocked` marker even on a 200, so the offline cache is never poisoned with placeholders.

## Testing

- Live reproduction against `tile.openstreetmap.org` (table above): old UA → 6987-byte block, new UA → 25412-byte real tile.
- New `HttpTileFetcherTest` (4 tests) locks the `isBlocked()` decision against the exact headers observed from the live server.
- `:app:testDebugUnitTest` green locally — HttpTileFetcherTest 4/4, RegionDownloaderTest 6/6, MapTileHttpTest 7/7.
- Device check still recommended: switch source → OSM → "Download this region" → confirm real tiles save and survive going fully offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
