### PR TITLE
feat(terrain): elevation profile + line-of-sight core (#153)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/terrain/ElevationProfile.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/terrain/ElevationProfile.kt
@@ -1,0 +1,157 @@
+package soy.engindearing.omnitak.mobile.data.terrain
+
+import kotlin.math.abs
+
+/**
+ * Elevation-profile + Line-of-Sight analysis (#153, ported from iOS
+ * `ElevationProfileService`).
+ *
+ * Pure math over a list of [ProfilePoint] (distance from start + bare-earth
+ * elevation), so it unit-tests directly. The Android layer walks the drawn line
+ * at a fixed interval, samples each point's elevation with
+ * [soy.engindearing.omnitak.mobile.data.uas.TerrainSampler], and feeds the
+ * resulting profile in.
+ */
+
+/** One sample along the path: [distanceM] from the start, bare-earth [elevationM]. */
+data class ProfilePoint(val distanceM: Double, val elevationM: Double)
+
+/** Steepness bucket for a segment grade (matches the iOS categories/thresholds). */
+enum class Steepness {
+    FLAT, GENTLE, MODERATE, STEEP, VERY_STEEP, EXTREME;
+
+    companion object {
+        fun from(gradePct: Double): Steepness {
+            val g = abs(gradePct)
+            return when {
+                g < 3.0 -> FLAT
+                g < 8.0 -> GENTLE
+                g < 15.0 -> MODERATE
+                g < 25.0 -> STEEP
+                g < 40.0 -> VERY_STEEP
+                else -> EXTREME
+            }
+        }
+    }
+}
+
+/** A constant-grade run between two consecutive samples. */
+data class GradientSegment(
+    val startM: Double,
+    val endM: Double,
+    val gradePct: Double,
+    val steepness: Steepness,
+)
+
+/** Whole-profile summary. */
+data class ProfileStats(
+    val minElevationM: Double,
+    val maxElevationM: Double,
+    val totalClimbM: Double,
+    val totalDescentM: Double,
+    val totalDistanceM: Double,
+    val maxGradePct: Double,
+    val avgGradePct: Double,
+)
+
+/**
+ * Result of a line-of-sight check. [minClearanceM] is the smallest vertical gap
+ * between the sight line and the terrain across all intermediate points
+ * (negative ⇒ the terrain pokes through, i.e. blocked).
+ */
+data class LineOfSightResult(
+    val clear: Boolean,
+    val firstObstructionIndex: Int?,
+    val firstObstructionDistanceM: Double?,
+    val minClearanceM: Double,
+)
+
+object ElevationProfile {
+
+    private const val EARTH_RADIUS_M = 6_371_008.8
+
+    /** Min/max/climb/descent + max & average (absolute) grade. */
+    fun stats(points: List<ProfilePoint>): ProfileStats {
+        require(points.isNotEmpty()) { "elevation profile is empty" }
+        var climb = 0.0
+        var descent = 0.0
+        var maxGrade = 0.0
+        var gradeSum = 0.0
+        var segments = 0
+        for (i in 1 until points.size) {
+            val dz = points[i].elevationM - points[i - 1].elevationM
+            if (dz >= 0) climb += dz else descent += -dz
+            val dx = points[i].distanceM - points[i - 1].distanceM
+            if (dx > 0.0) {
+                val grade = abs(dz / dx * 100.0)
+                if (grade > maxGrade) maxGrade = grade
+                gradeSum += grade
+                segments++
+            }
+        }
+        return ProfileStats(
+            minElevationM = points.minOf { it.elevationM },
+            maxElevationM = points.maxOf { it.elevationM },
+            totalClimbM = climb,
+            totalDescentM = descent,
+            totalDistanceM = points.last().distanceM - points.first().distanceM,
+            maxGradePct = maxGrade,
+            avgGradePct = if (segments > 0) gradeSum / segments else 0.0,
+        )
+    }
+
+    /** Per-segment grade + steepness category. */
+    fun gradients(points: List<ProfilePoint>): List<GradientSegment> =
+        (1 until points.size).mapNotNull { i ->
+            val dx = points[i].distanceM - points[i - 1].distanceM
+            if (dx <= 0.0) return@mapNotNull null
+            val grade = (points[i].elevationM - points[i - 1].elevationM) / dx * 100.0
+            GradientSegment(points[i - 1].distanceM, points[i].distanceM, grade, Steepness.from(grade))
+        }
+
+    /**
+     * Is the target visible from the observer along this terrain profile?
+     *
+     * Sight line runs from `start.elev + observerHeight` to
+     * `end.elev + targetHeight`. Each intermediate sample blocks if the terrain
+     * rises above that line. When [earthCurvature] is on, the Earth's bulge
+     * between the two points (with atmospheric [refractionK] ≈ 0.13 standard)
+     * is subtracted from the available clearance — which is what drops a distant
+     * sea-level target below the horizon.
+     */
+    fun lineOfSight(
+        points: List<ProfilePoint>,
+        observerHeightM: Double,
+        targetHeightM: Double,
+        earthCurvature: Boolean = true,
+        refractionK: Double = 0.13,
+    ): LineOfSightResult {
+        require(points.size >= 2) { "line of sight needs at least 2 points" }
+        val start = points.first().elevationM + observerHeightM
+        val end = points.last().elevationM + targetHeightM
+        val total = points.last().distanceM - points.first().distanceM
+        val effR = EARTH_RADIUS_M / (1.0 - refractionK)
+
+        var minClearance = Double.POSITIVE_INFINITY
+        var firstIdx: Int? = null
+        var firstDist: Double? = null
+        for (i in 1 until points.size - 1) {
+            val d1 = points[i].distanceM - points.first().distanceM
+            val sight = if (total > 0.0) start + (end - start) * (d1 / total) else start
+            val bulge = if (earthCurvature) d1 * (total - d1) / (2.0 * effR) else 0.0
+            val clearance = (sight - bulge) - points[i].elevationM
+            if (clearance < minClearance) minClearance = clearance
+            if (clearance < 0.0 && firstIdx == null) {
+                firstIdx = i
+                firstDist = points[i].distanceM
+            }
+        }
+        if (minClearance == Double.POSITIVE_INFINITY) minClearance = Double.MAX_VALUE // <3 points
+        return LineOfSightResult(
+            clear = firstIdx == null,
+            firstObstructionIndex = firstIdx,
+            firstObstructionDistanceM = firstDist,
+            minClearanceM = minClearance,
+        )
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/terrain/ElevationProfileTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/terrain/ElevationProfileTest.kt
@@ -1,0 +1,83 @@
+package soy.engindearing.omnitak.mobile.data.terrain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #153 — Elevation profile + Line-of-Sight math (ported from iOS
+ * ElevationProfileService). Pure over a list of (distance, elevation) samples
+ * so it unit-tests directly; the Android layer samples those points along the
+ * drawn line with TerrainSampler and feeds them in.
+ */
+class ElevationProfileTest {
+
+    private fun pts(vararg de: Pair<Double, Double>) =
+        de.map { ProfilePoint(it.first, it.second) }
+
+    @Test fun steepness_thresholds_use_absolute_grade() {
+        assertEquals(Steepness.FLAT, Steepness.from(2.0))
+        assertEquals(Steepness.GENTLE, Steepness.from(5.0))
+        assertEquals(Steepness.MODERATE, Steepness.from(10.0))
+        assertEquals(Steepness.STEEP, Steepness.from(-20.0)) // abs
+        assertEquals(Steepness.VERY_STEEP, Steepness.from(30.0))
+        assertEquals(Steepness.EXTREME, Steepness.from(50.0))
+    }
+
+    @Test fun stats_climb_descent_min_max_grades() {
+        val s = ElevationProfile.stats(pts(0.0 to 100.0, 100.0 to 110.0, 200.0 to 105.0))
+        assertEquals(100.0, s.minElevationM, 1e-9)
+        assertEquals(110.0, s.maxElevationM, 1e-9)
+        assertEquals(10.0, s.totalClimbM, 1e-9)
+        assertEquals(5.0, s.totalDescentM, 1e-9)
+        assertEquals(200.0, s.totalDistanceM, 1e-9)
+        assertEquals(10.0, s.maxGradePct, 1e-9)   // |+10%| then |-5%|
+        assertEquals(7.5, s.avgGradePct, 1e-9)    // mean |grade| = (10+5)/2
+    }
+
+    @Test fun gradients_segment_grade_and_category() {
+        val g = ElevationProfile.gradients(pts(0.0 to 0.0, 100.0 to 20.0)) // +20% over 100m
+        assertEquals(1, g.size)
+        assertEquals(20.0, g[0].gradePct, 1e-9)
+        assertEquals(Steepness.STEEP, g[0].steepness)
+    }
+
+    @Test fun los_clear_over_a_valley() {
+        // endpoints high, dip in the middle, observers 2m AGL — clearly visible
+        val r = ElevationProfile.lineOfSight(
+            pts(0.0 to 100.0, 500.0 to 50.0, 1000.0 to 100.0),
+            observerHeightM = 2.0, targetHeightM = 2.0, earthCurvature = false,
+        )
+        assertTrue(r.clear)
+        assertNull(r.firstObstructionIndex)
+        assertTrue(r.minClearanceM > 0)
+    }
+
+    @Test fun los_blocked_by_a_hill() {
+        val r = ElevationProfile.lineOfSight(
+            pts(0.0 to 100.0, 500.0 to 200.0, 1000.0 to 100.0),
+            observerHeightM = 2.0, targetHeightM = 2.0, earthCurvature = false,
+        )
+        assertFalse(r.clear)
+        assertEquals(1, r.firstObstructionIndex)
+        assertEquals(500.0, r.firstObstructionDistanceM!!, 1e-9)
+        assertTrue(r.minClearanceM < 0)
+    }
+
+    @Test fun los_raising_observer_clears_the_hill() {
+        val profile = pts(0.0 to 100.0, 500.0 to 150.0, 1000.0 to 100.0)
+        assertFalse(ElevationProfile.lineOfSight(profile, 2.0, 2.0, earthCurvature = false).clear)
+        // lift both ends enough that the mid sight line (avg) tops the 150 hill
+        assertTrue(ElevationProfile.lineOfSight(profile, 60.0, 60.0, earthCurvature = false).clear)
+    }
+
+    @Test fun earth_curvature_blocks_a_long_flat_shot() {
+        // 30 km of flat sea-level terrain, observers on the deck
+        val flat = (0..6).map { ProfilePoint(it * 5000.0, 0.0) }
+        assertTrue(ElevationProfile.lineOfSight(flat, 0.0, 0.0, earthCurvature = false).clear)
+        val curved = ElevationProfile.lineOfSight(flat, 0.0, 0.0, earthCurvature = true)
+        assertFalse("curvature should drop the target below the horizon", curved.clear)
+    }
+}


### PR DESCRIPTION
## What

First slice of #153 (iOS→Android parity). Ports the iOS `ElevationProfileService` analysis to a pure, unit-tested Android core in `data/terrain/ElevationProfile.kt`:

- `stats()` → min/max elevation, total climb/descent, total distance, max + average grade
- `gradients()` → per-segment grade % + `Steepness` category (flat→extreme, iOS thresholds)
- `lineOfSight()` → clear/blocked + first obstruction + min clearance, with observer/target heights and **Earth-curvature + atmospheric-refraction** (k≈0.13) correction

Feeds off the existing `data/uas/TerrainSampler.kt` (TAK Terrain SRTM, HAE).

## Tests (TDD, 7/7 green)

`ElevationProfileTest` — steepness thresholds (abs grade), climb/descent/grade stats, segment grade+category, LoS clear-over-valley, LoS blocked-by-hill (first obstruction), raising the observer to clear a hill, and **Earth curvature dropping a 30 km sea-level target below the horizon**. `./gradlew :app:testDebugUnitTest` green.

## Remaining for #153 (follow-on)

- [ ] Sample the drawn line at a fixed interval via `TerrainSampler` → build the `ProfilePoint` list
- [ ] Elevation-profile chart sheet (cross-section + LoS clear/blocked banner)
- [ ] Tools-sheet entry + 2-point draw interaction

Part of #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)