### PR TITLE
feat(geofence): general circle/polygon geofencing core + entry/exit/dwell (#155)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/geofence/Geofencing.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/geofence/Geofencing.kt
@@ -1,0 +1,115 @@
+package soy.engindearing.omnitak.mobile.data.geofence
+
+import soy.engindearing.omnitak.mobile.data.GeoMath
+
+/**
+ * General geofencing (#155, ported from iOS GeofenceService): circle + polygon
+ * zones with entry/exit/dwell transitions on tracked contacts.
+ *
+ * Pure — no Android dependency — so it unit-tests directly. The Android layer
+ * feeds each contact's position into [GeofenceMonitor.update] (from the CoT
+ * stream / self GPS) and turns the returned events into notifications + a map
+ * highlight; CoT for the zone definitions/events layers on top.
+ */
+
+/** A WGS84 point. */
+data class LatLon(val lat: Double, val lon: Double)
+
+enum class GeofenceEventType { ENTRY, EXIT, DWELL }
+
+/** A monitored area. [contains] is the only thing the monitor needs. */
+sealed interface GeofenceZone {
+    val id: String
+    fun contains(lat: Double, lon: Double): Boolean
+}
+
+/** Circular zone — inside when within [radiusMeters] great-circle distance. */
+data class CircleZone(
+    override val id: String,
+    val centerLat: Double,
+    val centerLon: Double,
+    val radiusMeters: Double,
+) : GeofenceZone {
+    override fun contains(lat: Double, lon: Double): Boolean =
+        GeoMath.haversineMeters(centerLat, centerLon, lat, lon) <= radiusMeters
+}
+
+/** Polygon zone — inside per ray-casting over the ring of [vertices]. */
+data class PolygonZone(
+    override val id: String,
+    val vertices: List<LatLon>,
+) : GeofenceZone {
+    override fun contains(lat: Double, lon: Double): Boolean = Geofencing.pointInPolygon(lat, lon, vertices)
+}
+
+/** One transition for [contactUid] against [zoneId] at [atMs]. */
+data class GeofenceEvent(
+    val zoneId: String,
+    val contactUid: String,
+    val type: GeofenceEventType,
+    val atMs: Long,
+)
+
+object Geofencing {
+    /**
+     * Ray-casting point-in-polygon on (x = lon, y = lat). Planar approximation —
+     * correct for tactical-scale zones; doesn't handle the antimeridian.
+     */
+    fun pointInPolygon(lat: Double, lon: Double, vertices: List<LatLon>): Boolean {
+        if (vertices.size < 3) return false
+        var inside = false
+        var j = vertices.size - 1
+        for (i in vertices.indices) {
+            val yi = vertices[i].lat
+            val xi = vertices[i].lon
+            val yj = vertices[j].lat
+            val xj = vertices[j].lon
+            val intersects = (yi > lat) != (yj > lat) &&
+                lon < (xj - xi) * (lat - yi) / (yj - yi) + xi
+            if (intersects) inside = !inside
+            j = i
+        }
+        return inside
+    }
+}
+
+/**
+ * Tracks per-(zone, contact) inside state and emits entry/exit/dwell events,
+ * mirroring the iOS transition logic. [dwellThresholdMs] of 0 disables dwell;
+ * otherwise a DWELL fires once after a contact has been continuously inside a
+ * zone for that long (re-armed on the next entry). Not thread-safe — call from
+ * a single coroutine/looper.
+ */
+class GeofenceMonitor(
+    private val zones: List<GeofenceZone>,
+    private val dwellThresholdMs: Long = 0L,
+) {
+    private class State(var inside: Boolean, var enteredMs: Long, var dwellFired: Boolean)
+
+    private val state = HashMap<Pair<String, String>, State>()
+
+    fun update(contactUid: String, lat: Double, lon: Double, nowMs: Long): List<GeofenceEvent> {
+        val events = ArrayList<GeofenceEvent>()
+        for (zone in zones) {
+            val key = zone.id to contactUid
+            val now = zone.contains(lat, lon)
+            val s = state[key]
+            when {
+                now && (s == null || !s.inside) -> {
+                    state[key] = State(inside = true, enteredMs = nowMs, dwellFired = false)
+                    events += GeofenceEvent(zone.id, contactUid, GeofenceEventType.ENTRY, nowMs)
+                }
+                !now && s != null && s.inside -> {
+                    s.inside = false
+                    events += GeofenceEvent(zone.id, contactUid, GeofenceEventType.EXIT, nowMs)
+                }
+                now && s != null && s.inside && !s.dwellFired &&
+                    dwellThresholdMs > 0L && nowMs - s.enteredMs >= dwellThresholdMs -> {
+                    s.dwellFired = true
+                    events += GeofenceEvent(zone.id, contactUid, GeofenceEventType.DWELL, nowMs)
+                }
+            }
+        }
+        return events
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/geofence/GeofencingTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/geofence/GeofencingTest.kt
@@ -1,0 +1,70 @@
+package soy.engindearing.omnitak.mobile.data.geofence
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #155 — General geofencing (ported from iOS GeofenceService): circle + polygon
+ * zones with entry/exit/dwell transitions. Pure, so it unit-tests directly; the
+ * Android layer feeds contact position updates in and surfaces the events as
+ * notifications + map highlights.
+ */
+class GeofencingTest {
+
+    private val circle = CircleZone("c", centerLat = 47.0, centerLon = -122.0, radiusMeters = 1000.0)
+    private val square = PolygonZone(
+        "sq",
+        listOf(LatLon(-1.0, -1.0), LatLon(-1.0, 1.0), LatLon(1.0, 1.0), LatLon(1.0, -1.0)),
+    )
+
+    @Test fun circle_contains_center_excludes_far() {
+        assertTrue(circle.contains(47.0, -122.0))
+        assertFalse(circle.contains(48.0, -122.0)) // ~111 km away
+    }
+
+    @Test fun circle_radius_boundary() {
+        assertTrue(circle.contains(47.0 + 0.008, -122.0))  // ~890 m — inside
+        assertFalse(circle.contains(47.0 + 0.010, -122.0)) // ~1113 m — outside
+    }
+
+    @Test fun polygon_contains_via_ray_casting() {
+        assertTrue(square.contains(0.0, 0.0))    // center
+        assertFalse(square.contains(2.0, 2.0))   // outside (NE)
+        assertFalse(square.contains(0.0, 5.0))   // outside (E)
+        assertTrue(square.contains(0.9, 0.9))    // inside near corner
+    }
+
+    @Test fun monitor_emits_entry_then_exit_then_reentry() {
+        val m = GeofenceMonitor(listOf(circle))
+        assertEquals(listOf(GeofenceEventType.ENTRY), m.update("A", 47.0, -122.0, 1000L).map { it.type })
+        assertTrue("staying inside emits nothing", m.update("A", 47.0, -122.0, 2000L).isEmpty())
+        assertEquals(listOf(GeofenceEventType.EXIT), m.update("A", 48.0, -122.0, 3000L).map { it.type })
+        assertTrue("staying outside emits nothing", m.update("A", 49.0, -122.0, 3500L).isEmpty())
+        assertEquals(listOf(GeofenceEventType.ENTRY), m.update("A", 47.0, -122.0, 4000L).map { it.type })
+    }
+
+    @Test fun monitor_tracks_contacts_independently() {
+        val m = GeofenceMonitor(listOf(circle))
+        assertEquals(listOf(GeofenceEventType.ENTRY), m.update("A", 47.0, -122.0, 1L).map { it.type })
+        assertEquals(listOf(GeofenceEventType.ENTRY), m.update("B", 47.0, -122.0, 2L).map { it.type })
+        assertTrue(m.update("A", 47.0, -122.0, 3L).isEmpty())
+    }
+
+    @Test fun monitor_dwell_fires_once_after_threshold() {
+        val m = GeofenceMonitor(listOf(circle), dwellThresholdMs = 5000L)
+        assertEquals(listOf(GeofenceEventType.ENTRY), m.update("A", 47.0, -122.0, 0L).map { it.type })
+        assertTrue("before threshold", m.update("A", 47.0, -122.0, 3000L).isEmpty())
+        assertEquals(listOf(GeofenceEventType.DWELL), m.update("A", 47.0, -122.0, 6000L).map { it.type })
+        assertTrue("dwell fires only once", m.update("A", 47.0, -122.0, 9000L).isEmpty())
+    }
+
+    @Test fun monitor_reports_only_the_zone_entered() {
+        val far = CircleZone("c2", 10.0, 10.0, 1000.0)
+        val m = GeofenceMonitor(listOf(circle, far))
+        val events = m.update("A", 47.0, -122.0, 1L)
+        assertEquals(1, events.size)
+        assertEquals("c", events[0].zoneId)
+    }
+}


### PR DESCRIPTION
## What

First slice of #155 (iOS→Android parity). Ports the iOS `GeofenceService` transition logic to a pure, unit-tested Android core in `data/geofence/Geofencing.kt`:

- `CircleZone` (great-circle radius) + `PolygonZone` (ray-casting) implementing `contains(lat, lon)`
- `GeofenceMonitor` — tracks per-`(zone, contact)` inside state; emits **ENTRY**/**EXIT** on transitions and **DWELL** once after a contact stays inside past `dwellThresholdMs`

This is general geofencing on **any tracked contact**, distinct from the existing UAS-only geofence circles.

## Tests (TDD, 7/7 green)

`GeofencingTest` — circle center/far/boundary, polygon ray-casting (center, outside, near-corner), monitor entry→exit→re-entry, per-contact independence, dwell-fires-once-after-threshold, and multi-zone (reports only the zone entered). `./gradlew :app:testDebugUnitTest` green.

## Remaining for #155 (follow-on)

- [ ] Create-zone UI (drop a circle / draw a polygon) under the Tools/Layers menu
- [ ] Feed contact + self positions into the monitor; surface events as a notification + map highlight
- [ ] Zone-definition + entry/exit CoT (mirror iOS `GeofenceCoTGenerator`) so zones share to TAK

Part of #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)