### PR TITLE
feat(military): MEDEVAC/SALUTE/SPOTREP report → CoT core (#154)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/military/MilitaryReports.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/military/MilitaryReports.kt
@@ -1,0 +1,158 @@
+package soy.engindearing.omnitak.mobile.data.military
+
+import soy.engindearing.omnitak.mobile.data.CotXml
+
+/**
+ * Military report → CoT (#154, ported from iOS `MilitaryReportCoT` +
+ * MEDEVAC/SPOTREP models). Pure text formatting + CoT XML, so it unit-tests
+ * directly; the Android layer fills the forms and ships the event over the
+ * active TAK connection (the same path PPLI/markers use).
+ */
+
+/** CoT type per report — matches the iOS `ReportType` constants. */
+enum class ReportType(val cot: String) {
+    /** 9-line casevac request (ATAK Medline). */
+    MEDEVAC("b-r-f-h-c"),
+
+    /** SALUTE observation — renders as a spot-report point. */
+    SALUTE("b-m-p-w"),
+
+    /** SPOTREP — same spot-report point type as SALUTE. */
+    SPOTREP("b-m-p-w"),
+}
+
+// --- MEDEVAC 9-line coded fields (standard MEDEVAC request codes) ---
+
+enum class SpecialEquipment(val code: String, val label: String) {
+    NONE("A", "None Required"),
+    HOIST("B", "Hoist"),
+    EXTRACTION("C", "Extraction Equipment"),
+    VENTILATOR("D", "Ventilator"),
+}
+
+enum class PickupSecurity(val code: String, val label: String) {
+    NO_ENEMY("N", "No Enemy Troops in Area"),
+    POSSIBLE_ENEMY("P", "Possible Enemy Troops in Area"),
+    ENEMY("E", "Enemy Troops in Area (Approach with Caution)"),
+    ESCORT_REQUIRED("X", "Armed Escort Required"),
+}
+
+enum class MarkingMethod(val code: String, val label: String) {
+    PANELS("A", "Panels"),
+    PYROTECHNIC("B", "Pyrotechnic Signal"),
+    SMOKE("C", "Smoke Signal"),
+    NONE("D", "None"),
+    OTHER("E", "Other"),
+}
+
+enum class PatientNationality(val code: String, val label: String) {
+    US_MILITARY("A", "US Military"),
+    US_CIVILIAN("B", "US Civilian"),
+    NON_US_MILITARY("C", "Non-US Military"),
+    NON_US_CIVILIAN("D", "Non-US Civilian"),
+    EPW("E", "Enemy Prisoner of War"),
+}
+
+enum class CbrnContamination(val code: String, val label: String) {
+    NONE("-", "None"),
+    NUCLEAR("N", "Nuclear"),
+    BIOLOGICAL("B", "Biological"),
+    CHEMICAL("C", "Chemical"),
+}
+
+/** Nine-line MEDEVAC request (CoT type `b-r-f-h-c`). */
+data class Medevac9Line(
+    val locationGrid: String,
+    val radioFreq: String,
+    val callSign: String,
+    val callSignSuffix: String = "",
+    val patientsUrgent: Int = 0,
+    val patientsPriority: Int = 0,
+    val patientsRoutine: Int = 0,
+    val specialEquipment: SpecialEquipment = SpecialEquipment.NONE,
+    val patientsLitter: Int = 0,
+    val patientsAmbulatory: Int = 0,
+    val security: PickupSecurity = PickupSecurity.NO_ENEMY,
+    val marking: MarkingMethod = MarkingMethod.NONE,
+    val nationality: PatientNationality = PatientNationality.US_MILITARY,
+    val cbrn: CbrnContamination = CbrnContamination.NONE,
+) {
+    fun formattedText(): String {
+        val suffix = if (callSignSuffix.isBlank()) "" else "-$callSignSuffix"
+        return buildString {
+            appendLine("9-LINE MEDEVAC REQUEST")
+            appendLine("LINE 1 - LOCATION: $locationGrid")
+            appendLine("LINE 2 - FREQ/CALLSIGN: $radioFreq / $callSign$suffix")
+            appendLine(
+                "LINE 3 - PATIENTS BY PRECEDENCE: URGENT $patientsUrgent, " +
+                    "PRIORITY $patientsPriority, ROUTINE $patientsRoutine",
+            )
+            appendLine("LINE 4 - SPECIAL EQUIPMENT: ${specialEquipment.code} - ${specialEquipment.label}")
+            appendLine("LINE 5 - PATIENTS BY TYPE: LITTER $patientsLitter, AMBULATORY $patientsAmbulatory")
+            appendLine("LINE 6 - SECURITY: ${security.code} - ${security.label}")
+            appendLine("LINE 7 - MARKING: ${marking.code} - ${marking.label}")
+            appendLine("LINE 8 - NATIONALITY: ${nationality.code} - ${nationality.label}")
+            append("LINE 9 - CBRN: ${cbrn.code} - ${cbrn.label}")
+        }
+    }
+}
+
+/** SALUTE / SPOTREP observation report (CoT type `b-m-p-w`). */
+data class SaluteReport(
+    val size: String,
+    val activity: String,
+    val locationGrid: String,
+    val unit: String,
+    val time: String,
+    val equipment: String,
+    val title: String = "SALUTE REPORT",
+) {
+    fun formattedText(): String = buildString {
+        appendLine(title)
+        appendLine("S - SIZE: $size")
+        appendLine("A - ACTIVITY: $activity")
+        appendLine("L - LOCATION: $locationGrid")
+        appendLine("U - UNIT: $unit")
+        appendLine("T - TIME: $time")
+        append("E - EQUIPMENT: $equipment")
+    }
+}
+
+object MilitaryReportCoT {
+
+    /** 1-hour stale, matching the iOS report envelope. */
+    private const val STALE_MS = 3_600_000L
+
+    /**
+     * Wrap a formatted report in a CoT event: a point at the report location
+     * carrying a `<contact>` and the report text in `<remarks>`. Matches the
+     * iOS envelope (how=`h-g-i-g-o`, 1-hour stale). Field content is XML-escaped.
+     */
+    fun buildReportEvent(
+        uid: String,
+        type: ReportType,
+        senderCallsign: String,
+        lat: Double,
+        lon: Double,
+        reportText: String,
+        nowMs: Long = System.currentTimeMillis(),
+    ): String {
+        val detail = buildString {
+            append("<detail>")
+            append("<contact callsign=\"").append(CotXml.escape(senderCallsign)).append("\"/>")
+            append("<remarks>").append(CotXml.escape(reportText)).append("</remarks>")
+            append("</detail>")
+        }
+        return CotXml.buildEvent(
+            uid = uid,
+            type = type.cot,
+            how = "h-g-i-g-o",
+            lat = lat,
+            lon = lon,
+            timeIso = CotXml.isoMillis(nowMs),
+            startIso = CotXml.isoMillis(nowMs),
+            staleIso = CotXml.isoMillis(nowMs + STALE_MS),
+            detailXml = detail,
+        )
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MilitaryReportSheet.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/MilitaryReportSheet.kt
@@ -1,0 +1,210 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+import soy.engindearing.omnitak.mobile.data.military.CbrnContamination
+import soy.engindearing.omnitak.mobile.data.military.MarkingMethod
+import soy.engindearing.omnitak.mobile.data.military.Medevac9Line
+import soy.engindearing.omnitak.mobile.data.military.PatientNationality
+import soy.engindearing.omnitak.mobile.data.military.PickupSecurity
+import soy.engindearing.omnitak.mobile.data.military.ReportType
+import soy.engindearing.omnitak.mobile.data.military.SaluteReport
+import soy.engindearing.omnitak.mobile.data.military.SpecialEquipment
+
+/** What [MilitaryReportSheet] hands back on Send: the report's CoT type + the
+ *  formatted body that rides in `<remarks>`. The caller geolocates it at the
+ *  operator's position, ingests it as a marker, and broadcasts it (#154). */
+data class MilitaryReportResult(val type: ReportType, val reportText: String)
+
+/**
+ * #154 — entry forms for the three military reports the core (`MilitaryReportCoT`)
+ * can build: MEDEVAC 9-line, SALUTE, and SPOTREP. SALUTE/SPOTREP share the
+ * six-element observation form (only the title differs); MEDEVAC has its nine
+ * coded lines. Send returns the formatted text; the map screen wraps it in a CoT
+ * point and ships it over the active TAK connection.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MilitaryReportSheet(
+    defaultLocationGrid: String,
+    onSend: (MilitaryReportResult) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var type by remember { mutableStateOf(ReportType.SALUTE) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(start = 16.dp, end = 16.dp, bottom = 28.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text("Military report", style = androidx.compose.material3.MaterialTheme.typography.titleLarge)
+
+            // Report-type selector.
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf(
+                    ReportType.MEDEVAC to "MEDEVAC",
+                    ReportType.SALUTE to "SALUTE",
+                    ReportType.SPOTREP to "SPOTREP",
+                ).forEach { (t, label) ->
+                    FilterChip(selected = type == t, onClick = { type = t }, label = { Text(label) })
+                }
+            }
+
+            when (type) {
+                ReportType.MEDEVAC -> MedevacForm(defaultLocationGrid, onSend)
+                ReportType.SALUTE -> SaluteForm("SALUTE REPORT", ReportType.SALUTE, defaultLocationGrid, onSend)
+                ReportType.SPOTREP -> SaluteForm("SPOT REPORT", ReportType.SPOTREP, defaultLocationGrid, onSend)
+            }
+        }
+    }
+}
+
+/** SALUTE / SPOTREP — six observation elements. */
+@Composable
+private fun SaluteForm(
+    title: String,
+    type: ReportType,
+    defaultLocationGrid: String,
+    onSend: (MilitaryReportResult) -> Unit,
+) {
+    var size by remember { mutableStateOf("") }
+    var activity by remember { mutableStateOf("") }
+    var location by remember { mutableStateOf(defaultLocationGrid) }
+    var unit by remember { mutableStateOf("") }
+    var time by remember { mutableStateOf("") }
+    var equipment by remember { mutableStateOf("") }
+
+    ReportField("S — Size", size) { size = it }
+    ReportField("A — Activity", activity) { activity = it }
+    ReportField("L — Location", location) { location = it }
+    ReportField("U — Unit", unit) { unit = it }
+    ReportField("T — Time", time) { time = it }
+    ReportField("E — Equipment", equipment) { equipment = it }
+
+    SendButton {
+        val text = SaluteReport(
+            size = size, activity = activity, locationGrid = location,
+            unit = unit, time = time, equipment = equipment, title = title,
+        ).formattedText()
+        onSend(MilitaryReportResult(type, text))
+    }
+}
+
+/** MEDEVAC 9-line. Coded lines (4/6/7/8/9) cycle through their enum on tap. */
+@Composable
+private fun MedevacForm(
+    defaultLocationGrid: String,
+    onSend: (MilitaryReportResult) -> Unit,
+) {
+    var location by remember { mutableStateOf(defaultLocationGrid) }
+    var freq by remember { mutableStateOf("") }
+    var callsign by remember { mutableStateOf("") }
+    var urgent by remember { mutableStateOf("0") }
+    var priority by remember { mutableStateOf("0") }
+    var routine by remember { mutableStateOf("0") }
+    var litter by remember { mutableStateOf("0") }
+    var ambulatory by remember { mutableStateOf("0") }
+    var equip by remember { mutableStateOf(SpecialEquipment.NONE) }
+    var security by remember { mutableStateOf(PickupSecurity.NO_ENEMY) }
+    var marking by remember { mutableStateOf(MarkingMethod.NONE) }
+    var nationality by remember { mutableStateOf(PatientNationality.US_MILITARY) }
+    var cbrn by remember { mutableStateOf(CbrnContamination.NONE) }
+
+    ReportField("Line 1 — Location", location) { location = it }
+    ReportField("Line 2 — Radio freq", freq) { freq = it }
+    ReportField("Line 2 — Callsign", callsign) { callsign = it }
+    ReportField("Line 3 — Urgent", urgent, numeric = true) { urgent = it }
+    ReportField("Line 3 — Priority", priority, numeric = true) { priority = it }
+    ReportField("Line 3 — Routine", routine, numeric = true) { routine = it }
+    CycleField("Line 4 — Special equipment", equip.label) {
+        equip = SpecialEquipment.entries[(equip.ordinal + 1) % SpecialEquipment.entries.size]
+    }
+    ReportField("Line 5 — Litter", litter, numeric = true) { litter = it }
+    ReportField("Line 5 — Ambulatory", ambulatory, numeric = true) { ambulatory = it }
+    CycleField("Line 6 — Security", security.label) {
+        security = PickupSecurity.entries[(security.ordinal + 1) % PickupSecurity.entries.size]
+    }
+    CycleField("Line 7 — Marking", marking.label) {
+        marking = MarkingMethod.entries[(marking.ordinal + 1) % MarkingMethod.entries.size]
+    }
+    CycleField("Line 8 — Nationality", nationality.label) {
+        nationality = PatientNationality.entries[(nationality.ordinal + 1) % PatientNationality.entries.size]
+    }
+    CycleField("Line 9 — CBRN", cbrn.label) {
+        cbrn = CbrnContamination.entries[(cbrn.ordinal + 1) % CbrnContamination.entries.size]
+    }
+
+    SendButton {
+        val text = Medevac9Line(
+            locationGrid = location, radioFreq = freq, callSign = callsign,
+            patientsUrgent = urgent.toIntOrNull() ?: 0,
+            patientsPriority = priority.toIntOrNull() ?: 0,
+            patientsRoutine = routine.toIntOrNull() ?: 0,
+            specialEquipment = equip,
+            patientsLitter = litter.toIntOrNull() ?: 0,
+            patientsAmbulatory = ambulatory.toIntOrNull() ?: 0,
+            security = security, marking = marking, nationality = nationality, cbrn = cbrn,
+        ).formattedText()
+        onSend(MilitaryReportResult(ReportType.MEDEVAC, text))
+    }
+}
+
+@Composable
+private fun ReportField(label: String, value: String, numeric: Boolean = false, onChange: (String) -> Unit) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onChange,
+        label = { Text(label) },
+        singleLine = true,
+        keyboardOptions = if (numeric) KeyboardOptions(keyboardType = KeyboardType.Number) else KeyboardOptions.Default,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+/** A read-only field that cycles its coded value on tap (compact vs a dropdown). */
+@Composable
+private fun CycleField(label: String, current: String, onCycle: () -> Unit) {
+    OutlinedTextField(
+        value = current,
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(label) },
+        trailingIcon = {
+            androidx.compose.material3.TextButton(onClick = onCycle) { Text("Next") }
+        },
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun SendButton(onSend: () -> Unit) {
+    Button(onClick = onSend, modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+        Text("Send report", fontFamily = FontFamily.Monospace)
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.TrackChanges
+import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.AddLocation
@@ -234,6 +235,8 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     var layersSheetOpen by remember { mutableStateOf(false) }
     // #120 — offline map download sheet.
     var offlineMapsOpen by remember { mutableStateOf(false) }
+    // #154 — military report entry sheet (MEDEVAC / SALUTE / SPOTREP).
+    var reportsSheetOpen by remember { mutableStateOf(false) }
     val offlineRegions by app.offlineRegionStore.regions.collectAsState()
     var teamsPanelOpen by remember { mutableStateOf(false) }
     var panTarget by remember { mutableStateOf<LatLng?>(null) }
@@ -1463,6 +1466,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 ToolEntry("draw", Icons.Filled.Brush, "Drawing"),
                 ToolEntry("measure", Icons.Filled.Straighten, "Measure"),
                 ToolEntry("rangerings", Icons.Filled.TrackChanges, "Range Rings"),
+                ToolEntry("reports", Icons.Filled.Description, "Reports"),
                 ToolEntry("layers", Icons.Filled.Layers, "Layers"),
                 // ADS-B moved to the ADS-B plugin — its on/off control now
                 // lives in Settings → Plugins → ADS-B (the plugin's
@@ -1492,6 +1496,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                         rangeRingCenter = null
                         toast("Range rings — tap map to set center")
                     }
+                    "reports" -> reportsSheetOpen = true
                     "draw" -> {
                         rangeRingsActive = false
                         drawingPickerOpen = true
@@ -2137,6 +2142,54 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 provider = userPrefs.mapProvider,
                 customTileUrl = userPrefs.customTileUrl,
                 onDismiss = { offlineMapsOpen = false },
+            )
+        }
+
+        // #154 — military report entry. The report drops as a CoT point at the
+        // operator's position (the location grid prefills from it, editable),
+        // ingests locally so it shows on the map, and broadcasts over the active
+        // TAK connection via MilitaryReportCoT.buildReportEvent — the same
+        // local-ingest + sendCoT path the marker drop uses.
+        if (reportsSheetOpen) {
+            val rptPos = effectiveSelfFix?.let { LatLng(it.lat, it.lon) }
+                ?: cameraTarget ?: selfFix?.let { LatLng(it.lat, it.lon) }
+            val defaultGrid = rptPos?.let {
+                soy.engindearing.omnitak.mobile.data.CoordFormatter
+                    .position(it.latitude, it.longitude, userPrefs.coordFormat)
+            } ?: ""
+            soy.engindearing.omnitak.mobile.ui.components.MilitaryReportSheet(
+                defaultLocationGrid = defaultGrid,
+                onSend = { result ->
+                    val pos = rptPos ?: FALLBACK_GLOBAL_VIEW
+                    val uid = "report-${result.type.name.lowercase()}-${java.util.UUID.randomUUID()}"
+                    val event = soy.engindearing.omnitak.mobile.data.CoTEvent(
+                        uid = uid,
+                        type = result.type.cot,
+                        lat = pos.latitude,
+                        lon = pos.longitude,
+                        callsign = result.type.name,
+                        remarks = result.reportText,
+                    )
+                    app.contactStore.ingest(event)
+                    reportsSheetOpen = false
+                    scope.launch {
+                        val xml = soy.engindearing.omnitak.mobile.data.military.MilitaryReportCoT
+                            .buildReportEvent(
+                                uid = uid,
+                                type = result.type,
+                                senderCallsign = userPrefs.callsign,
+                                lat = pos.latitude,
+                                lon = pos.longitude,
+                                reportText = result.reportText,
+                            )
+                        val sent = runCatching { app.serverManager.sendCoT(xml) }.getOrDefault(false)
+                        toast(
+                            if (sent) "${result.type.name} sent to server"
+                            else "${result.type.name} saved — local only (no server)",
+                        )
+                    }
+                },
+                onDismiss = { reportsSheetOpen = false },
             )
         }
 

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/military/MilitaryReportsTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/military/MilitaryReportsTest.kt
@@ -1,0 +1,84 @@
+package soy.engindearing.omnitak.mobile.data.military
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #154 — Military report → CoT builders (ported from iOS MilitaryReportCoT +
+ * MEDEVAC/SPOTREP models). Pure formatting + XML, so it unit-tests directly.
+ */
+class MilitaryReportsTest {
+
+    private val medevac = Medevac9Line(
+        locationGrid = "18SUJ2348907654",
+        radioFreq = "30.55", callSign = "DUSTOFF", callSignSuffix = "6",
+        patientsUrgent = 2, patientsPriority = 1, patientsRoutine = 0,
+        specialEquipment = SpecialEquipment.HOIST,
+        patientsLitter = 2, patientsAmbulatory = 1,
+        security = PickupSecurity.ENEMY,
+        marking = MarkingMethod.SMOKE,
+        nationality = PatientNationality.US_MILITARY,
+        cbrn = CbrnContamination.NONE,
+    )
+
+    @Test fun medevac_text_has_all_nine_lines_and_codes() {
+        val t = medevac.formattedText()
+        assertTrue(t.startsWith("9-LINE MEDEVAC REQUEST"))
+        assertTrue(t.contains("LINE 1 - LOCATION: 18SUJ2348907654"))
+        assertTrue(t.contains("LINE 2 - FREQ/CALLSIGN: 30.55 / DUSTOFF-6"))
+        assertTrue(t.contains("URGENT 2") && t.contains("PRIORITY 1") && t.contains("ROUTINE 0"))
+        assertTrue(t.contains("LINE 4 - SPECIAL EQUIPMENT: B - Hoist"))
+        assertTrue(t.contains("LITTER 2") && t.contains("AMBULATORY 1"))
+        assertTrue(t.contains("LINE 6 - SECURITY: E -"))
+        assertTrue(t.contains("LINE 7 - MARKING: C - Smoke Signal"))
+        assertTrue(t.contains("LINE 9 - CBRN:"))
+        for (n in 1..9) assertTrue("missing LINE $n", t.contains("LINE $n -"))
+    }
+
+    @Test fun salute_text_has_all_six_elements() {
+        val t = SaluteReport(
+            size = "Squad (8-12)", activity = "Digging in", locationGrid = "18SUJ23480765",
+            unit = "Unknown infantry", time = "211530ZJUN26", equipment = "2x PKM, 1x RPG",
+        ).formattedText()
+        assertTrue(t.contains("S - SIZE: Squad (8-12)"))
+        assertTrue(t.contains("A - ACTIVITY: Digging in"))
+        assertTrue(t.contains("L - LOCATION: 18SUJ23480765"))
+        assertTrue(t.contains("U - UNIT: Unknown infantry"))
+        assertTrue(t.contains("T - TIME: 211530ZJUN26"))
+        assertTrue(t.contains("E - EQUIPMENT: 2x PKM, 1x RPG"))
+    }
+
+    @Test fun report_cot_types_match_ios() {
+        assertEquals("b-r-f-h-c", ReportType.MEDEVAC.cot)
+        assertEquals("b-m-p-w", ReportType.SPOTREP.cot)
+        assertEquals("b-m-p-w", ReportType.SALUTE.cot)
+    }
+
+    @Test fun cot_event_wraps_type_point_contact_and_remarks() {
+        val xml = MilitaryReportCoT.buildReportEvent(
+            uid = "MEDEVAC-abc", type = ReportType.MEDEVAC,
+            senderCallsign = "OMNI-1", lat = 47.6, lon = -122.3,
+            reportText = medevac.formattedText(), nowMs = 1_700_000_000_000L,
+        )
+        assertTrue(xml.contains("<event"))
+        assertTrue(xml.contains("uid=\"MEDEVAC-abc\""))
+        assertTrue(xml.contains("type=\"b-r-f-h-c\""))
+        assertTrue(xml.contains("lat=\"47.6\"") && xml.contains("lon=\"-122.3\""))
+        assertTrue(xml.contains("<contact callsign=\"OMNI-1\"/>"))
+        assertTrue(xml.contains("<remarks>") && xml.contains("9-LINE MEDEVAC REQUEST"))
+        assertTrue(xml.contains("how=\"h-g-i-g-o\""))
+    }
+
+    @Test fun cot_event_xml_escapes_callsign_and_remarks() {
+        val xml = MilitaryReportCoT.buildReportEvent(
+            uid = "SPOTREP-1", type = ReportType.SPOTREP,
+            senderCallsign = "A&B", lat = 0.0, lon = 0.0,
+            reportText = "remark <hostile> & \"danger\"", nowMs = 1_700_000_000_000L,
+        )
+        assertTrue("callsign & must be escaped", xml.contains("callsign=\"A&amp;B\""))
+        assertTrue("remarks < must be escaped", xml.contains("&lt;hostile&gt;"))
+        assertFalse("no raw unescaped <hostile> in output", xml.contains("<hostile>"))
+    }
+}


### PR DESCRIPTION
Closes #154.

Military reports for OmniTAK Android, **wired end-to-end** (was core-only).

### Core (MilitaryReportCoT)
MEDEVAC 9-line, SALUTE, and SPOTREP → CoT point with the formatted report in `<remarks>` (iOS envelope: `how=h-g-i-g-o`, 1-hour stale, XML-escaped). `MilitaryReportsTest` locks the 9-line/6-element formatting, CoT types, and escaping.

### Wiring (new)
- **"Reports"** entry in the Tools drawer → `MilitaryReportSheet`: a type selector (MEDEVAC / SALUTE / SPOTREP) over the matching form. SALUTE/SPOTREP share the six-element observation form (title differs); MEDEVAC has its nine coded lines (numeric patient counts + tap-to-cycle coded fields for equipment/security/marking/nationality/CBRN).
- Location **prefills from the operator's position** (`CoordFormatter`, editable). On Send the report drops as a CoT point there, ingests locally (shows on the map), and broadcasts via `MilitaryReportCoT.buildReportEvent` — the same `contactStore.ingest` + `serverManager.sendCoT` path the marker-drop uses. Toast distinguishes sent-to-server vs local-only.

### Verified on-device (emulator)
Reports tool → SALUTE form (location prefilled from GPS) → filled S/A/U → **Send → "SALUTE saved — local only (no server)"**, the report ingested as a CoT marker. Sheet + send flow photographed (shared with J). The marker pin itself renders through the `ContactMarkerRenderer` path already on-device-verified in #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X56oaELvYvJcBGgurTkc3A