### PR TITLE
chore(release): OmniTAK Android 0.42.0 (versionCode 105)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 104
-        versionName = "0.41.0"
+        versionCode = 105
+        versionName = "0.42.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }


### PR DESCRIPTION
## Why 0.42.0 (not another 0.41.0)
Play Production is already live on **0.41.0 / vc103** (built Aug 12). That build predates the six features below (all merged **Aug 17**), so it doesn't contain them — "0.41.0" shipped by name but not by contents. `0.41.0/vc104` was built to close the gap but never uploaded; a clean **0.42.0** avoids two different builds both labeled 0.41.0 in production.

## Ships over the live vc103
- **field feedback (#186)** — background PPLI, paired-radio visibility split, mesh status dot *(time-sensitive)*
- mDNS-discovered TAK servers in Add Server (#158/#183) + Bonjour/mDNS core (#158)
- echelon / org-size ladder (#159)
- elevation profile + line-of-sight (#153)
- circle/polygon geofencing + entry/exit/dwell (#155)

## Artifact
Signed AAB built at **0.42.0 / vc105**. `versionCode 105` clears both vc103 (live) and the abandoned vc104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)