### PR TITLE
fix(offline): render markers on top of downloaded/imported raster maps (#139)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/KmlOverlayRenderer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/KmlOverlayRenderer.kt
@@ -183,6 +183,30 @@ object KmlOverlayRenderer {
 
     private fun layerIds(id: String) = listOf("kmlfill-$id", "kmlline-$id")
 
+    /** Live basemap raster layer id from buildTacticalStyle — the anchor every
+     *  cached/imported raster overlay sits directly ABOVE (and thus below every
+     *  operational overlay + the self-marker). */
+    private const val BASEMAP_LAYER_ID = "basemap-tiles"
+
+    /**
+     * Add a raster overlay ([layerId] backed by [sourceId]) directly ABOVE the
+     * live basemap but BELOW the operational overlay layers (grid, drawings,
+     * measurements, contacts, aircraft) and the self-marker. A plain
+     * [Style.addLayer] appends to the TOP of the stack, so the opaque raster
+     * would paint over every marker on a downloaded/imported map — exactly the
+     * "self-marker + contacts vanish on offline maps" failure (#139 follow-up;
+     * the on-map render of downloaded regions was previously device-pending).
+     * Falls back to a top add if the basemap anchor is absent (custom style).
+     */
+    private fun addRasterAboveBasemap(style: Style, layerId: String, sourceId: String) {
+        val layer = RasterLayer(layerId, sourceId)
+        if (style.getLayer(BASEMAP_LAYER_ID) != null) {
+            style.addLayerAbove(layer, BASEMAP_LAYER_ID)
+        } else {
+            style.addLayer(layer)
+        }
+    }
+
     // Single-image raster overlays (KMZ GroundOverlay etc.) via ImageSource.
     private val installedRaster = mutableSetOf<String>()
 
@@ -207,7 +231,7 @@ object KmlOverlayRenderer {
                     LatLng(overlay.south, overlay.west), // bottom-left
                 )
                 style.addSource(ImageSource(sourceId, quad, bmp))
-                style.addLayer(RasterLayer(layerId, sourceId))
+                addRasterAboveBasemap(style, layerId, sourceId)
             }
             val vis = if (overlay.visible) Property.VISIBLE else Property.NONE
             style.getLayerAs<RasterLayer>(layerId)?.setProperties(
@@ -239,7 +263,7 @@ object KmlOverlayRenderer {
                     maxZoom = overlay.maxZoom.toFloat()
                 }
                 style.addSource(RasterSource(sourceId, tileSet, 256))
-                style.addLayer(RasterLayer(layerId, sourceId))
+                addRasterAboveBasemap(style, layerId, sourceId)
             }
             val vis = if (overlay.visible) Property.VISIBLE else Property.NONE
             style.getLayerAs<RasterLayer>(layerId)?.setProperties(
@@ -281,9 +305,10 @@ object KmlOverlayRenderer {
                     maxZoom = region.maxZoom.toFloat()
                 }
                 style.addSource(RasterSource(sourceId, tileSet, 256))
-                // When offline, draw cached tiles on top so they win over the
-                // (unreachable) live basemap; online, let it layer normally.
-                style.addLayer(RasterLayer(layerId, sourceId))
+                // Draw cached tiles just ABOVE the (possibly unreachable) live
+                // basemap so they win the basemap slot — but BELOW every marker
+                // overlay, so the self-marker + contacts still render offline.
+                addRasterAboveBasemap(style, layerId, sourceId)
             }
             style.getLayerAs<RasterLayer>(layerId)?.setProperties(
                 PropertyFactory.visibility(Property.VISIBLE),

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalStyleLayerOrderTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalStyleLayerOrderTest.kt
@@ -1,0 +1,51 @@
+package soy.engindearing.omnitak.mobile.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #139 follow-up — markers must render on downloaded/imported raster maps.
+ *
+ * KmlOverlayRenderer inserts every cached/imported raster overlay with
+ * `addLayerAbove(layer, "basemap-tiles")`, so the overlay sits just above the
+ * basemap but below every operational overlay (grid, drawings, measurements,
+ * contacts, aircraft) and the self-marker. That ordering is only correct if
+ * `basemap-tiles` really is the bottom layer with the overlays stacked above
+ * it. This pins the buildTacticalStyle layer order so the anchor can't drift.
+ */
+class TacticalStyleLayerOrderTest {
+
+    private fun layerIdsInOrder(json: String): List<String> =
+        Regex("\"id\"\\s*:\\s*\"([^\"]+)\"").findAll(json).map { it.groupValues[1] }.toList()
+
+    @Test fun basemap_is_the_bottom_layer_below_every_overlay() {
+        val json = buildTacticalStyle(
+            name = "OSM",
+            basemapTiles = "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+            attribution = "© OpenStreetMap contributors",
+        )
+        val ids = layerIdsInOrder(json)
+
+        // The raster-overlay anchor must exist and be the very bottom layer.
+        assertEquals("basemap-tiles must be the bottom (first) layer", 0, ids.indexOf("basemap-tiles"))
+
+        // Every operational overlay + the marker layers must stack ABOVE it, so
+        // a raster inserted just above basemap-tiles renders beneath them.
+        val overlaysAboveBasemap = listOf(
+            "grid-line",
+            "drawings-fill",
+            "drawings-outline",
+            "measurement-line",
+            "contacts-circles",
+            "contacts-labels",
+            "aircraft-circle",
+            "aircraft-label",
+        )
+        for (id in overlaysAboveBasemap) {
+            val idx = ids.indexOf(id)
+            assertTrue("overlay layer '$id' is missing from the tactical style", idx >= 0)
+            assertTrue("overlay layer '$id' must sit ABOVE basemap-tiles", idx > 0)
+        }
+    }
+}


### PR DESCRIPTION
## The problem (great catch from field reasoning)

#139 made offline OSM tiles **download**, but the on-map render of downloaded regions was marked *device-pending in code* — and it was broken. `KmlOverlayRenderer` added every cached region (and imported MBTiles / raster imagery) with a plain `style.addLayer()`, which appends to the **top of the style stack**.

`buildTacticalStyle` bakes the operational overlays into the style above the basemap (bottom→top): `basemap-tiles` → `grid-line` → `drawings-*` → `measurement-*` → `contacts-*` → `aircraft-*`. The self-marker (`LocationComponent`) activates on top of those. So the opaque offline raster, added last/on-top, **painted over the self-marker, contacts, drawings, grid, and aircraft.** Only `addMarker` annotations survived. On a downloaded map you'd see tiles but **no self-marker and no contacts** — situational awareness gone, exactly the "then it's pointless" failure.

## Fix

Insert raster overlays with `addLayerAbove(layer, "basemap-tiles")` — just above the live basemap, **below every marker/overlay layer**. Extracted a shared `addRasterAboveBasemap()` helper and applied it to all three appliers (offline regions, imported MBTiles, raster imagery), since they shared the bug. Falls back to a top-add only if the basemap anchor is absent.

## Verification

- **`TacticalStyleLayerOrderTest`** (new, JVM) pins the contract: `basemap-tiles` is the bottom layer and all 8 operational overlays (`grid-line`, `drawings-*`, `measurement-*`, `contacts-*`, `aircraft-*`) sit above it — so a raster inserted above the basemap renders beneath every marker. Green locally.
- Existing `:app:testDebugUnitTest` green.
- Recommend an on-device confirm: download an OSM region → airplane mode → self-marker + contacts still render over the cached tiles.

Closes the rendering half of #139 (the download half shipped in #151).

🤖 Generated with [Claude Code](https://claude.com/claude-code)