### PR TITLE
feat(rangebearing): Range & Bearing computation core + range rings (#152)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/rangebearing/RangeBearing.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/rangebearing/RangeBearing.kt
@@ -1,0 +1,101 @@
+package soy.engindearing.omnitak.mobile.data.rangebearing
+
+import soy.engindearing.omnitak.mobile.data.GeoMath
+import kotlin.math.asin
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Range & Bearing computation (#152, ported from iOS `RangeBearingService`).
+ *
+ * Pure great-circle math with no Android dependency, so it unit-tests directly.
+ * The Android layer supplies [declinationDeg] from
+ * `android.hardware.GeomagneticField` and [gridConvergenceDeg] from the active
+ * map grid; both default to 0.0 (i.e. magnetic/grid == true bearing) so a caller
+ * with no magnetic model still gets correct distance + true bearing.
+ */
+object RangeBearing {
+
+    private const val EARTH_RADIUS_M = 6_371_008.8
+
+    /** Normalize any degree value into [0, 360). */
+    fun norm360(deg: Double): Double = ((deg % 360.0) + 360.0) % 360.0
+
+    /**
+     * Distance + true/magnetic/grid bearing + back-azimuth from origin to
+     * destination. Declination and grid convergence are east-positive
+     * (magnetic = true − declination; grid = true − convergence), matching the
+     * iOS service and standard land-nav convention.
+     */
+    fun compute(
+        originLat: Double,
+        originLon: Double,
+        destLat: Double,
+        destLon: Double,
+        declinationDeg: Double = 0.0,
+        gridConvergenceDeg: Double = 0.0,
+    ): RangeBearingResult {
+        val tru = GeoMath.bearingDegrees(originLat, originLon, destLat, destLon)
+        return RangeBearingResult(
+            distanceMeters = GeoMath.haversineMeters(originLat, originLon, destLat, destLon),
+            trueBearing = norm360(tru),
+            magneticBearing = norm360(tru - declinationDeg),
+            backAzimuth = norm360(tru + 180.0),
+            gridBearing = norm360(tru - gridConvergenceDeg),
+        )
+    }
+
+    /**
+     * Geodesic points (each `[lat, lon]`) approximating a circle of
+     * [radiusMeters] around the center, walking [segments] equal bearings. The
+     * ring is closed (first point repeated at the end) so it can be drawn as a
+     * single polyline. Used for tactical range rings.
+     */
+    fun ringPoints(
+        centerLat: Double,
+        centerLon: Double,
+        radiusMeters: Double,
+        segments: Int = 64,
+    ): List<DoubleArray> {
+        val n = segments.coerceAtLeast(3)
+        val angDist = radiusMeters / EARTH_RADIUS_M
+        val lat1 = Math.toRadians(centerLat)
+        val lon1 = Math.toRadians(centerLon)
+        val out = ArrayList<DoubleArray>(n + 1)
+        for (i in 0..n) {
+            val brng = Math.toRadians(360.0 * i / n)
+            val lat2 = asin(sin(lat1) * cos(angDist) + cos(lat1) * sin(angDist) * cos(brng))
+            val lon2 = lon1 + atan2(
+                sin(brng) * sin(angDist) * cos(lat1),
+                cos(angDist) - sin(lat1) * sin(lat2),
+            )
+            out.add(doubleArrayOf(Math.toDegrees(lat2), normLon(Math.toDegrees(lon2))))
+        }
+        return out
+    }
+
+    /** Concentric rings at [spacingMeters] × 1..[count] (inner → outer). */
+    fun rings(
+        centerLat: Double,
+        centerLon: Double,
+        spacingMeters: Double,
+        count: Int,
+        segments: Int = 64,
+    ): List<List<DoubleArray>> =
+        (1..count.coerceAtLeast(1)).map { ring ->
+            ringPoints(centerLat, centerLon, spacingMeters * ring, segments)
+        }
+
+    /** Fold longitude back into [-180, 180). */
+    private fun normLon(lon: Double): Double = ((lon + 540.0) % 360.0) - 180.0
+}
+
+/** Resolved distance + bearings for one Range & Bearing line. Angles in [0,360). */
+data class RangeBearingResult(
+    val distanceMeters: Double,
+    val trueBearing: Double,
+    val magneticBearing: Double,
+    val backAzimuth: Double,
+    val gridBearing: Double,
+)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/rangebearing/RangeRings.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/rangebearing/RangeRings.kt
@@ -1,0 +1,51 @@
+package soy.engindearing.omnitak.mobile.data.rangebearing
+
+import soy.engindearing.omnitak.mobile.data.Drawing
+import soy.engindearing.omnitak.mobile.data.DrawingKind
+
+/**
+ * #152 — tactical range rings: concentric geodesic circles around a center,
+ * built on top of [RangeBearing.ringPoints]. Kept out of the UI layer so the
+ * (parity-relevant) default radii + label format are unit-testable without an
+ * Android/MapLibre runtime — CI can't exercise the map tool itself.
+ *
+ * Rings are emitted as transient [Drawing]s of kind [DrawingKind.LINE] (an
+ * un-filled closed polyline), so they reuse the native drawing renderer that
+ * paints on the GL-buggy Adreno/Mali drivers. They never touch the drawing
+ * store; the map screen merges them into the render list while the tool is open.
+ */
+object RangeRings {
+
+    /** Default radii in meters — matches iOS `RangeRingConfiguration.defaultConfiguration()`. */
+    val DEFAULT_DISTANCES_M: List<Double> = listOf(100.0, 500.0, 1000.0, 2000.0, 5000.0)
+
+    /** Amber, distinct from the green drawing default. */
+    const val RING_COLOR_HEX: String = "#FFC107"
+
+    private const val RING_SEGMENTS = 72
+
+    /** "100m" / "1.0km" — matches iOS `formatRangeRingLabel`. */
+    fun label(meters: Double): String =
+        if (meters < 1000) "${meters.toInt()}m" else String.format("%.1fkm", meters / 1000.0)
+
+    /**
+     * One closed-loop [DrawingKind.LINE] drawing per radius in [distancesMeters],
+     * each a great-circle ring around ([centerLat], [centerLon]). Stable ids so
+     * recompositions don't thrash the renderer's annotation tracking.
+     */
+    fun ringDrawings(
+        centerLat: Double,
+        centerLon: Double,
+        distancesMeters: List<Double> = DEFAULT_DISTANCES_M,
+    ): List<Drawing> = distancesMeters.mapIndexed { i, radius ->
+        Drawing(
+            id = "__range_ring_${i}__",
+            kind = DrawingKind.LINE,
+            name = label(radius),
+            points = RangeBearing.ringPoints(centerLat, centerLon, radius, RING_SEGMENTS)
+                .map { it[0] to it[1] },
+            colorHex = RING_COLOR_HEX,
+            widthPx = 2f,
+        )
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Brush
+import androidx.compose.material.icons.filled.TrackChanges
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.AddLocation
@@ -215,6 +216,10 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     }
     var rehearsalRunning by remember { mutableStateOf(false) }
     var measurementPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
+    // #152 — range-rings tool: tap sets the center, concentric rings draw
+    // around it via the native drawing renderer (RangeBearing.ringPoints).
+    var rangeRingsActive by remember { mutableStateOf(false) }
+    var rangeRingCenter by remember { mutableStateOf<LatLng?>(null) }
     var drawingKind by remember { mutableStateOf<DrawingKind?>(null) }
     var drawingPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var drawingPickerOpen by remember { mutableStateOf(false) }
@@ -312,9 +317,9 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     // MapLibre (the handle is null on the globe → it no-ops), exactly as the
     // pre-plugin code never painted aircraft on the globe. So enabling ADS-B
     // does not force a drop to 2D — identical to today's behavior.
-    LaunchedEffect(measurementActive, drawingKind, lassoMode) {
+    LaunchedEffect(measurementActive, drawingKind, lassoMode, rangeRingsActive) {
         if (!userPrefs.cesiumGlobeEnabled) return@LaunchedEffect
-        if (measurementActive || drawingKind != null || lassoMode) {
+        if (measurementActive || drawingKind != null || lassoMode || rangeRingsActive) {
             app.userPrefsStore.update { it.copy(cesiumGlobeEnabled = false) }
             toast(Loc.t("map.toast.globeTo2d"))
         }
@@ -437,20 +442,24 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 .update(m, appContext, visibleContacts)
         }
     }
-    LaunchedEffect(drawings, drawingsVisible, mapboxMap) {
+    // #152 — render user drawings AND the transient range rings through the
+    // single native renderer. apply() clears and redraws the whole set, so the
+    // rings must ride in the SAME list; a separate call would wipe the drawings.
+    LaunchedEffect(drawings, drawingsVisible, mapboxMap, rangeRingCenter) {
         mapboxMap?.let { m ->
+            val base = if (drawingsVisible) drawings else emptyList()
             soy.engindearing.omnitak.mobile.ui.components.DrawingShapeRenderer
-                .apply(m, if (drawingsVisible) drawings else emptyList())
+                .apply(m, base + buildRangeRingDrawings(rangeRingCenter))
         }
     }
     val handleMapLongPress: (LatLng, Offset) -> Unit = { latLng, offset ->
-        if (!measurementActive) {
+        if (!measurementActive && !rangeRingsActive) {
             radialLatLng = latLng
             radialAnchor = offset
         }
     }
     val handleContactTap: (soy.engindearing.omnitak.mobile.data.CoTEvent) -> Unit = { event ->
-        if (!measurementActive) {
+        if (!measurementActive && !rangeRingsActive) {
             editingMarker = event
             markerSheetLatLng = LatLng(event.lat, event.lon)
         }
@@ -623,6 +632,12 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             onMapLongPress = handleMapLongPress,
             onContactTap = handleContactTap,
             onMapSingleTap = onMapSingleTap@ { latLng ->
+                // #152 — range-rings mode owns the tap: it just (re)sets the
+                // center, so it wins before any waypoint/placement hit-test.
+                if (rangeRingsActive) {
+                    rangeRingCenter = latLng
+                    return@onMapSingleTap true
+                }
                 // Hit-test existing mission waypoints first so a tap on
                 // a pin opens its edit sheet instead of adding a new
                 // waypoint on top of it. ~80 m radius covers both
@@ -711,11 +726,13 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             zoomOutTrigger = zoomOutTick,
             contacts = visibleContacts,
             measurementPoints = measurementPoints,
-            drawings = if (drawingsVisible) {
+            // #152 — range rings ride the drawing list so they survive style
+            // reloads (TacticalMap re-applies this param after every reload).
+            drawings = (if (drawingsVisible) {
                 drawings + buildInProgressDrawing(drawingKind, drawingPoints)
             } else {
                 emptyList()
-            },
+            }) + buildRangeRingDrawings(rangeRingCenter),
             // Graticule follows the viewport (was hardcoded to Mountain
             // View — invisible for any user outside ±2° of the
             // Googleplex). Quantized to 0.5° so micro-pans don't re-push
@@ -1445,6 +1462,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             tools = listOf(
                 ToolEntry("draw", Icons.Filled.Brush, "Drawing"),
                 ToolEntry("measure", Icons.Filled.Straighten, "Measure"),
+                ToolEntry("rangerings", Icons.Filled.TrackChanges, "Range Rings"),
                 ToolEntry("layers", Icons.Filled.Layers, "Layers"),
                 // ADS-B moved to the ADS-B plugin — its on/off control now
                 // lives in Settings → Plugins → ADS-B (the plugin's
@@ -1462,11 +1480,22 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             onSelect = { tool ->
                 when (tool.id) {
                     "measure" -> {
+                        rangeRingsActive = false
                         measurementActive = true
                         measurementPoints = emptyList()
                         toast("Measure mode — tap map to add points")
                     }
-                    "draw" -> drawingPickerOpen = true
+                    "rangerings" -> {
+                        measurementActive = false
+                        drawingKind = null
+                        rangeRingsActive = true
+                        rangeRingCenter = null
+                        toast("Range rings — tap map to set center")
+                    }
+                    "draw" -> {
+                        rangeRingsActive = false
+                        drawingPickerOpen = true
+                    }
                     "layers" -> layersSheetOpen = true
                     "chat" -> onOpenTab("chat")
                     "missionsync" -> onOpenTab("missionsync")
@@ -2052,6 +2081,19 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             )
         }
 
+        if (rangeRingsActive) {
+            RangeRingsOverlay(
+                center = rangeRingCenter,
+                distancesMeters = soy.engindearing.omnitak.mobile.data.rangebearing.RangeRings.DEFAULT_DISTANCES_M,
+                onClear = { rangeRingCenter = null },
+                onClose = {
+                    rangeRingsActive = false
+                    rangeRingCenter = null
+                },
+                modifier = Modifier.align(Alignment.TopStart),
+            )
+        }
+
         if (layersSheetOpen) {
             LayersDialog(
                 gridEnabled = gridEnabled,
@@ -2246,6 +2288,60 @@ private fun MeasurementOverlay(
         androidx.compose.foundation.layout.Spacer(Modifier.width(12.dp))
         androidx.compose.material3.TextButton(onClick = onUndo, enabled = points.isNotEmpty()) {
             androidx.compose.material3.Text("Undo", color = TacticalAccent)
+        }
+        androidx.compose.material3.TextButton(onClick = onClose) {
+            androidx.compose.material3.Text("Done", color = TacticalAccent)
+        }
+    }
+}
+
+/** #152 — concentric range rings around [center] as transient native LINE
+ *  drawings (no fill). Delegates to [RangeRings] (unit-tested); these never
+ *  touch the drawing store, they ride the drawing renderer so they paint on the
+ *  GL-buggy Adreno/Mali drivers like every other shape. */
+private fun buildRangeRingDrawings(center: LatLng?): List<Drawing> =
+    center?.let {
+        soy.engindearing.omnitak.mobile.data.rangebearing.RangeRings
+            .ringDrawings(it.latitude, it.longitude)
+    } ?: emptyList()
+
+/**
+ * #152 — range-rings HUD. Mirrors [MeasurementOverlay]: a translucent readout
+ * pinned top-start with the center fix + ring legend, a Clear (re-place center)
+ * and a Done (exit tool) action.
+ */
+@Composable
+private fun RangeRingsOverlay(
+    center: LatLng?,
+    distancesMeters: List<Double>,
+    onClear: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    androidx.compose.foundation.layout.Row(
+        modifier = modifier
+            .padding(top = 76.dp, start = 12.dp, end = 12.dp)
+            .clip(androidx.compose.foundation.shape.RoundedCornerShape(8.dp))
+            .background(TacticalBackground.copy(alpha = 0.9f))
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        androidx.compose.material3.Text(
+            if (center == null) {
+                "Range rings · tap map to set center"
+            } else {
+                "Rings ${"%.5f".format(center.latitude)}, ${"%.5f".format(center.longitude)} · " +
+                    distancesMeters.joinToString(" · ") {
+                        soy.engindearing.omnitak.mobile.data.rangebearing.RangeRings.label(it)
+                    }
+            },
+            color = TacticalAccent,
+            fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        androidx.compose.foundation.layout.Spacer(Modifier.width(12.dp))
+        androidx.compose.material3.TextButton(onClick = onClear, enabled = center != null) {
+            androidx.compose.material3.Text("Clear", color = TacticalAccent)
         }
         androidx.compose.material3.TextButton(onClick = onClose) {
             androidx.compose.material3.Text("Done", color = TacticalAccent)

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/rangebearing/RangeBearingTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/rangebearing/RangeBearingTest.kt
@@ -1,0 +1,82 @@
+package soy.engindearing.omnitak.mobile.data.rangebearing
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.GeoMath
+
+/**
+ * #152 — Range & Bearing math (ported from iOS RangeBearingService). Pure, so
+ * it unit-tests directly against known great-circle values.
+ */
+class RangeBearingTest {
+
+    @Test fun east_along_equator_is_90deg_backaz_270() {
+        val r = RangeBearing.compute(0.0, 0.0, 0.0, 1.0)
+        assertEquals(90.0, r.trueBearing, 1e-6)
+        assertEquals(270.0, r.backAzimuth, 1e-6)
+        assertEquals(111_195.0, r.distanceMeters, 60.0) // ~1° of longitude at equator
+    }
+
+    @Test fun north_is_0deg_backaz_180() {
+        val r = RangeBearing.compute(0.0, 0.0, 1.0, 0.0)
+        assertEquals(0.0, r.trueBearing, 1e-6)
+        assertEquals(180.0, r.backAzimuth, 1e-6)
+    }
+
+    @Test fun magnetic_subtracts_east_declination() {
+        // true 90, east declination +10 -> magnetic 80
+        val r = RangeBearing.compute(0.0, 0.0, 0.0, 1.0, declinationDeg = 10.0)
+        assertEquals(80.0, r.magneticBearing, 1e-6)
+    }
+
+    @Test fun magnetic_with_west_declination() {
+        // true 0, west declination -10 -> magnetic 10
+        val r = RangeBearing.compute(0.0, 0.0, 1.0, 0.0, declinationDeg = -10.0)
+        assertEquals(10.0, r.magneticBearing, 1e-6)
+    }
+
+    @Test fun magnetic_wraps_below_zero() {
+        // true 0, east declination +10 -> magnetic 350 (wrap)
+        val r = RangeBearing.compute(0.0, 0.0, 1.0, 0.0, declinationDeg = 10.0)
+        assertEquals(350.0, r.magneticBearing, 1e-6)
+    }
+
+    @Test fun grid_subtracts_convergence() {
+        // true 90, grid convergence +5 -> grid 85
+        val r = RangeBearing.compute(0.0, 0.0, 0.0, 1.0, gridConvergenceDeg = 5.0)
+        assertEquals(85.0, r.gridBearing, 1e-6)
+    }
+
+    @Test fun norm360_wraps_both_directions() {
+        assertEquals(10.0, RangeBearing.norm360(370.0), 1e-9)
+        assertEquals(350.0, RangeBearing.norm360(-10.0), 1e-9)
+        assertEquals(0.0, RangeBearing.norm360(360.0), 1e-9)
+    }
+
+    @Test fun ring_is_closed_and_every_point_is_at_radius() {
+        val cLat = 47.6; val cLon = -122.3; val radius = 5_000.0
+        val pts = RangeBearing.ringPoints(cLat, cLon, radius, segments = 32)
+        assertEquals(33, pts.size) // segments + 1 (closed)
+        assertEquals(pts.first()[0], pts.last()[0], 1e-9)
+        assertEquals(pts.first()[1], pts.last()[1], 1e-9)
+        for (p in pts) {
+            val d = GeoMath.haversineMeters(cLat, cLon, p[0], p[1])
+            assertEquals("ring point off radius", radius, d, radius * 0.02)
+        }
+    }
+
+    @Test fun ring_first_point_is_due_north() {
+        // segments=4 -> point 0 is bearing 0 (north)
+        val pts = RangeBearing.ringPoints(0.0, 0.0, 111_195.0, segments = 4)
+        assertTrue("north point should be ~1° north", pts[0][0] > 0.9)
+        assertEquals(0.0, pts[0][1], 1e-6)
+    }
+
+    @Test fun concentric_rings_count_and_outer_radius() {
+        val rings = RangeBearing.rings(0.0, 0.0, spacingMeters = 1_000.0, count = 3, segments = 16)
+        assertEquals(3, rings.size)
+        val outer = GeoMath.haversineMeters(0.0, 0.0, rings[2][0][0], rings[2][0][1])
+        assertEquals(3_000.0, outer, 60.0)
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/rangebearing/RangeRingsTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/rangebearing/RangeRingsTest.kt
@@ -1,0 +1,52 @@
+package soy.engindearing.omnitak.mobile.data.rangebearing
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.DrawingKind
+
+/**
+ * #152 — range-rings tool helper. Locks the parity-relevant defaults + label
+ * format and the drawing shape the map tool renders (CI can't drive the map UI).
+ */
+class RangeRingsTest {
+
+    @Test fun default_distances_match_the_ios_configuration() {
+        assertEquals(listOf(100.0, 500.0, 1000.0, 2000.0, 5000.0), RangeRings.DEFAULT_DISTANCES_M)
+    }
+
+    @Test fun label_uses_meters_under_1km_and_km_above() {
+        assertEquals("100m", RangeRings.label(100.0))
+        assertEquals("500m", RangeRings.label(500.0))
+        assertEquals("1.0km", RangeRings.label(1000.0))
+        assertEquals("2.0km", RangeRings.label(2000.0))
+        assertEquals("5.0km", RangeRings.label(5000.0))
+    }
+
+    @Test fun builds_one_closed_line_drawing_per_radius() {
+        val rings = RangeRings.ringDrawings(25.0330, 121.5654)
+        assertEquals(RangeRings.DEFAULT_DISTANCES_M.size, rings.size)
+        for (d in rings) {
+            assertEquals(DrawingKind.LINE, d.kind)            // un-filled outline, not a polygon
+            assertTrue("ring should be a closed loop", d.points.first() == d.points.last())
+            assertTrue("ring needs enough points to read as a circle", d.points.size > 60)
+        }
+    }
+
+    @Test fun ring_radius_grows_with_distance() {
+        val rings = RangeRings.ringDrawings(0.0, 0.0, listOf(100.0, 1000.0))
+        // East-point longitude offset from center scales ~linearly with radius.
+        val inner = rings[0].points.maxOf { it.second }
+        val outer = rings[1].points.maxOf { it.second }
+        assertTrue("1km ring must be wider than the 100m ring", outer > inner * 5)
+    }
+
+    @Test fun rings_are_centered_on_the_requested_point() {
+        val rings = RangeRings.ringDrawings(51.5074, -0.1278, listOf(500.0))
+        val lats = rings[0].points.map { it.first }
+        val lons = rings[0].points.map { it.second }
+        // Center is the mean of the symmetric ring vertices.
+        assertEquals(51.5074, lats.average(), 0.01)
+        assertEquals(-0.1278, lons.average(), 0.01)
+    }
+}


### PR DESCRIPTION
Closes #152.

Range & Bearing for OmniTAK Android, now **wired end-to-end** (was core-only).

### Core (RangeBearing)
Pure great-circle math, no Android deps: distance (haversine) + true/magnetic/grid bearing + back-azimuth, plus geodesic `ringPoints`/`rings`. Ported from iOS `RangeBearingService`. Unit-tested against cardinal-direction and known great-circle values.

### Tool wiring (new)
- **"Range Rings"** entry in the Tools drawer. Activate → tap the map to drop a center → concentric great-circle rings draw at the iOS-default radii **[100, 500, 1000, 2000, 5000] m**, with a center + distance-legend HUD (mirrors `MeasurementOverlay`). **Clear** re-places the center; **Done** exits.
- Rings render as transient native **LINE** drawings via `DrawingShapeRenderer` — the Annotation path that paints on the GL-buggy Adreno/Mali drivers — and never touch the drawing store. They ride both render owners (the TacticalMap `drawings` param and the drawing `LaunchedEffect`) so they survive style reloads.
- Mutually exclusive with measure/draw; drops the globe to 2D like other map tools; suppresses the long-press radial + contact-tap while placing.
- Ring building + parity defaults/label format extracted to a JVM-testable `RangeRings` helper.

### Tests
- `RangeBearingTest` (core math), `RangeRingsTest` (5 cases: defaults match iOS, `100m`/`1.0km` label format, one closed LINE drawing per radius, radius scales with distance, rings centered on the point).
- `:app:testDebugUnitTest` + `:app:assembleDebug` green.

### Verified on-device
engie_emulator: opened Tools → Range Rings → tapped a center → 5 concentric amber rings rendered with the `100m · 500m · 1.0km · 2.0km · 5.0km` legend. Screenshot shared with J.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X56oaELvYvJcBGgurTkc3A