### PR TITLE
feat(coords): British National Grid (OSGB36) coordinate format (#157)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/Bng.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/Bng.kt
@@ -1,0 +1,151 @@
+package soy.engindearing.omnitak.mobile.data
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.floor
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlin.math.tan
+
+/**
+ * British National Grid / OSGB36 conversion (#157, ported from iOS
+ * `BNGConverter`): WGS84 -> OSGB36 (Helmert 7-parameter datum shift) -> easting
+ * /northing (Transverse Mercator on the Airy 1830 ellipsoid) -> grid reference.
+ *
+ * The Helmert shift is ~5 m accurate (good enough for tactical readouts; OSTN15
+ * would be needed for survey-grade). Pure math, so it unit-tests against the
+ * Ordnance Survey worked example.
+ */
+object Bng {
+
+    // Airy 1830 (OSGB36)
+    private const val A_OSGB = 6377563.396
+    private const val B_OSGB = 6356256.909
+    private const val E2_OSGB = 0.00667054015
+
+    // WGS84
+    private const val A_WGS = 6378137.0
+    private const val E2_WGS = 0.00669437999014
+
+    // BNG Transverse Mercator parameters
+    private val LAT0 = Math.toRadians(49.0)
+    private val LON0 = Math.toRadians(-2.0)
+    private const val N0 = -100000.0
+    private const val E0 = 400000.0
+    private const val F0 = 0.9996012717
+
+    // Helmert WGS84 -> OSGB36
+    private const val TX = -446.448
+    private const val TY = 125.157
+    private const val TZ = -542.060
+    private val RX = Math.toRadians(-0.1502 / 3600.0)
+    private val RY = Math.toRadians(-0.2470 / 3600.0)
+    private val RZ = Math.toRadians(-0.8421 / 3600.0)
+    private const val S = 20.4894 / 1_000_000.0
+
+    // 100 km grid squares indexed [n100k][e100k] over the GB grid.
+    private val GRID = arrayOf(
+        arrayOf("SV", "SW", "SX", "SY", "SZ", "TV", "TW"),
+        arrayOf("SQ", "SR", "SS", "ST", "SU", "TQ", "TR"),
+        arrayOf("SL", "SM", "SN", "SO", "SP", "TL", "TM"),
+        arrayOf("SF", "SG", "SH", "SJ", "SK", "TF", "TG"),
+        arrayOf("SA", "SB", "SC", "SD", "SE", "TA", "TB"),
+        arrayOf("NV", "NW", "NX", "NY", "NZ", "OV", "OW"),
+        arrayOf("NQ", "NR", "NS", "NT", "NU", "OQ", "OR"),
+        arrayOf("NL", "NM", "NN", "NO", "NP", "OL", "OM"),
+        arrayOf("NF", "NG", "NH", "NJ", "NK", "OF", "OG"),
+        arrayOf("NA", "NB", "NC", "ND", "NE", "OA", "OB"),
+        arrayOf("HV", "HW", "HX", "HY", "HZ", "JV", "JW"),
+        arrayOf("HQ", "HR", "HS", "HT", "HU", "JQ", "JR"),
+        arrayOf("HL", "HM", "HN", "HO", "HP", "JL", "JM"),
+    )
+
+    /** WGS84 lat/lon -> OSGB36 lat/lon (degrees) via the Helmert transform. */
+    fun wgs84ToOsgb36(latDeg: Double, lonDeg: Double): DoubleArray {
+        val lat = Math.toRadians(latDeg)
+        val lon = Math.toRadians(lonDeg)
+        val sinLat = sin(lat)
+        val cosLat = cos(lat)
+        val nu = A_WGS / sqrt(1 - E2_WGS * sinLat * sinLat)
+        val x1 = nu * cosLat * cos(lon)
+        val y1 = nu * cosLat * sin(lon)
+        val z1 = nu * (1 - E2_WGS) * sinLat
+        val x2 = TX + (1 + S) * x1 + (-RZ) * y1 + RY * z1
+        val y2 = TY + RZ * x1 + (1 + S) * y1 + (-RX) * z1
+        val z2 = TZ + (-RY) * x1 + RX * y1 + (1 + S) * z1
+        val p = sqrt(x2 * x2 + y2 * y2)
+        var lat2 = atan2(z2, p * (1 - E2_OSGB))
+        repeat(10) {
+            val sinLat2 = sin(lat2)
+            val nu2 = A_OSGB / sqrt(1 - E2_OSGB * sinLat2 * sinLat2)
+            lat2 = atan2(z2 + E2_OSGB * nu2 * sinLat2, p)
+        }
+        return doubleArrayOf(Math.toDegrees(lat2), Math.toDegrees(atan2(y2, x2)))
+    }
+
+    /** OSGB36 lat/lon (degrees) -> BNG easting/northing (meters). */
+    fun osgb36ToEastingNorthing(latDeg: Double, lonDeg: Double): DoubleArray {
+        val lat = Math.toRadians(latDeg)
+        val lon = Math.toRadians(lonDeg)
+        val sinLat = sin(lat)
+        val cosLat = cos(lat)
+        val tanLat = tan(lat)
+        val n = (A_OSGB - B_OSGB) / (A_OSGB + B_OSGB)
+        val n2 = n * n
+        val n3 = n * n * n
+        val nu = A_OSGB * F0 / sqrt(1 - E2_OSGB * sinLat * sinLat)
+        val rho = A_OSGB * F0 * (1 - E2_OSGB) / (1 - E2_OSGB * sinLat * sinLat).pow(1.5)
+        val eta2 = nu / rho - 1
+        val ma = (1 + n + 5.0 / 4.0 * n2 + 5.0 / 4.0 * n3) * (lat - LAT0)
+        val mb = (3 * n + 3 * n2 + 21.0 / 8.0 * n3) * sin(lat - LAT0) * cos(lat + LAT0)
+        val mc = (15.0 / 8.0 * n2 + 15.0 / 8.0 * n3) * sin(2 * (lat - LAT0)) * cos(2 * (lat + LAT0))
+        val md = 35.0 / 24.0 * n3 * sin(3 * (lat - LAT0)) * cos(3 * (lat + LAT0))
+        val m = B_OSGB * F0 * (ma - mb + mc - md)
+        val i = m + N0
+        val ii = nu / 2 * sinLat * cosLat
+        val iii = nu / 24 * sinLat * cosLat.pow(3) * (5 - tanLat * tanLat + 9 * eta2)
+        val iiia = nu / 720 * sinLat * cosLat.pow(5) * (61 - 58 * tanLat * tanLat + tanLat.pow(4))
+        val iv = nu * cosLat
+        val v = nu / 6 * cosLat.pow(3) * (nu / rho - tanLat * tanLat)
+        val vi = nu / 120 * cosLat.pow(5) *
+            (5 - 18 * tanLat * tanLat + tanLat.pow(4) + 14 * eta2 - 58 * tanLat * tanLat * eta2)
+        val dLon = lon - LON0
+        val northing = i + ii * dLon * dLon + iii * dLon.pow(4) + iiia * dLon.pow(6)
+        val easting = E0 + iv * dLon + v * dLon.pow(3) + vi * dLon.pow(5)
+        return doubleArrayOf(easting, northing)
+    }
+
+    /** 2-letter 100 km grid square for an easting/northing, or null if off-grid. */
+    fun gridSquare(easting: Double, northing: Double): String? {
+        val e100k = floor(easting / 100000.0).toInt()
+        val n100k = floor(northing / 100000.0).toInt()
+        if (n100k < 0 || n100k >= GRID.size || e100k < 0 || e100k >= GRID[0].size) return null
+        return GRID[n100k][e100k]
+    }
+
+    /**
+     * WGS84 lat/lon -> a BNG grid reference, e.g. `TG 51409 13177`. [digits] is
+     * the digit count per axis (1..5; 5 = 1 m). Returns null outside Great
+     * Britain's grid.
+     */
+    fun wgs84ToGridRef(
+        latDeg: Double,
+        lonDeg: Double,
+        digits: Int = 5,
+        withSpaces: Boolean = true,
+    ): String? {
+        if (latDeg < 49.0 || latDeg > 61.0 || lonDeg < -9.0 || lonDeg > 2.0) return null
+        val osgb = wgs84ToOsgb36(latDeg, lonDeg)
+        val en = osgb36ToEastingNorthing(osgb[0], osgb[1])
+        val e = en[0]
+        val n = en[1]
+        if (e < 0 || e > 700000 || n < 0 || n > 1300000) return null
+        val square = gridSquare(e, n) ?: return null
+        val d = digits.coerceIn(1, 5)
+        val divisor = 10.0.pow(5 - d)
+        val eStr = ((e % 100000.0) / divisor).toInt().toString().padStart(d, '0')
+        val nStr = ((n % 100000.0) / divisor).toInt().toString().padStart(d, '0')
+        return if (withSpaces) "$square $eStr $nStr" else "$square$eStr$nStr"
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoordFormatter.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/CoordFormatter.kt
@@ -42,6 +42,12 @@ object CoordFormatter {
             if (Twd97Converter.isWithinBounds(lat, lon))
                 "TWD97 ${Twd97Converter.formatTwd97(lat, lon, Twd97Converter.DigitMode.FULL7)}"
             else latLonDecimal(lat, lon)
+
+        // British National Grid (OSGB36). Returns null outside Great Britain,
+        // so fall back to plain decimal lat/lon there (mirrors TWD97).
+        CoordFormat.BNG ->
+            Bng.wgs84ToGridRef(lat, lon, digits = 5)?.let { "BNG $it" }
+                ?: latLonDecimal(lat, lon)
     }
 
     fun altitude(meters: Double, unit: DistanceUnit): String = when (unit) {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.map
 private val Context.userPrefsDataStore by preferencesDataStore(name = "user_prefs")
 
 enum class DistanceUnit { METRIC, IMPERIAL }
-enum class CoordFormat { LATLON_DECIMAL, LATLON_DMS, MGRS, UTM, TWD97 }
+enum class CoordFormat { LATLON_DECIMAL, LATLON_DMS, MGRS, UTM, TWD97, BNG }
 enum class MapProvider { OSM_RASTER, SATELLITE_HINT, TOPO_HINT, WMTS_CUSTOM }
 
 /** Mesh framework the operator's radio speaks. Drives which manager the

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/i18n/LocStrings.kt
@@ -57,6 +57,7 @@ internal object LocStrings {
         "settings.coord.mgrs" to "MGRS",
         "settings.coord.utm" to "UTM",
         "settings.coord.twd97" to "TWD97",
+        "settings.coord.bng" to "BNG",
         // Go to Coordinate
         "coordentry.title" to "Go to Coordinate",
         "coordentry.format" to "Format",

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -217,6 +217,7 @@ fun SettingsScreen(
                     CoordFormat.MGRS to Loc.t("settings.coord.mgrs"),
                     CoordFormat.UTM to Loc.t("settings.coord.utm"),
                     CoordFormat.TWD97 to Loc.t("settings.coord.twd97"),
+                    CoordFormat.BNG to Loc.t("settings.coord.bng"),
                 ),
                 selected = prefs.coordFormat,
                 onSelect = { v -> mutate { it.copy(coordFormat = v) } },

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/BngTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/BngTest.kt
@@ -1,0 +1,64 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+/**
+ * #157 — British National Grid (OSGB36). Ported from iOS BNGConverter. The
+ * Transverse Mercator projection is checked against the worked example in the
+ * Ordnance Survey "Guide to coordinate systems in Great Britain".
+ */
+class BngTest {
+
+    @Test fun tm_projection_matches_OS_worked_example() {
+        // OSGB36 lat 52.6575703 N, lon 1.7179215 E -> E 651409.903, N 313177.270
+        val en = Bng.osgb36ToEastingNorthing(52.6575703, 1.7179215)
+        assertEquals(651409.903, en[0], 0.5)
+        assertEquals(313177.270, en[1], 0.5)
+    }
+
+    @Test fun grid_square_lookup() {
+        assertEquals("TG", Bng.gridSquare(651409.0, 313177.0)) // OS example square
+        assertEquals("SV", Bng.gridSquare(0.0, 0.0))           // false-origin square
+        assertEquals("TQ", Bng.gridSquare(530000.0, 180000.0)) // London
+        assertEquals("NT", Bng.gridSquare(325000.0, 674000.0)) // Edinburgh
+        assertNull("off the east edge of the grid", Bng.gridSquare(800000.0, 0.0))
+    }
+
+    @Test fun wgs84_to_gridref_london_is_TQ() {
+        val ref = Bng.wgs84ToGridRef(51.5074, -0.1278, digits = 2) // Trafalgar Square area
+        assertNotNull(ref)
+        assertTrue("expected a TQ ref, got $ref", ref!!.startsWith("TQ"))
+    }
+
+    @Test fun wgs84_to_gridref_full_precision_format() {
+        val ref = Bng.wgs84ToGridRef(52.6575703, 1.7179215, digits = 5)
+        assertNotNull(ref)
+        // "<2-letter sq> <5 digits> <5 digits>"
+        assertTrue("malformed ref: $ref", Regex("^[A-Z]{2} \\d{5} \\d{5}$").matches(ref!!))
+        assertTrue("should land in TG, got $ref", ref.startsWith("TG"))
+    }
+
+    @Test fun out_of_uk_bounds_returns_null() {
+        assertNull(Bng.wgs84ToGridRef(40.4168, -3.7038)) // Madrid
+        assertNull(Bng.wgs84ToGridRef(48.8566, 2.3522))  // Paris (lon > 2)
+    }
+
+    @Test fun datum_shift_moves_the_point_slightly() {
+        val osgb = Bng.wgs84ToOsgb36(52.6575703, 1.7179215)
+        assertNotEquals(52.6575703, osgb[0], 1e-6)        // it actually shifts
+        assertTrue("shift should be < ~1 km", abs(osgb[0] - 52.6575703) < 0.01)
+    }
+
+    @Test fun coordformatter_bng_branch_formats_in_gb_and_falls_back_outside() {
+        assertTrue(CoordFormatter.position(52.6575703, 1.7179215, CoordFormat.BNG).startsWith("BNG TG"))
+        // Outside GB falls back to plain lat/lon, not a BNG ref.
+        assertFalse(CoordFormatter.position(40.4168, -3.7038, CoordFormat.BNG).startsWith("BNG"))
+    }
+}


### PR DESCRIPTION
## What

Ports the iOS `BNGConverter` to Android (#157, iOS→Android parity) and wires it through the readout path:

- `data/Bng.kt` — WGS84 → OSGB36 (Helmert 7-parameter datum shift) → easting/northing (Transverse Mercator, Airy 1830) → grid reference. ~5 m accurate (Helmert; OSTN15 would be survey-grade).
- `CoordFormat.BNG` enum value + `CoordFormatter.position()` branch (falls back to lat/lon outside Great Britain, mirroring TWD97).
- Settings coordinate-format picker entry + `settings.coord.bng` i18n label.

## Tests (TDD, 7/7 green)

`BngTest`:
- **TM projection matches the Ordnance Survey worked example** (OSGB36 52.6575703 N, 1.7179215 E → E 651409.903, N 313177.270) to within 0.5 m
- grid-square lookup: TG (OS example), SV (false origin), TQ (London), NT (Edinburgh), null off-grid
- WGS84 → grid ref: London is TQ; full-precision format matches `XX ##### #####`
- out-of-UK (Madrid, Paris) returns null
- datum shift actually moves the point
- `CoordFormatter` BNG branch formats in GB, falls back outside

`./gradlew :app:testDebugUnitTest` green; `:app:compileDebugKotlin` clean.

## Remaining for #157 (follow-on)

- [ ] Go-to-Coordinate **reverse parse**: accept a typed BNG grid ref → lat/lon (the inverse TM + OSGB36→WGS84 path is in the iOS converter; this PR ships the forward/display half).

Part of #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)