### PR TITLE
feat(discovery): Bonjour/mDNS LAN TAK server discovery (#158)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/discovery/TakMdns.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/discovery/TakMdns.kt
@@ -1,0 +1,60 @@
+package soy.engindearing.omnitak.mobile.data.discovery
+
+import soy.engindearing.omnitak.mobile.data.ConnectionProtocol
+import soy.engindearing.omnitak.mobile.data.TAKServer
+
+/**
+ * LAN TAK server discovery over Bonjour/mDNS (#158, Android parity — iOS
+ * declares `_tak._tcp` in Info.plist). The NsdManager browse/resolve lives in
+ * [TakNsdDiscovery]; this is the pure part: a resolved service and the mapping
+ * to a [TAKServer] ready to prefill Add-Server, so it unit-tests directly.
+ */
+
+/** A resolved `_tak._tcp` service from the mDNS responder. */
+data class DiscoveredTakService(
+    val serviceName: String,
+    val host: String,
+    val port: Int,
+    /** TXT-record attributes, lower-cased keys. */
+    val attributes: Map<String, String> = emptyMap(),
+)
+
+object TakMdns {
+
+    /** The TAK service type advertised on the LAN (matches iOS' Info.plist). */
+    const val SERVICE_TYPE = "_tak._tcp"
+
+    /** TAK streaming/secure ports that imply TLS when no TXT record says otherwise. */
+    private val TLS_PORTS = setOf(8089, 8443, 8446, 443)
+
+    /**
+     * Decide whether a discovered service is TLS. A `tls` TXT record wins, then
+     * a `protocol` TXT record (ssl/tls vs tcp), then the port convention.
+     */
+    fun isTls(service: DiscoveredTakService): Boolean {
+        service.attributes["tls"]?.let { v ->
+            return v.equals("true", ignoreCase = true) || v == "1"
+        }
+        service.attributes["protocol"]?.let { p ->
+            if (p.contains("ssl", ignoreCase = true) || p.contains("tls", ignoreCase = true)) return true
+            if (p.contains("tcp", ignoreCase = true)) return false
+        }
+        return service.port in TLS_PORTS
+    }
+
+    /**
+     * Map a resolved service to a [TAKServer] (new id, sensible defaults) the
+     * Add-Server flow can prefill. Name falls back to the host when the mDNS
+     * instance name is blank.
+     */
+    fun toTakServer(service: DiscoveredTakService): TAKServer {
+        val tls = isTls(service)
+        return TAKServer(
+            name = service.serviceName.ifBlank { service.host },
+            host = service.host,
+            port = service.port,
+            protocol = if (tls) ConnectionProtocol.TLS.wire else ConnectionProtocol.TCP.wire,
+            useTLS = tls,
+        )
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/discovery/TakNsdDiscovery.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/discovery/TakNsdDiscovery.kt
@@ -1,0 +1,63 @@
+package soy.engindearing.omnitak.mobile.data.discovery
+
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import soy.engindearing.omnitak.mobile.data.TAKServer
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * NsdManager-backed Bonjour/mDNS discovery of `_tak._tcp` servers on the LAN
+ * (#158). [discover] emits the current set of resolved servers as the browse
+ * runs, and stops discovery when the collector cancels.
+ *
+ * Device-only (NsdManager is an Android system service); the resolved-service →
+ * [TAKServer] mapping it relies on is unit-tested in [TakMdns]. The Add-Server
+ * UI collects this and prefills a tapped entry.
+ */
+class TakNsdDiscovery(private val nsdManager: NsdManager) {
+
+    // NsdManager expects the registration-style type with a trailing dot.
+    private val type = "${TakMdns.SERVICE_TYPE}."
+
+    fun discover(): Flow<List<TAKServer>> = callbackFlow {
+        // Keyed by mDNS instance name so a re-resolve replaces, not duplicates.
+        val found = ConcurrentHashMap<String, TAKServer>()
+        fun publish() { trySend(found.values.sortedBy { it.name }) }
+
+        val discoveryListener = object : NsdManager.DiscoveryListener {
+            override fun onDiscoveryStarted(serviceType: String) {}
+
+            override fun onServiceFound(info: NsdServiceInfo) {
+                // A fresh ResolveListener per resolve — NsdManager rejects a reused one.
+                nsdManager.resolveService(info, object : NsdManager.ResolveListener {
+                    override fun onServiceResolved(resolved: NsdServiceInfo) {
+                        val host = resolved.host?.hostAddress ?: return
+                        val attrs = resolved.attributes.orEmpty()
+                            .mapKeys { it.key.lowercase() }
+                            .mapValues { (_, v) -> v?.toString(Charsets.UTF_8).orEmpty() }
+                        found[resolved.serviceName] = TakMdns.toTakServer(
+                            DiscoveredTakService(resolved.serviceName, host, resolved.port, attrs),
+                        )
+                        publish()
+                    }
+
+                    override fun onResolveFailed(info: NsdServiceInfo, errorCode: Int) {}
+                })
+            }
+
+            override fun onServiceLost(info: NsdServiceInfo) {
+                if (found.remove(info.serviceName) != null) publish()
+            }
+
+            override fun onDiscoveryStopped(serviceType: String) {}
+            override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) { close() }
+            override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {}
+        }
+
+        nsdManager.discoverServices(type, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+        awaitClose { runCatching { nsdManager.stopServiceDiscovery(discoveryListener) } }
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/discovery/TakMdnsTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/discovery/TakMdnsTest.kt
@@ -1,0 +1,62 @@
+package soy.engindearing.omnitak.mobile.data.discovery
+
+import soy.engindearing.omnitak.mobile.data.ConnectionProtocol
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #158 — LAN TAK server discovery over Bonjour/mDNS. NsdManager does the
+ * browse/resolve on-device; this pins the pure part — turning a resolved
+ * `_tak._tcp` service into a TAKServer ready to prefill Add-Server, including
+ * the TLS decision from TXT records or the port convention.
+ */
+class TakMdnsTest {
+
+    private fun svc(
+        name: String = "TAK Server",
+        host: String = "192.168.1.50",
+        port: Int = 8089,
+        attrs: Map<String, String> = emptyMap(),
+    ) = DiscoveredTakService(name, host, port, attrs)
+
+    @Test fun service_type_is_tak_tcp() {
+        assertEquals("_tak._tcp", TakMdns.SERVICE_TYPE)
+    }
+
+    @Test fun maps_host_port_and_name() {
+        val s = TakMdns.toTakServer(svc(name = "OPS", host = "10.0.0.5", port = 8088))
+        assertEquals("OPS", s.name)
+        assertEquals("10.0.0.5", s.host)
+        assertEquals(8088, s.port)
+    }
+
+    @Test fun name_falls_back_to_host_when_blank() {
+        assertEquals("10.0.0.5", TakMdns.toTakServer(svc(name = "  ", host = "10.0.0.5")).name)
+    }
+
+    @Test fun tls_streaming_port_8089_is_tls() {
+        val s = TakMdns.toTakServer(svc(port = 8089))
+        assertTrue(s.useTLS)
+        assertEquals(ConnectionProtocol.TLS, s.protocolEnum)
+    }
+
+    @Test fun plain_port_8088_is_tcp() {
+        val s = TakMdns.toTakServer(svc(port = 8088))
+        assertFalse(s.useTLS)
+        assertEquals(ConnectionProtocol.TCP, s.protocolEnum)
+    }
+
+    @Test fun txt_tls_true_overrides_a_plain_port() {
+        assertTrue(TakMdns.toTakServer(svc(port = 8088, attrs = mapOf("tls" to "true"))).useTLS)
+    }
+
+    @Test fun txt_tls_false_overrides_a_tls_port() {
+        assertFalse(TakMdns.toTakServer(svc(port = 8089, attrs = mapOf("tls" to "false"))).useTLS)
+    }
+
+    @Test fun txt_protocol_ssl_is_tls() {
+        assertTrue(TakMdns.toTakServer(svc(port = 8088, attrs = mapOf("protocol" to "ssl"))).useTLS)
+    }
+}


### PR DESCRIPTION
## What

Adds LAN TAK server discovery over Bonjour/mDNS (#158, iOS→Android parity — iOS declares `_tak._tcp` in Info.plist; Android had nothing).

- `data/discovery/TakMdns.kt` — pure core: `SERVICE_TYPE` (`_tak._tcp`), the **TLS decision** (a `tls` TXT record wins → a `protocol` TXT record → the 8089/8443/8446/443 port convention), and `toTakServer()` mapping a resolved service → a `TAKServer` (new id, name falls back to host) ready to prefill Add-Server.
- `data/discovery/TakNsdDiscovery.kt` — `NsdManager` browse/resolve wrapper that emits the discovered servers as a `Flow<List<TAKServer>>` (fresh `ResolveListener` per resolve to dodge NsdManager's reuse error; stops discovery on cancel).

## Tests (TDD, 8/8 green)

`TakMdnsTest` — service type, host/port/name mapping, name→host fallback, TLS port 8089, plain port 8088, TXT `tls=true` overriding a plain port, TXT `tls=false` overriding a TLS port, TXT `protocol=ssl`. `./gradlew :app:testDebugUnitTest` green; `:app:compileDebugKotlin` clean (NsdManager wrapper compiles).

## Remaining for #158 (follow-on)

- [ ] Add-Server UI: collect `TakNsdDiscovery.discover()`, list the found servers, tap one to prefill host/port/TLS.

Part of #158. (`NsdManager` discovery is device-only, so the wrapper is compile-verified, not unit-tested; the mapping it relies on is fully covered.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)