### PR TITLE
Field feedback: background PPLI, paired-radio visibility split, mesh status dot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,12 @@
          the service still runs, the persistent chip just doesn't show. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- Field feedback (PatoG, 2026-08) — with only the dataSync type, fused
+         location updates stop the moment the screen locks, so PPLI freezes
+         for everyone while the socket/mesh stay up. The location FGS type
+         keeps while-in-use GPS flowing in the background — no "Allow all
+         the time" (ACCESS_BACKGROUND_LOCATION) prompt needed. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- Bluetooth LE for the Meshtastic BLE transport (Android 12+). -->
@@ -99,7 +105,7 @@
         <service
             android:name=".domain.TAKConnectionService"
             android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="dataSync|location" />
 
         <!-- Issue #16 — FileProvider for lasso exports (KML / Mission
              Package zip) so we can hand them to the system share sheet

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -110,24 +110,54 @@ class OmniTAKApp : Application() {
         // with ForegroundServiceDidNotStartInTimeException. Waiting
         // [FGS_DEBOUNCE_MS] before calling start() means transient
         // connections never trigger the FGS at all.
+        // Field feedback (PatoG, 2026-08) — the FGS must also run for
+        // mesh-only operation. His MilSim devices with a radio but no TAK
+        // server had no foreground privilege at all, so location (and
+        // eventually the process) died at screen lock. The service now runs
+        // while EITHER a server socket or a mesh radio link is up, and its
+        // location FGS type keeps background GPS flowing for both.
         appScope.launch {
             var pendingStart: Job? = null
-            serverManager.connectionState.collect { state ->
-                when (state) {
-                    is ConnectionState.Connected -> {
+            fun currentLinkLabel(): String? {
+                val server = serverManager.connectionState.value as? ConnectionState.Connected
+                val meshUp = meshtastic.activeConnectionState.value is ConnectionState.Connected ||
+                    meshcore.activeConnectionState.value is ConnectionState.Connected
+                return when {
+                    server != null && meshUp -> "${server.serverName} + mesh"
+                    server != null -> server.serverName
+                    meshUp -> "mesh radio"
+                    else -> null
+                }
+            }
+            combine(
+                serverManager.connectionState,
+                meshtastic.activeConnectionState,
+                meshcore.activeConnectionState,
+            ) { server, mesh, meshCore ->
+                val states = listOf(server, mesh, meshCore)
+                when {
+                    states.any { it is ConnectionState.Connected } -> FgsWant.START
+                    // Connecting / Failed hold the service as before — a
+                    // transient reconnect must not bounce the FGS.
+                    states.all { it is ConnectionState.Disconnected } -> FgsWant.STOP
+                    else -> FgsWant.HOLD
+                }
+            }.distinctUntilChanged().collect { want ->
+                when (want) {
+                    FgsWant.START -> {
                         pendingStart?.cancel()
                         pendingStart = appScope.launch {
                             delay(FGS_DEBOUNCE_MS)
-                            if (serverManager.connectionState.value is ConnectionState.Connected) {
-                                TAKConnectionService.start(this@OmniTAKApp, state.serverName)
+                            currentLinkLabel()?.let { label ->
+                                TAKConnectionService.start(this@OmniTAKApp, label)
                             }
                         }
                     }
-                    ConnectionState.Disconnected -> {
+                    FgsWant.STOP -> {
                         pendingStart?.cancel()
                         TAKConnectionService.stop(this@OmniTAKApp)
                     }
-                    else -> { /* Connecting / Failed: leave service state alone */ }
+                    FgsWant.HOLD -> { /* leave service state alone */ }
                 }
             }
         }
@@ -833,3 +863,6 @@ private fun meshChannelTitle(channel: AdminResponse.Channel): String {
         else -> "Mesh: Channel ${channel.index}"
     }
 }
+
+/** Desired foreground-service state derived from the server + mesh links. */
+private enum class FgsWant { START, HOLD, STOP }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshNode.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshNode.kt
@@ -20,8 +20,22 @@ data class MeshNode(
     val snr: Double? = null,
     val hopDistance: Int? = null,
     val batteryLevel: Int? = null,
+    /** Meshtastic device role (`User.role`, config.proto enum value), or
+     *  null when the NodeInfo didn't carry one. */
+    val role: Int? = null,
 ) {
     val idHex: String get() = "%08x".format(id.toInt())
+
+    /** Role `TAK` — a radio paired to a phone running a TAK client. Its
+     *  position duplicates the operator's own PLI, so the map can hide it
+     *  (field feedback: two mismatched dots per person). */
+    val isTakPaired: Boolean get() = role == ROLE_TAK
+
+    companion object {
+        /** meshtastic config.proto Config.DeviceConfig.Role values we care about. */
+        const val ROLE_TAK = 7
+        const val ROLE_TAK_TRACKER = 10
+    }
 }
 
 data class MeshPosition(

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticProtoParser.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticProtoParser.kt
@@ -158,6 +158,7 @@ object MeshtasticProtoParser {
         var nodeNumSeen = false
         var shortName = ""
         var longName = ""
+        var role: Int? = null
         var position: MeshPosition? = null
         var snr: Double? = null
         var lastHeard: Long = System.currentTimeMillis() / 1000
@@ -186,15 +187,15 @@ object MeshtasticProtoParser {
                     }
                 }
                 4 -> {
-                    // user submessage — long_name (2), short_name (3) are
-                    // the only fields we surface. iOS uses field 2 = user
-                    // historically; the modern proto puts user at field 4.
-                    // Accept either.
+                    // user submessage — long_name (2), short_name (3), and
+                    // role (7). iOS uses field 2 = user historically; the
+                    // modern proto puts user at field 4. Accept either.
                     if (wire != 2) { idx = skipField(bytes, idx, wire); continue }
                     val sub = readLengthDelimited(bytes, idx) ?: break
-                    val (sn, ln) = parseUser(sub.first)
-                    if (sn.isNotEmpty()) shortName = sn
-                    if (ln.isNotEmpty()) longName = ln
+                    val user = parseUser(sub.first)
+                    if (user.shortName.isNotEmpty()) shortName = user.shortName
+                    if (user.longName.isNotEmpty()) longName = user.longName
+                    if (user.role != null) role = user.role
                     idx = sub.second
                 }
                 2 -> {
@@ -202,9 +203,10 @@ object MeshtasticProtoParser {
                     // payload shape.
                     if (wire != 2) { idx = skipField(bytes, idx, wire); continue }
                     val sub = readLengthDelimited(bytes, idx) ?: break
-                    val (sn, ln) = parseUser(sub.first)
-                    if (sn.isNotEmpty()) shortName = sn
-                    if (ln.isNotEmpty()) longName = ln
+                    val user = parseUser(sub.first)
+                    if (user.shortName.isNotEmpty()) shortName = user.shortName
+                    if (user.longName.isNotEmpty()) longName = user.longName
+                    if (user.role != null) role = user.role
                     idx = sub.second
                 }
                 5 -> {
@@ -278,13 +280,18 @@ object MeshtasticProtoParser {
             snr = snr,
             hopDistance = hopsAway,
             batteryLevel = battery,
+            role = role,
         )
     }
 
-    private fun parseUser(bytes: ByteArray): Pair<String, String> {
+    /** Decoded `User` submessage fields we surface off a NodeInfo. */
+    data class ParsedUser(val shortName: String, val longName: String, val role: Int?)
+
+    private fun parseUser(bytes: ByteArray): ParsedUser {
         var idx = 0
         var shortName = ""
         var longName = ""
+        var role: Int? = null
         while (idx < bytes.size) {
             val (tag, afterTag) = readVarint(bytes, idx) ?: break
             val field = (tag shr 3).toInt()
@@ -301,10 +308,15 @@ object MeshtasticProtoParser {
                     val (s, after) = readString(bytes, idx) ?: break
                     shortName = s; idx = after
                 }
+                7 -> { // role (Config.DeviceConfig.Role) — TAK vs TAK_TRACKER
+                    if (wire != 0) { idx = skipField(bytes, idx, wire); continue }
+                    val (v, after) = readVarint(bytes, idx) ?: break
+                    role = v.toInt(); idx = after
+                }
                 else -> idx = skipField(bytes, idx, wire)
             }
         }
-        return shortName to longName
+        return ParsedUser(shortName, longName, role)
     }
 
     private fun parseDeviceMetricsBattery(bytes: ByteArray): Int? {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -68,6 +68,12 @@ data class UserPrefs(
     val customTileUrl: String = "",
     val autoPublishMeshToTak: Boolean = true,
     val meshNodesLayerVisible: Boolean = true,
+    // Field feedback (PatoG, 2026-08) — a radio in Meshtastic role TAK is
+    // paired to a phone that broadcasts its own PLI, so its node marker is a
+    // second, slightly-off dot for the same person. Hidden by default;
+    // standalone trackers (TAK_TRACKER / sensors / vehicles) stay visible
+    // under the main mesh toggle.
+    val meshPairedNodesVisible: Boolean = false,
     // GAP-110 — persisted UI toggles. Each one mirrors a switch the operator
     // hits via the long-press radial menu / Layers sheet / map controls. Used
     // to evaporate on relaunch (`var X by remember { mutableStateOf(...) }`)
@@ -172,6 +178,7 @@ class UserPrefsStore(private val context: Context) {
     private val KEY_CUSTOM_TILE_URL = stringPreferencesKey("custom_tile_url")
     private val KEY_AUTO_PUBLISH_MESH = booleanPreferencesKey("auto_publish_mesh_to_tak")
     private val KEY_MESH_LAYER_VISIBLE = booleanPreferencesKey("mesh_nodes_layer_visible")
+    private val KEY_MESH_PAIRED_VISIBLE = booleanPreferencesKey("mesh_paired_nodes_visible")
     // GAP-110 keys
     private val KEY_CALLSIGN_CARD = booleanPreferencesKey("callsign_card_visible")
     private val KEY_GRID = booleanPreferencesKey("grid_enabled")
@@ -220,6 +227,7 @@ class UserPrefsStore(private val context: Context) {
             p[KEY_CUSTOM_TILE_URL] = next.customTileUrl
             p[KEY_AUTO_PUBLISH_MESH] = next.autoPublishMeshToTak
             p[KEY_MESH_LAYER_VISIBLE] = next.meshNodesLayerVisible
+            p[KEY_MESH_PAIRED_VISIBLE] = next.meshPairedNodesVisible
             p[KEY_CALLSIGN_CARD] = next.callsignCardVisible
             p[KEY_GRID] = next.gridEnabled
             p[KEY_DRAWINGS_VIS] = next.drawingsVisible
@@ -348,6 +356,7 @@ class UserPrefsStore(private val context: Context) {
         customTileUrl = p[KEY_CUSTOM_TILE_URL] ?: "",
         autoPublishMeshToTak = p[KEY_AUTO_PUBLISH_MESH] ?: true,
         meshNodesLayerVisible = p[KEY_MESH_LAYER_VISIBLE] ?: true,
+        meshPairedNodesVisible = p[KEY_MESH_PAIRED_VISIBLE] ?: false,
         callsignCardVisible = p[KEY_CALLSIGN_CARD] ?: true,
         gridEnabled = p[KEY_GRID] ?: false,
         drawingsVisible = p[KEY_DRAWINGS_VIS] ?: true,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
@@ -291,6 +291,7 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
             batteryLevel = node.batteryLevel ?: existing.batteryLevel,
             shortName = node.shortName.ifBlank { existing.shortName },
             longName = node.longName.ifBlank { existing.longName },
+            role = node.role ?: existing.role,
         ) else node
         _nodes.value = _nodes.value + (merged.id to merged)
     }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/TAKConnectionService.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/TAKConnectionService.kt
@@ -1,5 +1,6 @@
 package soy.engindearing.omnitak.mobile.domain
 
+import android.Manifest
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -7,6 +8,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
@@ -33,19 +35,37 @@ import soy.engindearing.omnitak.mobile.R
 class TAKConnectionService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val serverName = intent?.getStringExtra(EXTRA_SERVER_NAME) ?: "TAK Server"
-        startForeground(NOTIFICATION_ID, buildNotification(serverName), foregroundServiceTypeOrZero())
+        val linkLabel = intent?.getStringExtra(EXTRA_LINK_LABEL) ?: "TAK Server"
+        startForeground(NOTIFICATION_ID, buildNotification(linkLabel), foregroundServiceTypes())
         return START_STICKY
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    private fun foregroundServiceTypeOrZero(): Int =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-        } else 0
+    /**
+     * dataSync keeps the socket read loop alive; the location type keeps
+     * fused GPS updates flowing while the screen is off, which is what
+     * makes background PPLI work (field feedback, PatoG 2026-08). The
+     * location type may only be claimed while while-in-use location is
+     * actually granted — Android 14 throws SecurityException otherwise —
+     * so it degrades to dataSync-only when the user denied location.
+     */
+    private fun foregroundServiceTypes(): Int {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return 0
+        var types = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        if (hasLocationPermission()) {
+            types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+        }
+        return types
+    }
 
-    private fun buildNotification(serverName: String): Notification {
+    private fun hasLocationPermission(): Boolean =
+        ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+
+    private fun buildNotification(linkLabel: String): Notification {
         ensureChannel(this)
         val tap = PendingIntent.getActivity(
             this,
@@ -54,8 +74,8 @@ class TAKConnectionService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
         return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("OmniTAK connected")
-            .setContentText("Holding TLS to $serverName")
+            .setContentTitle("OmniTAK active")
+            .setContentText("Sharing position over $linkLabel")
             .setSmallIcon(R.mipmap.app_icon)
             .setOngoing(true)
             .setSilent(true)
@@ -68,12 +88,14 @@ class TAKConnectionService : Service() {
     companion object {
         private const val CHANNEL_ID = "tak_connection"
         private const val NOTIFICATION_ID = 1001
-        private const val EXTRA_SERVER_NAME = "server_name"
+        private const val EXTRA_LINK_LABEL = "link_label"
 
-        fun start(context: Context, serverName: String) {
+        /** [linkLabel] names what we're holding open — a server name,
+         *  "Meshtastic mesh", or both — shown in the persistent chip. */
+        fun start(context: Context, linkLabel: String) {
             ensureChannel(context)
             val intent = Intent(context, TAKConnectionService::class.java)
-                .putExtra(EXTRA_SERVER_NAME, serverName)
+                .putExtra(EXTRA_LINK_LABEL, linkLabel)
             ContextCompat.startForegroundService(context, intent)
         }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CustomToolbar.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/CustomToolbar.kt
@@ -76,6 +76,10 @@ fun CustomToolbar(
     coachmarkVisible: Boolean,
     canAdd: Boolean,
     canRemove: Boolean,
+    /** Per-item status dot colors keyed by BarItem id — e.g. the Mesh tab's
+     *  radio-link state (field feedback: "is a mesh device even connected?"
+     *  needs an always-visible answer). Absent id = no dot. */
+    statusDots: Map<String, Color> = emptyMap(),
     onSelect: (BarItem) -> Unit,
     onEnterEdit: () -> Unit,
     onDoneEdit: () -> Unit,
@@ -180,6 +184,7 @@ fun CustomToolbar(
                         editing = editing,
                         compact = compact,
                         canRemove = canRemove,
+                        statusDot = statusDots[item.id],
                         jiggleAngle = if (isDragging) 0f else jiggleAngle,
                         isDragging = isDragging,
                         dragTranslationX = if (isDragging) dragOffsetX else 0f,
@@ -262,6 +267,7 @@ private fun BarCell(
     editing: Boolean,
     compact: Boolean,
     canRemove: Boolean,
+    statusDot: Color?,
     jiggleAngle: Float,
     isDragging: Boolean,
     dragTranslationX: Float,
@@ -308,6 +314,20 @@ private fun BarCell(
                     tint = if (selected) item.tint else Color.White.copy(alpha = 0.85f),
                     modifier = Modifier.size(22.dp),
                 )
+                if (statusDot != null) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(top = 3.dp, end = 3.dp)
+                            .size(7.dp)
+                            .clip(CircleShape)
+                            // Thin dark ring so the dot reads on any tint.
+                            .background(Color(0xFF0F1115))
+                            .padding(1.dp)
+                            .clip(CircleShape)
+                            .background(statusDot),
+                    )
+                }
             }
             // #182 — drop the per-cell label in the compact landscape rail;
             // the icon's contentDescription keeps it accessible and the bar

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/LayersDialog.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/LayersDialog.kt
@@ -36,6 +36,7 @@ fun LayersDialog(
     contactsVisible: Boolean,
     callsignCardVisible: Boolean,
     meshNodesVisible: Boolean = true,
+    meshPairedVisible: Boolean = false,
     map3dEnabled: Boolean = false,
     onToggleGrid: (Boolean) -> Unit,
     onToggleDrawings: (Boolean) -> Unit,
@@ -43,6 +44,7 @@ fun LayersDialog(
     onToggleContacts: (Boolean) -> Unit,
     onToggleCallsignCard: (Boolean) -> Unit,
     onToggleMeshNodes: (Boolean) -> Unit = {},
+    onToggleMeshPaired: (Boolean) -> Unit = {},
     onToggle3d: (Boolean) -> Unit = {},
     onOpenOfflineMaps: (() -> Unit)? = null,
     onDismiss: () -> Unit,
@@ -62,6 +64,17 @@ fun LayersDialog(
                 LayerRow("3D terrain", map3dEnabled, onToggle3d)
                 LayerRow("Contacts", contactsVisible, onToggleContacts)
                 LayerRow("Mesh nodes", meshNodesVisible, onToggleMeshNodes)
+                // Field feedback (PatoG, 2026-08) — radios in Meshtastic role
+                // TAK duplicate their operator's own PLI dot, so they're a
+                // separate opt-in. Standalone trackers (TAK_TRACKER, sensors,
+                // vehicles) ride the main "Mesh nodes" toggle above.
+                if (meshNodesVisible) {
+                    LayerRow(
+                        "    Paired radios (duplicate of operator)",
+                        meshPairedVisible,
+                        onToggleMeshPaired,
+                    )
+                }
                 LayerRow("Drawings", drawingsVisible, onToggleDrawings)
                 LayerRow("Aircraft (ADSB)", aircraftVisible, onToggleAircraft)
                 LayerRow("Lat/Lon grid", gridEnabled, onToggleGrid)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
@@ -4,6 +4,8 @@ import android.view.WindowManager
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.ui.graphics.Color
+import soy.engindearing.omnitak.mobile.domain.ConnectionState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -191,6 +193,22 @@ fun AppNav() {
     val barItems = ToolbarCatalog.resolve(workingIds)
     val coachmarkVisible = !prefs.toolbarCoachmarkSeen && currentRoute == "map" && !editing
 
+    // Field feedback (PatoG, 2026-08) — the Mesh tab icon carries an
+    // always-visible link-state dot so "is a radio even connected?" never
+    // needs a tab visit: green = connected, amber = connecting,
+    // red = failed, grey = no device.
+    val meshtasticState by app.meshtastic.activeConnectionState.collectAsState()
+    val meshcoreState by app.meshcore.activeConnectionState.collectAsState()
+    val meshDot = when {
+        meshtasticState is ConnectionState.Connected ||
+            meshcoreState is ConnectionState.Connected -> Color(0xFF34C759)
+        meshtasticState is ConnectionState.Connecting ||
+            meshcoreState is ConnectionState.Connecting -> Color(0xFFFFCC00)
+        meshtasticState is ConnectionState.Failed ||
+            meshcoreState is ConnectionState.Failed -> Color(0xFFFF3B30)
+        else -> Color(0xFF5A5F66)
+    }
+
     Scaffold(
         bottomBar = {
             CustomToolbar(
@@ -200,6 +218,7 @@ fun AppNav() {
                 coachmarkVisible = coachmarkVisible,
                 canAdd = workingIds.size < ToolbarCatalog.MAX_ITEMS,
                 canRemove = workingIds.size > ToolbarCatalog.MIN_ITEMS,
+                statusDots = mapOf("mesh" to meshDot),
                 onSelect = { dispatch(it) },
                 onEnterEdit = { enterEdit() },
                 onDoneEdit = {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -130,6 +130,18 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     // visible — matches iOS.
     val userPrefs by app.userPrefsStore.prefs.collectAsState(initial = soy.engindearing.omnitak.mobile.data.UserPrefs())
     val meshNodesVisible = userPrefs.meshNodesLayerVisible
+    // Field feedback (PatoG, 2026-08) — split "paired radios" (Meshtastic
+    // role TAK: the phone next to them already broadcasts the operator's
+    // PLI, so the node dot is a duplicate) from standalone trackers
+    // (vehicles / mission objects with no TAK client). Hidden by default.
+    val meshPairedVisible = userPrefs.meshPairedNodesVisible
+    val meshNodesById by app.activeMeshManager.nodes.collectAsState()
+    val pairedMeshUids = remember(meshNodesById) {
+        meshNodesById.values
+            .filter { it.isTakPaired }
+            .map { soy.engindearing.omnitak.mobile.data.MeshtasticCoTConverter.takUid(it.id) }
+            .toSet()
+    }
     // GAP-110 — persisted UI toggles. These survive relaunch instead of
     // resetting to defaults each time the user opens the app. Aliases so
     // existing read sites stay terse.
@@ -434,10 +446,19 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
     // dead 3D zoom buttons came from exactly this split).
     val visibleContacts: List<soy.engindearing.omnitak.mobile.data.CoTEvent> =
         if (contactsVisible) {
-            if (meshNodesVisible) contacts.values.toList()
-            // Hide mesh-origin contacts — they all share the `MESHTASTIC-`
-            // UID prefix produced by `MeshtasticCoTConverter.takUid`.
-            else contacts.values.filterNot { it.uid.startsWith("MESHTASTIC-") }
+            // Mesh-origin contacts share the `MESHTASTIC-` UID prefix
+            // produced by `MeshtasticCoTConverter.takUid`. The master mesh
+            // toggle hides them all; with it on, paired radios (role TAK —
+            // duplicate of the operator's own PLI dot) stay hidden unless
+            // the operator opts back in.
+            contacts.values.filter { c ->
+                when {
+                    !c.uid.startsWith("MESHTASTIC-") -> true
+                    !meshNodesVisible -> false
+                    c.uid in pairedMeshUids -> meshPairedVisible
+                    else -> true
+                }
+            }
         } else {
             emptyList()
         }
@@ -2161,12 +2182,16 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 contactsVisible = contactsVisible,
                 callsignCardVisible = callsignCardVisible,
                 meshNodesVisible = meshNodesVisible,
+                meshPairedVisible = meshPairedVisible,
                 map3dEnabled = map3dEnabled,
                 onToggleGrid = { v -> mutatePref { it.copy(gridEnabled = v) } },
                 onToggleDrawings = { v -> mutatePref { it.copy(drawingsVisible = v) } },
                 onToggleAircraft = { v -> mutatePref { it.copy(aircraftVisible = v) } },
                 onToggleContacts = { v -> mutatePref { it.copy(contactsVisible = v) } },
                 onToggleCallsignCard = { v -> mutatePref { it.copy(callsignCardVisible = v) } },
+                onToggleMeshPaired = { v ->
+                    mutatePref { it.copy(meshPairedNodesVisible = v) }
+                },
                 onToggleMeshNodes = { v ->
                     scope.launch { app.userPrefsStore.setMeshNodesLayerVisible(v) }
                 },

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticProtoParserTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/MeshtasticProtoParserTest.kt
@@ -134,6 +134,37 @@ class MeshtasticProtoParserTest {
         assertEquals(12.5, node.snr!!, 1e-3)
         assertEquals(1_700_000_000L, node.lastHeardEpoch)
         assertEquals(2, node.hopDistance)
+        // No role field in this frame — must stay null, not default to 0.
+        assertEquals(null, node.role)
+    }
+
+    // Field feedback (PatoG, 2026-08) — User.role (field 7) distinguishes a
+    // radio paired to a TAK client (role TAK → hideable duplicate dot) from
+    // a standalone tracker. Pin the decode + the isTakPaired split.
+    @Test fun fromRadio_nodeinfo_role_tak_vs_tracker() {
+        fun nodeWithRole(role: Int): MeshNode {
+            val user = ByteArrayOutputStream().apply {
+                writeTagString(this, field = 2, value = "Radio")
+                writeTagString(this, field = 3, value = "RDO")
+                writeTagVarint(this, field = 7, value = role.toULong())
+            }.toByteArray()
+            val nodeInfo = ByteArrayOutputStream().apply {
+                writeTagVarint(this, field = 1, value = 0x1234UL)
+                writeTagBytes(this, field = 4, value = user)
+            }.toByteArray()
+            val fromRadio = ByteArrayOutputStream().apply {
+                writeTagBytes(this, field = 4, value = nodeInfo)
+            }.toByteArray()
+            return (MeshtasticProtoParser.parseFromRadio(fromRadio) as FromRadioFrame.NodeInfoFrame).node
+        }
+
+        val paired = nodeWithRole(MeshNode.ROLE_TAK)
+        assertEquals(MeshNode.ROLE_TAK, paired.role)
+        assertTrue(paired.isTakPaired)
+
+        val tracker = nodeWithRole(MeshNode.ROLE_TAK_TRACKER)
+        assertEquals(MeshNode.ROLE_TAK_TRACKER, tracker.role)
+        assertTrue(!tracker.isTakPaired)
     }
 
     @Test fun fromRadio_my_info() {


### PR DESCRIPTION
Closed-test field feedback from PatoG (email 2026-08-08 — 5 clients, 1 server, 6 TAK-profile radios; prepping a 50-operator MilSim on pre-flashed radios + OmniTAK, store deadline early September).

### 1. Background PPLI — the critical one
Screen locked → position stopped updating for every other device, and the self marker was stale on unlock. Root cause: the FGS declared only `dataSync`, so Doze kept the socket but fused location stopped (that's why his relay kept working while dots froze). Mesh-only devices — radio, no server — never got a foreground service at all.

- Service type → `dataSync|location`; the location type is claimed only while while-in-use location is granted (Android 14 SecurityException otherwise)
- FGS now runs while **either** a server socket **or** a mesh radio link is up (tri-state keeps the old hold-through-reconnect behavior)
- `FOREGROUND_SERVICE_LOCATION` permission added; no "Allow all the time" prompt needed

### 2. Paired-radio visibility split (the feature request)
One operator = two mismatched dots (their TAK client + their paired radio). `User.role` (field 7) is now decoded off NodeInfo: role **TAK** = paired → hidden by default behind a new **Paired radios** sub-toggle in the layers dialog; standalone trackers (TAK_TRACKER / sensors / vehicles) stay on the main Mesh nodes toggle. Role survives node merges.

### 3. Mesh link-state dot
The Mesh tab icon carries an always-visible dot: green connected / amber connecting / red failed / grey no device. Verified on emulator (grey state).

### Not in this PR
Item 4 — in-app channel set not taking effect on the radio — needs a live-radio repro first: #185.

Tests: role decode + isTakPaired split pinned in `MeshtasticProtoParserTest`; full `testDebugUnitTest` green. Background-location behavior needs a physical device walk test (emulator GPS doesn't exercise doze) — flagging for the next device session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jRzhUGw1rWh25DL53qvWj