### PR TITLE
chore(release): OmniTAK Android 0.42.1 (versionCode 106, targetSdk 36)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "soy.engindearing.omnitak.mobile"
-    compileSdk = 35
+    compileSdk = 36
     // Pin to the locally-installed NDK so AGP can find llvm-objcopy when it
     // needs to (re)strip overlaid prebuilt libs from app/src/main/jniLibs/
     // and extract their debug info into BUNDLE-METADATA. Without this AGP
@@ -20,9 +20,9 @@ android {
     defaultConfig {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
-        targetSdk = 35
-        versionCode = 105
-        versionName = "0.42.0"
+        targetSdk = 36
+        versionCode = 106
+        versionName = "0.42.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }


### PR DESCRIPTION
## Why 0.42.1 / vc106

Two problems with the staged 0.42.0/vc105 draft on Play:

1. **It was never rolled out** — Play production is still live on vc103 (Aug 12), which predates the field-feedback fixes (#186). The GitHub Releases page is further behind (v0.40.0). A field tester is waiting on background PPLI for a group validation test this weekend.
2. **It targets API 35** — a downgrade from the live vc103 (target 36), and below Google Play's **Aug 31, 2026** target-API deadline. Rolling out vc105 would leave the app un-updatable after the deadline.

## This PR
- `compileSdk` / `targetSdk` **35 → 36** (matches what vc103 already shipped with; the committed gradle file never got the bump)
- `versionName` **0.42.0 → 0.42.1**, `versionCode` **105 → 106**

Content is identical to 0.42.0 otherwise — see #188 for the feature delta over the live vc103.

## Artifacts
Signed AAB + APK built at **0.42.1 / vc106**, unit tests green. AAB replaces the vc105 draft on the Play production track; APK attaches to the GitHub v0.42.1 release for sideloaders.
