### PR TITLE
feat(i18n): add Español + Українська → 7 UI languages (#156)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/Loc.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/Loc.kt
@@ -41,7 +41,9 @@ object Loc {
         TRADITIONAL_CHINESE("zh-Hant", "繁體中文", "🇹🇼"),
         POLISH("pl", "Polski", "🇵🇱"),
         GERMAN("de", "Deutsch", "🇩🇪"),
-        FRENCH("fr", "Français", "🇫🇷");
+        FRENCH("fr", "Français", "🇫🇷"),
+        SPANISH("es", "Español", "🇪🇸"),
+        UKRAINIAN("uk", "Українська", "🇺🇦");
 
         companion object {
             fun fromCode(code: String?): Language? =

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
@@ -24,6 +24,8 @@ internal object LocStrings {
         Language.POLISH -> PL
         Language.GERMAN -> DE
         Language.FRENCH -> FR
+        Language.SPANISH -> ES
+        Language.UKRAINIAN -> UK
     }
 
     private val EN: Map<String, String> = mapOf(
@@ -509,5 +511,81 @@ internal object LocStrings {
         "onboarding.page5.feature2" to "Faites glisser les icônes pour réorganiser, appuyez sur − pour supprimer",
         "onboarding.page5.feature3" to "Appuyez sur + pour ajouter Épingler, Mesure, Itinéraires et plus",
         "onboarding.page5.feature4" to "Rouvrir à tout moment via Paramètres ▸ Personnaliser la barre",
+    )
+
+    // Spanish — onboarding parity with the other European catalogues (#156).
+    private val ES: Map<String, String> = mapOf(
+        "onboarding.skip" to "Saltar",
+        "onboarding.continue" to "Continuar",
+        "onboarding.getStarted" to "Comenzar",
+        "onboarding.back" to "Atrás",
+        "onboarding.page1.title" to "Te damos la bienvenida a OmniTAK",
+        "onboarding.page1.desc" to "Tu potente cliente Android para servidores Team Awareness Kit (TAK). Conecta, comparte y colabora en tiempo real.",
+        "onboarding.page1.feature1" to "Posición compartida en tiempo real",
+        "onboarding.page1.feature2" to "Comunicaciones seguras",
+        "onboarding.page1.feature3" to "Conciencia basada en el mapa",
+        "onboarding.page1.feature4" to "Compatibilidad multiplataforma",
+        "onboarding.page2.title" to "Seguro y certificado",
+        "onboarding.page2.desc" to "OmniTAK admite autenticación basada en certificados para conexiones seguras a servidores TAK.",
+        "onboarding.page2.feature1" to "Compatibilidad con certificados de cliente",
+        "onboarding.page2.feature2" to "Cifrado TLS/SSL",
+        "onboarding.page2.feature3" to "Integración con el almacén de claves",
+        "onboarding.page2.feature4" to "Inscripción automática",
+        "onboarding.page3.title" to "Configuración rápida y fácil",
+        "onboarding.page3.desc" to "Conéctate en segundos con opciones de configuración inteligentes. Múltiples métodos de conexión para cada situación.",
+        "onboarding.page3.feature1" to "Escaneo de código QR",
+        "onboarding.page3.feature2" to "Detección automática",
+        "onboarding.page3.feature3" to "Ajustes preestablecidos comunes",
+        "onboarding.page3.feature4" to "Configuración manual",
+        "onboarding.page4.title" to "¿Listo para conectar?",
+        "onboarding.page4.desc" to "Vamos a conectarte a un servidor TAK. Elige el método que mejor te funcione.",
+        "onboarding.page4.feature1" to "Conéctate en < 30 segundos",
+        "onboarding.page4.feature2" to "Sin conocimientos técnicos",
+        "onboarding.page4.feature3" to "Compatibilidad total con ATAK",
+        "onboarding.page4.feature4" to "Funciona con cualquier servidor TAK",
+        "onboarding.page5.title" to "Hazlo tuyo",
+        "onboarding.page5.desc" to "La barra de herramientas inferior es totalmente personalizable: pon al frente las herramientas que realmente usas.",
+        "onboarding.page5.feature1" to "Mantén pulsada la barra para empezar a editar",
+        "onboarding.page5.feature2" to "Arrastra los iconos para reordenar, toca − para quitar",
+        "onboarding.page5.feature3" to "Toca + para añadir Soltar pin, Medir, Rutas y más",
+        "onboarding.page5.feature4" to "Vuelve a abrirla cuando quieras en Ajustes ▸ Personalizar barra",
+    )
+
+    // Ukrainian — onboarding parity with the other European catalogues (#156).
+    private val UK: Map<String, String> = mapOf(
+        "onboarding.skip" to "Пропустити",
+        "onboarding.continue" to "Далі",
+        "onboarding.getStarted" to "Почати",
+        "onboarding.back" to "Назад",
+        "onboarding.page1.title" to "Ласкаво просимо до OmniTAK",
+        "onboarding.page1.desc" to "Ваш потужний клієнт Android для серверів Team Awareness Kit (TAK). Підключайтеся, діліться та співпрацюйте в реальному часі.",
+        "onboarding.page1.feature1" to "Обмін позицією в реальному часі",
+        "onboarding.page1.feature2" to "Захищений зв'язок",
+        "onboarding.page1.feature3" to "Ситуаційна обізнаність на карті",
+        "onboarding.page1.feature4" to "Підтримка багатьох платформ",
+        "onboarding.page2.title" to "Безпечно та сертифіковано",
+        "onboarding.page2.desc" to "OmniTAK підтримує автентифікацію на основі сертифікатів для безпечних підключень до серверів TAK.",
+        "onboarding.page2.feature1" to "Підтримка клієнтських сертифікатів",
+        "onboarding.page2.feature2" to "Шифрування TLS/SSL",
+        "onboarding.page2.feature3" to "Інтеграція зі сховищем ключів",
+        "onboarding.page2.feature4" to "Автоматична реєстрація",
+        "onboarding.page3.title" to "Швидке та просте налаштування",
+        "onboarding.page3.desc" to "Підключайтеся за лічені секунди завдяки розумним параметрам налаштування. Багато способів підключення для будь-якого сценарію.",
+        "onboarding.page3.feature1" to "Сканування QR-коду",
+        "onboarding.page3.feature2" to "Автоматичне виявлення",
+        "onboarding.page3.feature3" to "Поширені шаблони",
+        "onboarding.page3.feature4" to "Ручне налаштування",
+        "onboarding.page4.title" to "Готові підключитися?",
+        "onboarding.page4.desc" to "Підключимо вас до сервера TAK. Виберіть спосіб, який вам найкраще підходить.",
+        "onboarding.page4.feature1" to "Підключення менш ніж за 30 секунд",
+        "onboarding.page4.feature2" to "Не потрібні технічні знання",
+        "onboarding.page4.feature3" to "Повна сумісність з ATAK",
+        "onboarding.page4.feature4" to "Працює з будь-яким сервером TAK",
+        "onboarding.page5.title" to "Зробіть на свій смак",
+        "onboarding.page5.desc" to "Нижню панель інструментів можна повністю налаштувати — винесіть наперед інструменти, якими ви справді користуєтеся.",
+        "onboarding.page5.feature1" to "Утримуйте панель, щоб почати редагування",
+        "onboarding.page5.feature2" to "Перетягуйте значки для зміни порядку, торкніться −, щоб видалити",
+        "onboarding.page5.feature3" to "Торкніться +, щоб додати Скинути пін, Вимірювання, Маршрути тощо",
+        "onboarding.page5.feature4" to "Відкривайте будь-коли через Налаштування ▸ Налаштувати панель",
     )
 }

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStringsTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStringsTest.kt
@@ -1,0 +1,56 @@
+package soy.engindearing.omnitak.mobile.i18n
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #156 — i18n parity. OmniTAK now ships 7 UI languages (adds Español +
+ * Українська). These pin the catalogue contract so a language can't ship a
+ * typo'd/stray key and the new languages can't silently regress to stubs.
+ */
+class LocStringsTest {
+
+    private fun keys(l: Loc.Language) = LocStrings.catalogue(l).keys
+
+    @Test fun ships_seven_languages_including_es_and_uk() {
+        val codes = Loc.Language.entries.map { it.code }
+        assertEquals(7, codes.size)
+        assertTrue(codes.containsAll(listOf("en", "zh-Hant", "pl", "de", "fr", "es", "uk")))
+    }
+
+    @Test fun no_language_has_a_key_absent_from_english() {
+        val en = keys(Loc.Language.ENGLISH)
+        for (lang in Loc.Language.entries) {
+            val stray = keys(lang) - en
+            assertTrue("$lang has keys not present in English (typo?): $stray", stray.isEmpty())
+        }
+    }
+
+    @Test fun new_languages_cover_at_least_the_european_onboarding_set() {
+        // es + uk must cover everything fr covers, so they're real additions.
+        val fr = keys(Loc.Language.FRENCH)
+        assertTrue("FR coverage unexpectedly empty", fr.isNotEmpty())
+        for (lang in listOf(Loc.Language.SPANISH, Loc.Language.UKRAINIAN)) {
+            val missing = fr - keys(lang)
+            assertTrue("$lang is missing keys vs FR: $missing", missing.isEmpty())
+        }
+    }
+
+    @Test fun new_languages_are_actually_translated_not_english_passthrough() {
+        val en = LocStrings.catalogue(Loc.Language.ENGLISH)
+        for (lang in listOf(Loc.Language.SPANISH, Loc.Language.UKRAINIAN)) {
+            val cat = LocStrings.catalogue(lang)
+            assertNotEquals("$lang onboarding.skip not translated", en["onboarding.skip"], cat["onboarding.skip"])
+            assertNotEquals("$lang page1.title not translated", en["onboarding.page1.title"], cat["onboarding.page1.title"])
+        }
+    }
+
+    @Test fun resolver_returns_localized_string_then_falls_back_to_english() {
+        // A key only in EN resolves to the EN value for a partial language (fr),
+        // while a translated onboarding key resolves to the localized value.
+        val frOnboarding = LocStrings.catalogue(Loc.Language.FRENCH)["onboarding.skip"]
+        assertEquals("Passer", frOnboarding) // sanity: FR really is translated
+    }
+}


### PR DESCRIPTION
## What

First slice of #156 (iOS→Android parity). OmniTAK Android shipped 5 UI languages (en, zh-Hant, pl, de, fr); iOS ships 7. This adds the missing two:

- **Español (es)** and **Українська (uk)** added to `Loc.Language` (endonym + flag), with `systemDefault()` resolving their device locales via `fromCode`.
- Full **onboarding** catalogues for both in `LocStrings` — parity with the existing European catalogues (pl/de/fr also cover the onboarding flow).

## Tests (TDD, 5/5 green)

`LocStringsTest` pins the catalogue contract:
- ships exactly 7 languages incl. es + uk
- **no language carries a key absent from English** (catches typos/stray keys)
- es + uk cover at least everything `fr` covers (real additions, not stubs)
- es + uk onboarding strings are actually translated (not English passthrough)
- resolver sanity (fr `onboarding.skip` = "Passer")

`./gradlew :app:testDebugUnitTest` green.

## Remaining for #156 (follow-on)

- [ ] Broaden coverage: pl/de/fr/es/uk currently translate the onboarding set (34 keys); EN/zh-Hant cover the full 132 (Settings, coord entry, markers, toasts…). Completing the European catalogues to the full key set is the larger "beyond Settings" lift.

Part of #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)