### PR TITLE
fix(map): open the edit sheet when tapping a 2D contact pin (#150)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactMarkerRenderer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactMarkerRenderer.kt
@@ -44,6 +44,16 @@ object ContactMarkerRenderer {
     // Pin+label bitmaps are expensive to draw; reuse by (color, callsign).
     private val iconCache = HashMap<String, Icon>()
 
+    // #150 — id→contact registry for the tapped-pin → edit-sheet route. A native
+    // annotation Marker's default tap handler selects the marker, shows `.title()`
+    // as an InfoWindow, and swallows the touch the map-click hit-test relies on —
+    // so editing never opened on a direct pin tap (only the label popped up).
+    // TacticalMap's OnMarkerClickListener resolves the tapped Marker through this
+    // map instead. Rebuilt in lockstep with [markers] on every [render]; KML
+    // placemarks (also addMarker) are absent here, so they pass through to the
+    // default InfoWindow untouched.
+    internal val markerContacts = HashMap<Long, CoTEvent>()
+
     private var boundMap: MapLibreMap? = null
     private var ctx: Context? = null
     private var contacts: List<CoTEvent> = emptyList()
@@ -71,6 +81,8 @@ object ContactMarkerRenderer {
         val map = boundMap ?: return
         val context = ctx ?: return
         markers.forEach { runCatching { map.removeMarker(it) } }
+        // Rebuilt below in lockstep with the markers we re-add (#150).
+        markerContacts.clear()
         val proj = map.projection
         val bounds = runCatching { proj.visibleRegion.latLngBounds }.getOrNull()
         val factory = IconFactory.getInstance(context)
@@ -87,7 +99,7 @@ object ContactMarkerRenderer {
             }
             runCatching {
                 map.addMarker(MarkerOptions().position(ll).title(label).icon(icon))
-            }.getOrNull()?.let { added.add(it); budget-- }
+            }.getOrNull()?.let { added.add(it); markerContacts[it.id] = c; budget-- }
         }
         markers = added
     }
@@ -96,10 +108,19 @@ object ContactMarkerRenderer {
     fun clear(map: MapLibreMap) {
         markers.forEach { runCatching { map.removeMarker(it) } }
         markers = emptyList()
+        markerContacts.clear()
         idleListener?.let { runCatching { map.removeOnCameraIdleListener(it) } }
         idleListener = null
         boundMap = null
     }
+
+    /** #150 — resolve a tapped annotation [Marker] back to the contact it
+     *  renders, or null when it isn't a contact pin (e.g. a KML placemark). */
+    fun contactForMarker(marker: Marker): CoTEvent? = markerContacts[marker.id]
+
+    /** Pure id-keyed resolution, exposed for unit tests — MapLibre's [Marker]
+     *  isn't constructible on the JVM. */
+    internal fun contactForMarkerId(id: Long): CoTEvent? = markerContacts[id]
 
     /** Stable cache key: one bitmap per (color, callsign) pair. */
     internal fun cacheKey(colorArgb: Int, label: String): String =
@@ -166,3 +187,23 @@ object ContactMarkerRenderer {
         return bmp
     }
 }
+
+/** #150 — what a tap on an annotation [Marker] should do, decided without any
+ *  MapLibre types so it stays unit-testable. */
+internal enum class MarkerTapAction { OPEN_CONTACT_EDIT, CONSUMED_BY_MODE, PASS_THROUGH }
+
+/**
+ * Decide the outcome of a marker tap:
+ *  - non-contact marker ([contact] is null) → [PASS_THROUGH]: leave MapLibre's
+ *    default behaviour (a KML placemark keeps its InfoWindow label).
+ *  - an active mode handler already consumed the tap ([modeHandled] is true) →
+ *    [CONSUMED_BY_MODE]: measurement/drawing/mission ate it — don't also edit.
+ *  - otherwise → [OPEN_CONTACT_EDIT]: route to the contact's edit sheet, the
+ *    same outcome a tap gets on the 3D globe.
+ */
+internal fun decideMarkerTap(contact: CoTEvent?, modeHandled: Boolean): MarkerTapAction =
+    when {
+        contact == null -> MarkerTapAction.PASS_THROUGH
+        modeHandled -> MarkerTapAction.CONSUMED_BY_MODE
+        else -> MarkerTapAction.OPEN_CONTACT_EDIT
+    }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/TacticalMap.kt
@@ -278,6 +278,32 @@ fun TacticalMap(
                         false
                     }
                 }
