### PR TITLE
chore(release): OmniTAK Android 0.39.2 (versionCode 100)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 99
-        versionName = "0.39.1"
+        versionCode = 100
+        versionName = "0.39.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }


### PR DESCRIPTION
Version bump for the 0.39.2 release: 0.39.1 + the #150 fix (tapping a 2D contact pin now opens the edit sheet, parity with the 3D globe). versionName 0.39.1→0.39.2, versionCode 99→100. Signed AAB (vc100) staged for Play Console; signed APK published to GitHub Releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X56oaELvYvJcBGgurTkc3A