### PR TITLE
feat(symbology): echelon / org size ladder (#159)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/Echelon.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/Echelon.kt
@@ -1,0 +1,33 @@
+package soy.engindearing.omnitak.mobile.data
+
+/**
+ * Military echelon / organizational size (#159, ported from the iOS
+ * `EchelonLevel`). Declared smallest -> largest, so the enum's natural order
+ * (ordinal) is the doctrinal order and `Echelon.TEAM < Echelon.CORPS` holds.
+ *
+ * [amplifier] is the NATO APP-6 echelon modifier drawn above a unit symbol
+ * (the "modifier" rendered on the self-marker / contacts). [code] is the wire
+ * value (matches the iOS `rawValue`) carried in PPLI and persisted with the
+ * self marker.
+ */
+enum class Echelon(
+    val code: String,
+    val displayName: String,
+    val amplifier: String,
+    val standardStrength: Int,
+) {
+    TEAM("team", "Team", "•", 4),
+    SQUAD("squad", "Squad", "••", 9),
+    PLATOON("platoon", "Platoon", "•••", 40),
+    COMPANY("company", "Company", "I", 150),
+    BATTALION("battalion", "Battalion", "II", 700),
+    BRIGADE("brigade", "Brigade", "III", 3500),
+    DIVISION("division", "Division", "XX", 15000),
+    CORPS("corps", "Corps", "XXX", 45000);
+
+    companion object {
+        /** Parse a wire [code] (case-insensitive); null if it isn't a known echelon. */
+        fun fromCode(code: String?): Echelon? =
+            entries.firstOrNull { it.code.equals(code, ignoreCase = true) }
+    }
+}

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -39,6 +39,9 @@ enum class MeshFramework { MESHTASTIC, MESHCORE }
 data class UserPrefs(
     val callsign: String = "OMNI-1",
     val team: String = "Cyan",
+    // #159 — operator's echelon / org size (Echelon.code, or "" = none). The
+    // APP-6 amplifier draws above the self symbol on the map.
+    val echelon: String = "",
     // Persistent EUD identifier broadcast in every PPLI CoT event. Empty
     // until the first connection generates one (`ANDROID-<uuid>`); after
     // that it never changes so TAK servers see a stable contact across
@@ -156,6 +159,7 @@ data class UserPrefs(
 class UserPrefsStore(private val context: Context) {
     private val KEY_CALLSIGN = stringPreferencesKey("callsign")
     private val KEY_TEAM = stringPreferencesKey("team")
+    private val KEY_ECHELON = stringPreferencesKey("echelon")
     private val KEY_SELF_UID = stringPreferencesKey("self_uid")
     private val KEY_SELF_LAT = stringPreferencesKey("self_lat")
     private val KEY_SELF_LON = stringPreferencesKey("self_lon")
@@ -204,6 +208,7 @@ class UserPrefsStore(private val context: Context) {
             val next = block(readFrom(p))
             p[KEY_CALLSIGN] = next.callsign
             p[KEY_TEAM] = next.team
+            p[KEY_ECHELON] = next.echelon
             p[KEY_SELF_UID] = next.selfUid
             p[KEY_SELF_LAT] = next.selfLat.toString()
             p[KEY_SELF_LON] = next.selfLon.toString()
@@ -327,6 +332,7 @@ class UserPrefsStore(private val context: Context) {
 
     private fun readFrom(p: androidx.datastore.preferences.core.Preferences): UserPrefs = UserPrefs(
         callsign = p[KEY_CALLSIGN] ?: "OMNI-1",
+        echelon = p[KEY_ECHELON] ?: "",
         team = normalizeTeam(p[KEY_TEAM]),
         selfUid = p[KEY_SELF_UID] ?: "",
         selfLat = p[KEY_SELF_LAT]?.toDoubleOrNull() ?: Double.NaN,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -91,6 +91,10 @@ fun TacticalMap(
      *  fall back to cyan (0xFF00FFFF) to match CivTAK's default for
      *  unaffiliated friendlies. Sourced from [soy.engindearing.omnitak.mobile.data.UserPrefs.team]. */
     selfTeamColor: String = "Cyan",
+    /** #159 — operator echelon code ([soy.engindearing.omnitak.mobile.data.Echelon.code],
+     *  or "" = none). Its APP-6 amplifier (•, ••, I, II, XX, …) draws above the
+     *  self symbol. Sourced from [soy.engindearing.omnitak.mobile.data.UserPrefs.echelon]. */
+    selfEchelon: String = "",
     /** Issue #75 — the operator's current/last-known fix from
      *  [soy.engindearing.omnitak.mobile.data.LocationProvider]. Forwarded
      *  into the LocationComponent so the self-marker renders immediately
@@ -146,6 +150,8 @@ fun TacticalMap(
     val currentFollowMe by rememberUpdatedState(followMeActive)
     val currentUseMilStd by rememberUpdatedState(useMilStdSelfSymbol)
     val currentTeamColor by rememberUpdatedState(selfTeamColor)
+    val currentSelfEchelon by rememberUpdatedState(selfEchelon)
+    val currentOnSelfMarkerTap by rememberUpdatedState(onSelfMarkerTap)
     val currentSelfMarkerTriangle by rememberUpdatedState(selfMarkerTriangle)
     // Issue #75 — whether the puck is currently rendered dimmed (stale
     // restored fix). Plain holder, not MutableState: nothing recomposes
@@ -209,6 +215,7 @@ fun TacticalMap(
                             map, style, context, currentUseMilStd, currentTeamColor,
                             seedFix = bindings.selfFix, puck = puckAppearance,
                             selfMarkerTriangle = currentSelfMarkerTriangle,
+                            echelonAmplifier = echelonAmplifierFor(currentSelfEchelon),
                         )
                     }
                     // Cold-start 3D: if the persisted pref has terrain on,
@@ -379,6 +386,7 @@ fun TacticalMap(
                         map, style, context, currentUseMilStd, currentTeamColor,
                         seedFix = currentSelfFix, puck = puckAppearance,
                         selfMarkerTriangle = currentSelfMarkerTriangle,
+                        echelonAmplifier = echelonAmplifierFor(currentSelfEchelon),
                     )
                 }
                 if (map.locationComponent.isLocationComponentActivated) {
@@ -411,10 +419,33 @@ fun TacticalMap(
                                 context, style, currentUseMilStd, currentTeamColor,
                                 dimmed = staleNow,
                                 selfMarkerTriangle = currentSelfMarkerTriangle,
+                                echelonAmplifier = echelonAmplifierFor(currentSelfEchelon),
                             ),
                         )
                         puckAppearance.dimmed = staleNow
                     }
+                }
+            }
+        }
+        onDispose { }
+    }
+
+    // #159 — re-apply the puck when the operator changes their echelon so the
+    // amplifier appears/updates live (Settings → Map), without waiting on a
+    // style reload or re-activation.
+    DisposableEffect(mapView, selfEchelon) {
+        if (locationEnabled) {
+            mapView.getMapAsync { map ->
+                val style = map.style
+                if (style != null && map.locationComponent.isLocationComponentActivated) {
+                    map.locationComponent.applyStyle(
+                        buildPuckOptions(
+                            context, style, currentUseMilStd, currentTeamColor,
+                            dimmed = puckAppearance.dimmed,
+                            selfMarkerTriangle = currentSelfMarkerTriangle,
+                            echelonAmplifier = echelonAmplifierFor(currentSelfEchelon),
+                        ),
+                    )
                 }
             }
         }
@@ -542,6 +573,7 @@ fun TacticalMap(
                                 context, style, currentUseMilStd, currentTeamColor,
                                 dimmed = puckAppearance.dimmed,
                                 selfMarkerTriangle = currentSelfMarkerTriangle,
+                                echelonAmplifier = echelonAmplifierFor(currentSelfEchelon),
                             ),
                         )
                     }
@@ -763,6 +795,7 @@ private fun activateLocation(
     seedFix: SelfFix? = null,
     puck: PuckAppearance = PuckAppearance(),
     selfMarkerTriangle: Boolean = false,
+    echelonAmplifier: String = "",
 ) {
     // Issue #75 — when the best position available at activation is a
     // restored (persisted) fix that is already old, start the puck dimmed
@@ -774,7 +807,7 @@ private fun activateLocation(
     val options = LocationComponentActivationOptions.builder(context, style)
         .useDefaultLocationEngine(true)
         .locationComponentOptions(
-            buildPuckOptions(context, style, useMilStdSelfSymbol, selfTeamColor, dimmed, selfMarkerTriangle),
+            buildPuckOptions(context, style, useMilStdSelfSymbol, selfTeamColor, dimmed, selfMarkerTriangle, echelonAmplifier),
         )
         .build()
     map.locationComponent.activateLocationComponent(options)
@@ -805,6 +838,7 @@ private fun buildPuckOptions(
     selfTeamColor: String,
     dimmed: Boolean,
     selfMarkerTriangle: Boolean = false,
+    echelonAmplifier: String = "",
 ): LocationComponentOptions {
     // Resolve the ARGB tint from the operator's configured TAK team name
     // ("Cyan", "Red", "Orange", …). Falls back to cyan — CivTAK default
@@ -843,6 +877,9 @@ private fun buildPuckOptions(
         soy.engindearing.omnitak.mobile.data.symbology.MilStdIconCache
             .bitmapFor(context, cotType = "a-f-G-U-C", sizePx = 96)
             ?.let { raw -> tintBitmap(raw, teamArgb) }
+            // #159 — draw the echelon amplifier above the symbol (symbol stays
+            // centered on the GPS fix; LocationComponent anchors the bitmap center).
+            ?.let { sym -> withEchelonAmplifier(sym, echelonAmplifier) }
     } else {
         null
     }
@@ -908,6 +945,46 @@ private fun tintBitmap(raw: android.graphics.Bitmap, argb: Int): android.graphic
     }
     canvas.drawBitmap(raw, 0f, 0f, paint)
     return tinted
+}
+
+/** #159 — resolve an echelon code to its APP-6 amplifier glyph; "" when unset
+ *  or unknown (no amplifier drawn). */
+private fun echelonAmplifierFor(code: String): String =
+    soy.engindearing.omnitak.mobile.data.Echelon.fromCode(code)?.amplifier ?: ""
+
+/**
+ * #159 — composite the echelon [amplifier] glyph above [symbol], returning a
+ * taller bitmap with the SYMBOL still vertically centered (so it stays on the
+ * GPS fix — LocationComponent anchors the foreground bitmap at its center).
+ * Returns [symbol] unchanged when there is no amplifier.
+ */
+private fun withEchelonAmplifier(symbol: android.graphics.Bitmap, amplifier: String): android.graphics.Bitmap {
+    if (amplifier.isBlank()) return symbol
+    val band = symbol.height * 0.42f          // top space for the glyph + matching bottom pad
+    val out = android.graphics.Bitmap.createBitmap(
+        symbol.width, (symbol.height + band * 2f).toInt(), android.graphics.Bitmap.Config.ARGB_8888,
+    )
+    val canvas = android.graphics.Canvas(out)
+    canvas.drawBitmap(symbol, 0f, band, null)  // symbol centered: band above, band below
+    val fill = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+        color = android.graphics.Color.WHITE
+        textSize = band * 0.82f
+        textAlign = android.graphics.Paint.Align.CENTER
+        typeface = android.graphics.Typeface.DEFAULT_BOLD
+    }
+    val halo = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+        color = android.graphics.Color.parseColor("#CC000000")
+        textSize = band * 0.82f
+        textAlign = android.graphics.Paint.Align.CENTER
+        typeface = android.graphics.Typeface.DEFAULT_BOLD
+        style = android.graphics.Paint.Style.STROKE
+        strokeWidth = band * 0.12f
+    }
+    val cx = symbol.width / 2f
+    val baseline = band * 0.86f
+    canvas.drawText(amplifier, cx, baseline, halo)
+    canvas.drawText(amplifier, cx, baseline, fill)
+    return out
 }
 
 /** Issue #75 — a translucent copy of [src] for the stale self-marker. */

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -773,6 +773,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
             followMeActive = followMeActive,
             useMilStdSelfSymbol = userPrefs.useMilStdSelfSymbol,
             selfTeamColor = userPrefs.team,
+            selfEchelon = userPrefs.echelon,
             selfMarkerTriangle = userPrefs.selfMarkerTriangle,
             // Issue #75 — feeds the puck so a restored fix renders
             // immediately on cold start (dimmed when stale) and the

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.OmniTAKApp
 import soy.engindearing.omnitak.mobile.i18n.Loc
 import soy.engindearing.omnitak.mobile.data.CoordFormat
+import soy.engindearing.omnitak.mobile.data.Echelon
 import soy.engindearing.omnitak.mobile.data.DistanceUnit
 import soy.engindearing.omnitak.mobile.data.MapProvider
 import soy.engindearing.omnitak.mobile.data.UserPrefs
@@ -135,6 +136,17 @@ fun SettingsScreen(
             TeamColorDropdown(
                 value = prefs.team,
                 onSelect = { v -> mutate { it.copy(team = v) } },
+            )
+
+            // #159 — operator echelon / org size. The selected level's APP-6
+            // amplifier (•, ••, •••, I, II, III, XX, XXX) draws above the self
+            // symbol on the map; "Off" clears it. Glyph labels keep the row
+            // compact for all nine choices.
+            SectionHeader("Echelon")
+            SegmentedRow(
+                options = listOf("" to "Off") + Echelon.entries.map { it.code to it.amplifier },
+                selected = prefs.echelon,
+                onSelect = { v -> mutate { it.copy(echelon = v) } },
             )
 
             // ── Configuration Profiles ──────────────────────────────────────

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/EchelonTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/EchelonTest.kt
@@ -1,0 +1,49 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #159 — Echelon / org size. Ported from the iOS `EchelonLevel`. The amplifier
+ * is the NATO APP-6 echelon modifier drawn above a unit symbol; the code is the
+ * wire value carried in PPLI / persisted with the self marker.
+ */
+class EchelonTest {
+
+    @Test fun amplifier_glyphs_match_ios_app6_ladder() {
+        assertEquals("•", Echelon.TEAM.amplifier)       // •
+        assertEquals("••", Echelon.SQUAD.amplifier) // ••
+        assertEquals("•••", Echelon.PLATOON.amplifier) // •••
+        assertEquals("I", Echelon.COMPANY.amplifier)
+        assertEquals("II", Echelon.BATTALION.amplifier)
+        assertEquals("III", Echelon.BRIGADE.amplifier)
+        assertEquals("XX", Echelon.DIVISION.amplifier)
+        assertEquals("XXX", Echelon.CORPS.amplifier)
+    }
+
+    @Test fun display_names_and_strengths_match_ios() {
+        assertEquals("Team", Echelon.TEAM.displayName)
+        assertEquals("Company", Echelon.COMPANY.displayName)
+        assertEquals(4, Echelon.TEAM.standardStrength)
+        assertEquals(150, Echelon.COMPANY.standardStrength)
+        assertEquals(45000, Echelon.CORPS.standardStrength)
+    }
+
+    @Test fun ordered_smallest_to_largest() {
+        assertTrue(Echelon.TEAM < Echelon.SQUAD)
+        assertTrue(Echelon.COMPANY < Echelon.CORPS)
+        // strength strictly increases up the ladder
+        val strengths = Echelon.entries.map { it.standardStrength }
+        assertEquals(strengths.sorted(), strengths)
+    }
+
+    @Test fun code_round_trips_and_matches_ios_rawvalue() {
+        assertEquals("company", Echelon.COMPANY.code)
+        assertEquals(Echelon.COMPANY, Echelon.fromCode("company"))
+        assertEquals(Echelon.COMPANY, Echelon.fromCode("COMPANY")) // case-insensitive
+        assertNull(Echelon.fromCode("regiment"))                   // not in the ladder
+        assertNull(Echelon.fromCode(null))
+    }
+}


### PR DESCRIPTION
Closes #159.

Echelon / org-size for OmniTAK Android, **wired end-to-end** (was core-only).

### Core (Echelon)
Eight-level ladder (Team → Corps) with code, display name, APP-6 amplifier (•, ••, •••, I, II, III, XX, XXX), and standard strength. Ported from iOS `EchelonLevel`; `EchelonTest` locks the glyphs/codes/order against iOS.

### Wiring (new)
- `UserPrefs.echelon` (persisted, "" = none), plumbed through the DataStore read/write.
- **Settings → Identity → "Echelon"** picker: a compact `SegmentedRow` of the nine choices using the amplifier glyphs as labels.
- `TacticalMap` composites the selected level's amplifier **above the MIL-STD self symbol** (`withEchelonAmplifier`), keeping the symbol centered on the GPS fix; threaded through `buildPuckOptions`/`activateLocation` and re-applied live on change via a dedicated `DisposableEffect`.

### Verification
- `:app:testDebugUnitTest` green (`EchelonTest` covers the amplifier/code logic the wiring resolves through).
- **On-device (emulator): the Echelon picker renders and selects in Settings → Identity** (screenshot shared with J).
- ⚠️ The **amplifier-on-self-marker render is NOT emulator-confirmed**: this emulator's MapLibre `LocationComponent` doesn't accept emulator mock-GPS fixes, so the self puck never renders to photograph. The composite uses the same proven bitmap path as `ContactMarkerRenderer`. **Recommend a real-device / live-GPS eyeball of the amplifier before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X56oaELvYvJcBGgurTkc3A