### PR TITLE
chore(release): OmniTAK Android 0.41.0 (versionCode 104)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 101
-        versionName = "0.40.0"
+        versionCode = 104
+        versionName = "0.41.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }


### PR DESCRIPTION
## What this is
A **version bump only** (`app/build.gradle.kts`: `0.40.0/vc101` → `0.41.0/vc104`). No code changes — every feature below is **already merged to `main`** but stranded above the last released build (`0.40.0/vc101`, current in Play closed testing), so none of it has reached testers.

## Ships since 0.40.0
- **field feedback (#186)** — background PPLI, paired-radio visibility split, mesh status dot *(PatoG MilSim tester asks — time-sensitive)*
- **feat(discovery)** — mDNS-discovered TAK servers surfaced in Add Server (#158/#183) + Bonjour/mDNS LAN discovery core (#158)
- **feat(symbology)** — echelon / org-size ladder (#159)
- **feat(terrain)** — elevation profile + line-of-sight core (#153, closes an open parity issue)
- **feat(geofence)** — circle/polygon geofencing + entry/exit/dwell (#155, closes an open parity issue)

## ⚠️ Stale artifact warning
`playstore-assets/OmniTAK-0.41.0-vc103.aab` already exists but was built from a working tree **6 commits behind main** — it is missing everything above. **Do not upload it.** This PR sets `versionCode 104` (strictly above 103) so a fresh, complete build supersedes it.

## How to ship after merge
```
./gradlew bundleRelease     # builds app-release.aab at 0.41.0 / vc104
```
Then upload the AAB to Play Console → closed testing. (`playstore-assets/build-release.sh` would auto-bump to vc105 instead; use `gradlew` directly to keep vc104, or let it roll — either is monotonic.)

## Not included
The uncommitted lean-audit cuts + the local vc103 bump in the working tree (8/12 batch, `§9` pending) are deliberately **not** part of this release — this branch was cut from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pJWva5qfW1yGYyVPhWort