+                // #150 — contacts render as native annotation Markers
+                // (ContactMarkerRenderer). A Marker's built-in tap handler selects
+                // it, shows `.title()` as an InfoWindow, and CONSUMES the touch —
+                // so the map-click hit-test above never ran on a DIRECT pin tap:
+                // only the label popped up and the edit sheet never opened (a
+                // near-miss within TAP_HIT_RADIUS still edited, which is why this
+                // read as "editing only works on the 3D globe"). Resolve the tapped
+                // pin back to its contact and route it through the SAME onContactTap
+                // the globe uses, returning true to suppress the InfoWindow. KML
+                // placemarks (also addMarker) resolve to null → return false so
+                // MapLibre's default InfoWindow label still works for them.
+                map.setOnMarkerClickListener { marker ->
+                    val contact = ContactMarkerRenderer.contactForMarker(marker)
+                    // Mirror the map-click precedence: an active mode handler
+                    // (measurement/drawing/mission) eats the tap before editing.
+                    val modeHandled = contact != null &&
+                        (currentMapSingleTap?.invoke(marker.position) ?: false)
+                    when (decideMarkerTap(contact, modeHandled)) {
+                        MarkerTapAction.OPEN_CONTACT_EDIT -> {
+                            currentContactTap?.invoke(contact!!)
+                            true
+                        }
+                        MarkerTapAction.CONSUMED_BY_MODE -> true
+                        MarkerTapAction.PASS_THROUGH -> false
+                    }
+                }
             }
             // Issue #80 — re-anchor drawing (and all other overlay) layers on
             // EVERY style reload, regardless of the trigger.

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactMarkerRendererTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/ui/components/ContactMarkerRendererTest.kt
@@ -3,8 +3,11 @@ package soy.engindearing.omnitak.mobile.ui.components
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import soy.engindearing.omnitak.mobile.data.CoTEvent
 
 /**
  * Locks the pure pieces of the #77 native-contact-marker fix. Dropped markers
@@ -48,5 +51,52 @@ class ContactMarkerRendererTest {
             ContactMarkerRenderer.cacheKey(0xFF4ADE80.toInt(), "ALPHA-1"),
             ContactMarkerRenderer.cacheKey(0xFF4ADE80.toInt(), "ALPHA-1"),
         )
+    }
+
+    // --- #150: tapping a 2D contact pin must open the edit sheet, not the
+    // native MapLibre InfoWindow. The pin is an annotation Marker whose default
+    // tap handler shows `.title()` and eats the touch, so the map-click hit-test
+    // (which opens the sheet) never runs. The fix routes the marker click back
+    // to the contact via this id→CoTEvent registry, then decides what to do.
+
+    private fun contact(uid: String) = CoTEvent(uid = uid, type = "a-f-G-U-C", lat = 0.0, lon = 0.0)
+
+    @Test fun marker_id_resolves_to_the_contact_rendered_for_it() {
+        ContactMarkerRenderer.markerContacts.clear()
+        val alpha = contact("ALPHA-1")
+        ContactMarkerRenderer.markerContacts[7L] = alpha
+        assertSame(alpha, ContactMarkerRenderer.contactForMarkerId(7L))
+    }
+
+    @Test fun unknown_marker_id_resolves_to_null_so_kml_pins_keep_their_label() {
+        // KML placemarks are also addMarker annotations but carry no contact —
+        // the listener must pass those through (return null) so their InfoWindow
+        // label still works.
+        ContactMarkerRenderer.markerContacts.clear()
+        ContactMarkerRenderer.markerContacts[7L] = contact("ALPHA-1")
+        assertNull(ContactMarkerRenderer.contactForMarkerId(404L))
+    }
+
+    @Test fun decide_opens_edit_when_a_contact_is_tapped_in_normal_mode() {
+        assertEquals(
+            MarkerTapAction.OPEN_CONTACT_EDIT,
+            decideMarkerTap(contact = contact("ALPHA-1"), modeHandled = false),
+        )
+    }
+
+    @Test fun decide_defers_to_an_active_mode_handler_over_editing() {
+        // Measurement / drawing / mission modes that consumed the tap win —
+        // tapping a pin while measuring drops a vertex, it doesn't open editing.
+        assertEquals(
+            MarkerTapAction.CONSUMED_BY_MODE,
+            decideMarkerTap(contact = contact("ALPHA-1"), modeHandled = true),
+        )
+    }
+
+    @Test fun decide_passes_through_non_contact_markers() {
+        // A null contact (KML placemark, unknown annotation) is left to MapLibre's
+        // default behaviour regardless of mode.
+        assertEquals(MarkerTapAction.PASS_THROUGH, decideMarkerTap(contact = null, modeHandled = false))
+        assertEquals(MarkerTapAction.PASS_THROUGH, decideMarkerTap(contact = null, modeHandled = true))
     }
 }


### PR DESCRIPTION
Closes #150.

### Problem
On the 2D map, contacts appear (the #77 paint fix) but tapping one **only pops up a label** — you can't edit it. On the 3D globe, tapping a marker opens the editor. So editing felt "3D-only."

### Root cause
2D contacts render as **native MapLibre annotation `Marker`s** (`ContactMarkerRenderer` — the Adreno/Mali paint workaround from #77, since the GeoJSON circle/symbol layers don't rasterize on those drivers). A `Marker` has a built-in tap handler that **selects the marker, shows its `.title()` as an InfoWindow, and consumes the touch**. That swallowed the tap before `TacticalMap`'s map-click hit-test (the thing that calls `onContactTap` → opens the edit sheet) could run. A *near-miss* within the 72px hit radius still edited (it hit empty map, not the pin), which is why the behavior looked inconsistent — and why the globe, which routes taps straight to `onContactTap`, always worked.

### Fix
Register `map.setOnMarkerClickListener` in `TacticalMap` that:
1. Resolves the tapped `Marker` back to its `CoTEvent` via a new `id → contact` registry in `ContactMarkerRenderer` (rebuilt in lockstep with the markers on every render/cull).
2. Routes it through the **same `onContactTap`** the 3D globe uses, and returns `true` to **suppress the InfoWindow**.
3. Passes non-contact annotations through (returns `false`) — **KML placemarks** are also `addMarker` annotations, so their label InfoWindows keep working.
4. Lets an active **mode handler** (measurement / drawing / mission) eat the tap first, mirroring the existing map-click precedence.

The tap-decision policy and id resolver are pulled into pure, JVM-testable functions — `decideMarkerTap()` / `contactForMarkerId()`.

### Testing
- **Unit** (`ContactMarkerRendererTest`, 5 new cases): id→contact resolution, unknown-id → null (KML pass-through), and the three `decideMarkerTap` outcomes (open-edit / consumed-by-mode / pass-through).
- `./gradlew :app:testDebugUnitTest :app:assembleDebug` — green.
- **On-device** (API-… emulator, debug build): dropped a pin via the radial menu, saved it, then **tapped the existing pin → the "Edit Marker" sheet opened** (callsign / affiliation / symbol), matching the globe. Screenshot shared with J.

### Scope
Two `.kt` files + tests. No change to how contacts are rendered or fed; only the tap routing. Does not touch the self-marker tap (#82, a LocationComponent puck, not an annotation) or the near-miss map-click hit-test (kept as a fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X56oaELvYvJcBGgurTkc3A