### PR TITLE
fix(mesh): admin messages addressed to local radio + position field + UTF-8 name clamp (#185)

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AdminMessageParser.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AdminMessageParser.kt
@@ -129,7 +129,9 @@ object AdminMessageParser {
         return AdminResponse.DeviceConfig(role = role)
     }
 
-    /** PositionConfig.position_broadcast_secs = field 4 (varint). */
+    /** PositionConfig.position_broadcast_secs = field 1 (varint). Field 4 is
+     *  the deprecated `gps_enabled` bool — reading it back yielded 0 or 1
+     *  where the UI expected seconds. */
     private fun parsePositionConfig(bytes: ByteArray): AdminResponse.PositionConfig {
         var idx = 0
         var secs = 0
@@ -138,7 +140,7 @@ object AdminMessageParser {
             val field = (tag shr 3).toInt()
             val wire = (tag and 0x7UL).toInt()
             idx = afterTag
-            if (field == 4 && wire == 0) {
+            if (field == 1 && wire == 0) {
                 val (v, after) = readVarint(bytes, idx) ?: break
                 secs = v.toInt()
                 idx = after

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AdminMessageSerializer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AdminMessageSerializer.kt
@@ -183,9 +183,11 @@ object AdminMessageSerializer {
      */
     fun buildSetPositionBroadcastSecs(myNodeNum: UInt, secs: Int): ByteArray {
         val safe = secs.coerceIn(0, 24 * 60 * 60).toULong()
-        // PositionConfig.position_broadcast_secs = field 4, varint.
+        // PositionConfig.position_broadcast_secs = field 1, varint. Field 4 is
+        // the deprecated `gps_enabled` bool — writing seconds there sets a
+        // boolean and leaves the cadence untouched.
         val positionConfig = ByteArrayOutputStream().apply {
-            MeshWire.appendVarintField(this, field = 4, value = safe)
+            MeshWire.appendVarintField(this, field = 1, value = safe)
         }.toByteArray()
         // Config.position = field 2, wire type 2.
         val config = ByteArrayOutputStream().apply {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AdminMessageSerializer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AdminMessageSerializer.kt
@@ -54,7 +54,7 @@ object AdminMessageSerializer {
      *   ChannelSettings.uplink_enabled   = 5 (bool)
      *   ChannelSettings.downlink_enabled = 6 (bool)
      */
-    fun buildSetChannel(channel: MeshChannel, index: Int): ByteArray {
+    fun buildSetChannel(myNodeNum: UInt, channel: MeshChannel, index: Int): ByteArray {
         // ChannelSettings — PSK first (field 2) then name (field 3), matching
         // the share-URL encoder field order.
         val settings = ByteArrayOutputStream().apply {
@@ -87,7 +87,7 @@ object AdminMessageSerializer {
             MeshWire.appendVarint(this, channelMsg.size.toULong())
             write(channelMsg)
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     /**
@@ -100,7 +100,7 @@ object AdminMessageSerializer {
      *   Config.device                 = 1
      *   DeviceConfig.rebroadcast_mode = 6  (enum)
      */
-    fun buildSetRebroadcastMode(mode: RebroadcastMode): ByteArray {
+    fun buildSetRebroadcastMode(myNodeNum: UInt, mode: RebroadcastMode): ByteArray {
         val deviceConfig = ByteArrayOutputStream().apply {
             MeshWire.appendVarintField(this, field = 6, value = mode.wire.toULong())
         }.toByteArray()
@@ -114,7 +114,7 @@ object AdminMessageSerializer {
             MeshWire.appendVarint(this, config.size.toULong())
             write(config)
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     private const val CHANNEL_ROLE_PRIMARY = 1
@@ -135,6 +135,7 @@ object AdminMessageSerializer {
      * `isLicensed = false` are omitted so the firmware keeps whatever it has.
      */
     fun buildSetOwner(
+        myNodeNum: UInt,
         longName: String,
         shortName: String,
         id: String = "",
@@ -147,14 +148,14 @@ object AdminMessageSerializer {
             MeshWire.appendVarint(this, owner.size.toULong())
             write(owner)
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     /**
      * Build a ToRadio with `AdminMessage { set_config { device { role = ... } } }`.
      * Only sets the role — the practitioner-headline knob.
      */
-    fun buildSetDeviceRole(role: MeshRole): ByteArray {
+    fun buildSetDeviceRole(myNodeNum: UInt, role: MeshRole): ByteArray {
         // DeviceConfig.role = field 1, varint of the proto-enum ordinal.
         val deviceConfig = ByteArrayOutputStream().apply {
             MeshWire.appendVarintField(this, field = 1, value = roleProtoOrdinal(role).toULong())
@@ -173,14 +174,14 @@ object AdminMessageSerializer {
             MeshWire.appendVarint(this, config.size.toULong())
             write(config)
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     /**
      * Build a ToRadio with `AdminMessage { set_config { position { position_broadcast_secs = N } } }`.
      * Headline practitioner ask — operator-controlled PLI cadence.
      */
-    fun buildSetPositionBroadcastSecs(secs: Int): ByteArray {
+    fun buildSetPositionBroadcastSecs(myNodeNum: UInt, secs: Int): ByteArray {
         val safe = secs.coerceIn(0, 24 * 60 * 60).toULong()
         // PositionConfig.position_broadcast_secs = field 4, varint.
         val positionConfig = ByteArrayOutputStream().apply {
@@ -198,7 +199,7 @@ object AdminMessageSerializer {
             MeshWire.appendVarint(this, config.size.toULong())
             write(config)
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     /**
@@ -209,7 +210,7 @@ object AdminMessageSerializer {
      * — see [buildSetLoraPreset]. Two messages because Meshtastic
      * splits channel and modem config across two protobuf submessages.
      */
-    fun buildSetChannel0Name(name: String): ByteArray {
+    fun buildSetChannel0Name(myNodeNum: UInt, name: String): ByteArray {
         // ChannelSettings.name = field 3, string.
         val settings = ByteArrayOutputStream().apply {
             appendString(this, field = 3, value = name)
@@ -231,17 +232,17 @@ object AdminMessageSerializer {
             MeshWire.appendVarint(this, channel.size.toULong())
             write(channel)
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     // region Read requests ----------------------------------------------
 
     /** AdminMessage.get_owner_request = field 3 (bool). */
-    fun buildGetOwnerRequest(): ByteArray {
+    fun buildGetOwnerRequest(myNodeNum: UInt): ByteArray {
         val admin = ByteArrayOutputStream().apply {
             MeshWire.appendVarintField(this, field = 3, value = 1UL)
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     /**
@@ -249,27 +250,27 @@ object AdminMessageSerializer {
      * Values: DEVICE=0, POSITION=1, POWER=2, NETWORK=3, DISPLAY=4, LORA=5,
      * BLUETOOTH=6, SECURITY=7, SESSIONKEY=8, DEVICEUI=9.
      */
-    fun buildGetConfigRequest(configType: Int): ByteArray {
+    fun buildGetConfigRequest(myNodeNum: UInt, configType: Int): ByteArray {
         val admin = ByteArrayOutputStream().apply {
             MeshWire.appendVarintField(this, field = 5, value = configType.toULong())
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     /** AdminMessage.get_channel_request = field 1 (varint, 1-based channel index). */
-    fun buildGetChannelRequest(channelIndex: Int): ByteArray {
+    fun buildGetChannelRequest(myNodeNum: UInt, channelIndex: Int): ByteArray {
         val admin = ByteArrayOutputStream().apply {
             // Index in get_channel_request is 1-based; channel 0 is requested as 1.
             val zeroBased = channelIndex.coerceAtLeast(0)
             MeshWire.appendVarintField(this, field = 1, value = (zeroBased + 1).toULong())
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     // endregion
 
     /** Build `set_config { lora { use_preset = true, modem_preset = ... } }`. */
-    fun buildSetLoraPreset(preset: MeshChannelPreset): ByteArray {
+    fun buildSetLoraPreset(myNodeNum: UInt, preset: MeshChannelPreset): ByteArray {
         // LoRaConfig.use_preset = field 1 (bool), modem_preset = field 2 (enum).
         val loraConfig = ByteArrayOutputStream().apply {
             MeshWire.appendVarintField(this, field = 1, value = 1UL)
@@ -287,7 +288,7 @@ object AdminMessageSerializer {
             MeshWire.appendVarint(this, config.size.toULong())
             write(config)
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     /**
@@ -310,6 +311,7 @@ object AdminMessageSerializer {
      * radio's current region untouched.
      */
     fun buildSetLoRaConfig(
+        myNodeNum: UInt,
         region: MeshRegion,
         modemPreset: MeshChannelPreset,
         usePreset: Boolean = true,
@@ -342,7 +344,7 @@ object AdminMessageSerializer {
             MeshWire.appendVarint(this, config.size.toULong())
             write(config)
         }.toByteArray()
-        return wrapToRadio(admin)
+        return wrapToRadio(admin, myNodeNum)
     }
 
     // endregion
@@ -408,16 +410,20 @@ object AdminMessageSerializer {
     /**
      * Wrap an AdminMessage byte blob into a fully-framed ToRadio.
      * Mirror of [AtakPluginSerializer.buildToRadio] but with portnum
-     * `ADMIN_APP` and `to = 0xFFFFFFFF` (broadcast) — the firmware
-     * routes admin payloads to the local radio when delivered on the
-     * admin channel. `wantAck` defaults to true so the operator gets
-     * a delivery signal we can surface in the UI later.
+     * `ADMIN_APP`, addressed to [myNodeNum] — the radio we are physically
+     * attached to. `wantAck` defaults to true so the operator gets a
+     * delivery signal we can surface in the UI later.
      */
-    private fun wrapToRadio(adminBytes: ByteArray): ByteArray = MeshWire.buildToRadio(
+    private fun wrapToRadio(adminBytes: ByteArray, myNodeNum: UInt): ByteArray = MeshWire.buildToRadio(
         portnum = PORTNUM_ADMIN_APP,
         payload = adminBytes,
-        // Broadcast addr — firmware unwraps admin payloads locally.
-        to = MeshWire.BROADCAST_ADDR,
+        // #185 — addressed to the local radio, never broadcast. The firmware's
+        // AdminModule only acts on packets addressed to the node itself, so a
+        // broadcast admin frame is silently ignored *and* put on the air —
+        // which for set_channel means transmitting the channel PSK under
+        // whatever key is currently in use. Every reference client addresses
+        // admin to myNodeNum.
+        to = myNodeNum,
         // want_response + want_ack so the radio sends a delivery signal
         // we can surface in the UI later.
         wantAck = true,

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AdminMessageSerializer.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/AdminMessageSerializer.kt
@@ -29,6 +29,12 @@ import java.io.ByteArrayOutputStream
  */
 object AdminMessageSerializer {
 
+    /** nanopb `User.long_name` is char[40] — 39 bytes plus the NUL. */
+    private const val MAX_LONG_NAME_BYTES = 39
+
+    /** nanopb `User.short_name` is char[5] — 4 bytes plus the NUL. */
+    private const val MAX_SHORT_NAME_BYTES = 4
+
     /** Meshtastic portnum for AdminMessage payloads on the local radio. */
     private const val PORTNUM_ADMIN_APP: ULong = 6UL
 
@@ -368,10 +374,10 @@ object AdminMessageSerializer {
         val out = ByteArrayOutputStream()
         // 1: id (string) — only when the caller supplied one.
         appendString(out, field = 1, value = id)
-        // 2: long_name (string, max ~40 chars)
-        appendString(out, field = 2, value = longName.take(39))
-        // 3: short_name (string, max 4 chars per firmware constraint)
-        appendString(out, field = 3, value = shortName.take(4))
+        // 2: long_name — nanopb char[40], so 39 usable bytes.
+        appendString(out, field = 2, value = clampUtf8(longName, MAX_LONG_NAME_BYTES))
+        // 3: short_name — nanopb char[5], so 4 usable bytes.
+        appendString(out, field = 3, value = clampUtf8(shortName, MAX_SHORT_NAME_BYTES))
         // 6: is_licensed (bool) — omit the proto3 default (false).
         if (isLicensed) MeshWire.appendVarintField(out, field = 6, value = 1UL)
         return out.toByteArray()
@@ -437,6 +443,38 @@ object AdminMessageSerializer {
     // region Wire helpers — see [MeshWire] ------------------------------
 
     /** proto3 skip-default semantics: omit empty strings entirely. */
+    /**
+     * Clamp [value] to [maxBytes] of UTF-8, cutting only on a character
+     * boundary.
+     *
+     * The firmware stores these names in fixed nanopb buffers, so the limit is
+     * bytes — `String.take(n)` counts UTF-16 units, and 39 Chinese characters
+     * is 117 bytes. Over-long or half-a-character input makes nanopb reject the
+     * field and drop the entire AdminMessage, so the rename silently does
+     * nothing rather than failing loudly.
+     *
+     * Cuts on code points, which keeps surrogate pairs intact. A ZWJ emoji
+     * sequence can still be split into its parts — that stays valid UTF-8 and
+     * renders as separate glyphs, which beats dropping the write.
+     */
+    internal fun clampUtf8(value: String, maxBytes: Int): String {
+        if (value.toByteArray(Charsets.UTF_8).size <= maxBytes) return value
+        val out = StringBuilder()
+        var used = 0
+        var i = 0
+        while (i < value.length) {
+            val codePoint = value.codePointAt(i)
+            val width = Character.charCount(codePoint)
+            val piece = value.substring(i, i + width)
+            val size = piece.toByteArray(Charsets.UTF_8).size
+            if (used + size > maxBytes) break
+            out.append(piece)
+            used += size
+            i += width
+        }
+        return out.toString()
+    }
+
     private fun appendString(out: ByteArrayOutputStream, field: Int, value: String) {
         if (value.isEmpty()) return
         MeshWire.appendString(out, field = field, value = value)

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
@@ -491,18 +491,21 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
      */
     suspend fun requestDeviceConfig(): Int {
         val transport = _activeTransport.value ?: return 0
+        // #185 — admin frames are addressed to the attached radio, so we
+        // cannot build one until it has told us its node number.
+        val dest = adminDestination() ?: return 0
         // GAP-123 — ask for all 8 channel slots (Meshtastic firmware caps
         // at 8). Disabled slots come back with role=0 and are filtered
         // out at the chat seeding layer; non-disabled ones become chat
         // conversations with the operator's actual channel names.
         val channelRequests = (0 until 8).map { idx ->
-            AdminMessageSerializer.buildGetChannelRequest(idx)
+            AdminMessageSerializer.buildGetChannelRequest(dest, idx)
         }
         val requests = listOf(
-            AdminMessageSerializer.buildGetOwnerRequest(),
-            AdminMessageSerializer.buildGetConfigRequest(GET_CONFIG_DEVICE),
-            AdminMessageSerializer.buildGetConfigRequest(GET_CONFIG_POSITION),
-            AdminMessageSerializer.buildGetConfigRequest(GET_CONFIG_LORA),
+            AdminMessageSerializer.buildGetOwnerRequest(dest),
+            AdminMessageSerializer.buildGetConfigRequest(dest, GET_CONFIG_DEVICE),
+            AdminMessageSerializer.buildGetConfigRequest(dest, GET_CONFIG_POSITION),
+            AdminMessageSerializer.buildGetConfigRequest(dest, GET_CONFIG_LORA),
         ) + channelRequests
         var sent = 0
         for (bytes in requests) {
@@ -607,13 +610,14 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
      */
     suspend fun pushDeviceConfig(config: MeshDeviceConfig): Int {
         val transport = _activeTransport.value ?: return 0
+        val dest = adminDestination() ?: return 0
 
         val messages = listOf(
-            AdminMessageSerializer.buildSetOwner(config.longName, config.shortName),
-            AdminMessageSerializer.buildSetDeviceRole(config.role),
-            AdminMessageSerializer.buildSetPositionBroadcastSecs(config.positionBroadcastSecs),
-            AdminMessageSerializer.buildSetChannel0Name(config.channelName),
-            AdminMessageSerializer.buildSetLoraPreset(config.channelPreset),
+            AdminMessageSerializer.buildSetOwner(dest, config.longName, config.shortName),
+            AdminMessageSerializer.buildSetDeviceRole(dest, config.role),
+            AdminMessageSerializer.buildSetPositionBroadcastSecs(dest, config.positionBroadcastSecs),
+            AdminMessageSerializer.buildSetChannel0Name(dest, config.channelName),
+            AdminMessageSerializer.buildSetLoraPreset(dest, config.channelPreset),
         )
         var sent = 0
         for (bytes in messages) {
@@ -632,14 +636,14 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
      * `set_channel` AdminMessage. Returns true on wire-layer dispatch.
      */
     suspend fun applyChannel(channel: MeshChannel, index: Int = 0): Boolean =
-        dispatchAdmin(AdminMessageSerializer.buildSetChannel(channel, index))
+        dispatchAdmin { dest -> AdminMessageSerializer.buildSetChannel(dest, channel, index) }
 
     /**
      * #172 — set the radio's rebroadcast scope (PatoG1899's "known channels
      * only"). Returns true on wire-layer dispatch.
      */
     suspend fun applyRebroadcastMode(mode: RebroadcastMode): Boolean =
-        dispatchAdmin(AdminMessageSerializer.buildSetRebroadcastMode(mode))
+        dispatchAdmin { dest -> AdminMessageSerializer.buildSetRebroadcastMode(dest, mode) }
 
     /**
      * #181 — set the radio's LoRa region + modem preset in one admin write
@@ -652,7 +656,7 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
         preset: MeshChannelPreset,
         usePreset: Boolean = true,
     ): Boolean =
-        dispatchAdmin(AdminMessageSerializer.buildSetLoRaConfig(region, preset, usePreset))
+        dispatchAdmin { dest -> AdminMessageSerializer.buildSetLoRaConfig(dest, region, preset, usePreset) }
 
     /**
      * #181 — set the radio's owner (display name) via `set_owner { User }`.
@@ -664,15 +668,33 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
         shortName: String,
         isLicensed: Boolean = false,
     ): Boolean =
-        dispatchAdmin(AdminMessageSerializer.buildSetOwner(longName, shortName, isLicensed = isLicensed))
+        dispatchAdmin { dest -> AdminMessageSerializer.buildSetOwner(dest, longName, shortName, isLicensed = isLicensed) }
 
-    /** Dispatch one already-framed ToRadio admin blob over the active transport. */
-    private suspend fun dispatchAdmin(toRadio: ByteArray): Boolean =
-        when (_activeTransport.value) {
+    /**
+     * #185 — the destination for an admin write: the node number of the radio
+     * we are attached to. Null until the radio has reported it (`my_node_num`
+     * arrives early in the FromRadio config stream). Broadcast is never a
+     * valid admin destination — the firmware ignores it and the frame goes on
+     * the air — so callers must refuse to send rather than fall back.
+     */
+    private fun adminDestination(): UInt? = _myNodeNum?.takeIf { it != 0u && it != BROADCAST_ADDR }
+
+    /**
+     * Frame one admin message for the attached radio and dispatch it over the
+     * active transport. [build] runs only once a destination is known.
+     */
+    private suspend fun dispatchAdmin(build: (UInt) -> ByteArray): Boolean {
+        val dest = adminDestination() ?: run {
+            Log.w(TAG, "admin write skipped — radio has not reported my_node_num yet")
+            return false
+        }
+        val toRadio = build(dest)
+        return when (_activeTransport.value) {
             MeshConnectionType.TCP -> tcpClient.sendBytes(toRadio)
             MeshConnectionType.BLUETOOTH -> bleClient?.sendToRadio(toRadio) ?: false
             null -> false
         }
+    }
 
     companion object {
         private const val TAG = "MeshtasticManager"

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/AdminAddressingTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/AdminAddressingTest.kt
@@ -1,0 +1,107 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * #185 — admin messages must be addressed to the local radio.
+ *
+ * PatoG's field report: settings applied in-app never take effect on the
+ * radio. Every admin frame was wrapped with `to = 0xFFFFFFFF` (broadcast) on
+ * the theory that "the firmware unwraps admin payloads locally". It does not.
+ * A working reference client (meshsat-android) addresses every admin call to
+ * `myNodeNum`, and the firmware's AdminModule only acts on packets addressed
+ * to the node itself.
+ *
+ * Broadcasting also puts the payload on the air — for `set_channel` that is
+ * the channel PSK, transmitted under whatever key is currently in use.
+ */
+class AdminAddressingTest {
+
+    /** `MeshPacket.to` — mesh.proto field 2, fixed32, little-endian. */
+    private fun meshPacketTo(frame: ByteArray): UInt? {
+        // ToRadio { packet = 1 (len-delimited) } → MeshPacket { to = 2 (fixed32) }
+        var i = 0
+        while (i < frame.size) {
+            val tag = frame[i].toInt() and 0xFF
+            if (tag == 0x0A) { // field 1, wire 2 — ToRadio.packet
+                var len = 0; var shift = 0; var j = i + 1
+                while (j < frame.size) {
+                    val b = frame[j].toInt() and 0xFF
+                    len = len or ((b and 0x7F) shl shift); j++
+                    if (b and 0x80 == 0) break
+                    shift += 7
+                }
+                val packet = frame.copyOfRange(j, minOf(j + len, frame.size))
+                var k = 0
+                while (k + 4 < packet.size) {
+                    if ((packet[k].toInt() and 0xFF) == 0x15) { // field 2, wire 5
+                        return ((packet[k + 1].toInt() and 0xFF).toUInt()) or
+                            ((packet[k + 2].toInt() and 0xFF).toUInt() shl 8) or
+                            ((packet[k + 3].toInt() and 0xFF).toUInt() shl 16) or
+                            ((packet[k + 4].toInt() and 0xFF).toUInt() shl 24)
+                    }
+                    k++
+                }
+                return null
+            }
+            i++
+        }
+        return null
+    }
+
+    private val myNodeNum = 0x336699AAu
+    private val broadcast = 0xFFFFFFFFu
+
+    /** Every admin frame the app can build, keyed by name for failure output. */
+    private fun allAdminFrames(): Map<String, ByteArray> {
+        val channel = MeshChannel(name = "OmniTAK", psk = ByteArray(16) { it.toByte() })
+        return mapOf(
+            "set_channel" to AdminMessageSerializer.buildSetChannel(myNodeNum, channel, index = 0),
+            "set_channel0_name" to AdminMessageSerializer.buildSetChannel0Name(myNodeNum, "OmniTAK"),
+            "set_owner" to AdminMessageSerializer.buildSetOwner(myNodeNum, "Pato Golf", "PATO"),
+            "set_device_role" to AdminMessageSerializer.buildSetDeviceRole(myNodeNum, MeshRole.TAK),
+            "set_rebroadcast_mode" to AdminMessageSerializer.buildSetRebroadcastMode(myNodeNum, RebroadcastMode.KNOWN_ONLY),
+            "set_position_secs" to AdminMessageSerializer.buildSetPositionBroadcastSecs(myNodeNum, 900),
+            "set_lora_preset" to AdminMessageSerializer.buildSetLoraPreset(myNodeNum, MeshChannelPreset.LONG_FAST),
+            "set_lora_config" to AdminMessageSerializer.buildSetLoRaConfig(myNodeNum, MeshRegion.US, MeshChannelPreset.LONG_FAST),
+            "get_owner" to AdminMessageSerializer.buildGetOwnerRequest(myNodeNum),
+            "get_config" to AdminMessageSerializer.buildGetConfigRequest(myNodeNum, 0),
+            "get_channel" to AdminMessageSerializer.buildGetChannelRequest(myNodeNum, 0),
+        )
+    }
+
+    @Test
+    fun `every admin message is addressed to the local radio`() {
+        for ((name, frame) in allAdminFrames()) {
+            assertEquals(
+                "$name must be addressed to myNodeNum — the firmware's AdminModule " +
+                    "only acts on packets addressed to the node itself",
+                myNodeNum,
+                meshPacketTo(frame),
+            )
+        }
+    }
+
+    @Test
+    fun `no admin message goes to the broadcast address`() {
+        for ((name, frame) in allAdminFrames()) {
+            assertNotEquals(
+                "$name must never be broadcast — it goes on the air, and for " +
+                    "set_channel that is the channel PSK",
+                broadcast,
+                meshPacketTo(frame),
+            )
+        }
+    }
+
+    @Test
+    fun `destination is carried verbatim, not truncated or byte-swapped`() {
+        // A node number with a high bit set and all four bytes distinct catches
+        // sign extension and endianness slips in the fixed32 encoding.
+        val awkward = 0xFF01A27Bu
+        val frame = AdminMessageSerializer.buildGetOwnerRequest(awkward)
+        assertEquals(awkward, meshPacketTo(frame))
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/ChannelApplyEncoderTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/ChannelApplyEncoderTest.kt
@@ -13,6 +13,10 @@ import org.junit.Test
  */
 class ChannelApplyEncoderTest {
 
+    /** #185 — admin frames are addressed to the attached radio. Value is
+     *  irrelevant to these byte-layout assertions, but must be supplied. */
+    private val myNodeNum = 0x12345678u
+
     // region helpers ------------------------------------------------------
 
     private fun ByteArray.hex(): String = joinToString("") { "%02x".format(it) }
@@ -36,7 +40,7 @@ class ChannelApplyEncoderTest {
         val psk = ByteArray(16) { (it * 7 + 3).toByte() }
         val channel = MeshChannel(name = "OmniTAK", psk = psk)
 
-        val frame = AdminMessageSerializer.buildSetChannel(channel, index = 0)
+        val frame = AdminMessageSerializer.buildSetChannel(myNodeNum, channel, index = 0)
 
         // Ground-truth admin bytes (computed from admin/channel.proto field
         // numbers): set_channel=33 (tag 8a 02), Channel{ settings=2{ psk=2,
@@ -53,7 +57,7 @@ class ChannelApplyEncoderTest {
     @Test
     fun `Meshtastic set_channel at non-zero index sets SECONDARY role and index`() {
         val psk = ByteArray(16) { it.toByte() }
-        val frame = AdminMessageSerializer.buildSetChannel(MeshChannel(name = "Cmd", psk = psk), index = 2)
+        val frame = AdminMessageSerializer.buildSetChannel(myNodeNum, MeshChannel(name = "Cmd", psk = psk), index = 2)
 
         // Channel.index = 1 (varint) = 2, Channel.role = 3 (varint) = SECONDARY(2).
         // index field present: tag 08 02; role field: tag 18 02.
@@ -65,7 +69,7 @@ class ChannelApplyEncoderTest {
 
     @Test
     fun `Meshtastic set_config rebroadcast KNOWN_ONLY encodes enum 3`() {
-        val frame = AdminMessageSerializer.buildSetRebroadcastMode(RebroadcastMode.KNOWN_ONLY)
+        val frame = AdminMessageSerializer.buildSetRebroadcastMode(myNodeNum, RebroadcastMode.KNOWN_ONLY)
 
         // set_config=34 (tag 92 02), Config.device=1{ rebroadcast_mode=6 = 3 }.
         val expected = "9202040a023003".chunked(2).map { it.toInt(16).toByte() }.toByteArray()
@@ -84,7 +88,7 @@ class ChannelApplyEncoderTest {
 
     @Test
     fun `set_config LoRa US LONG_FAST encodes use_preset and region with default preset omitted`() {
-        val frame = AdminMessageSerializer.buildSetLoRaConfig(
+        val frame = AdminMessageSerializer.buildSetLoRaConfig(myNodeNum, 
             region = MeshRegion.US,
             modemPreset = MeshChannelPreset.LONG_FAST,
         )
@@ -98,7 +102,7 @@ class ChannelApplyEncoderTest {
 
     @Test
     fun `set_config LoRa EU868 MEDIUM_FAST encodes preset 4 and region 3`() {
-        val frame = AdminMessageSerializer.buildSetLoRaConfig(
+        val frame = AdminMessageSerializer.buildSetLoRaConfig(myNodeNum, 
             region = MeshRegion.EU_868,
             modemPreset = MeshChannelPreset.MEDIUM_FAST,
         )
@@ -111,7 +115,7 @@ class ChannelApplyEncoderTest {
 
     @Test
     fun `set_config LoRa with UNSET region omits the region field`() {
-        val frame = AdminMessageSerializer.buildSetLoRaConfig(
+        val frame = AdminMessageSerializer.buildSetLoRaConfig(myNodeNum, 
             region = MeshRegion.UNSET,
             modemPreset = MeshChannelPreset.SHORT_FAST,
         )
@@ -141,7 +145,7 @@ class ChannelApplyEncoderTest {
 
     @Test
     fun `set_owner encodes long and short name with correct tags`() {
-        val frame = AdminMessageSerializer.buildSetOwner(longName = "OmniTAK", shortName = "OTK")
+        val frame = AdminMessageSerializer.buildSetOwner(myNodeNum, longName = "OmniTAK", shortName = "OTK")
 
         // set_owner=32 (tag 82 02), User{ long_name=2 (12 07 "OmniTAK"),
         // short_name=3 (1a 03 "OTK") }. id blank + is_licensed false omitted.
@@ -152,7 +156,7 @@ class ChannelApplyEncoderTest {
 
     @Test
     fun `set_owner with is_licensed sets bool field 6`() {
-        val frame = AdminMessageSerializer.buildSetOwner(
+        val frame = AdminMessageSerializer.buildSetOwner(myNodeNum, 
             longName = "W1AW",
             shortName = "W1AW",
             isLicensed = true,
@@ -167,7 +171,7 @@ class ChannelApplyEncoderTest {
 
     @Test
     fun `set_owner truncates short name to 4 chars`() {
-        val frame = AdminMessageSerializer.buildSetOwner(longName = "Node", shortName = "TOOLONG")
+        val frame = AdminMessageSerializer.buildSetOwner(myNodeNum, longName = "Node", shortName = "TOOLONG")
 
         // short_name field 3 must carry exactly 4 bytes: tag 1a, len 04, "TOOL".
         val shortField = ("1a04" + "TOOL".toByteArray().joinToString("") { "%02x".format(it) })

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/OwnerNameClampTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/OwnerNameClampTest.kt
@@ -1,0 +1,110 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `set_owner` names are clamped in **bytes**, not UTF-16 units.
+ *
+ * The firmware stores `long_name` in a nanopb `char[40]` and `short_name` in a
+ * `char[5]` — 39 and 4 usable bytes. `String.take(39)` counts UTF-16 code
+ * units, so 39 Chinese characters is ~117 bytes; nanopb rejects the field and
+ * drops the whole AdminMessage, and the rename silently does nothing. That
+ * lands on the zh-Hant users first.
+ *
+ * Clamping must also land on a character boundary — half a multi-byte
+ * character is invalid UTF-8 and nanopb rejects that too.
+ */
+class OwnerNameClampTest {
+
+    private val myNodeNum = 0x12345678u
+
+    /** UTF-8 byte length of the length-delimited string at [field] inside the
+     *  User submessage of a set_owner frame. */
+    private fun ownerFieldBytes(frame: ByteArray, field: Int): ByteArray? {
+        // AdminMessage.set_owner = field 32, wire 2 → tag varint 0x102 = "82 02".
+        var i = 0
+        while (i + 1 < frame.size) {
+            if ((frame[i].toInt() and 0xFF) == 0x82 && (frame[i + 1].toInt() and 0xFF) == 0x02) {
+                var j = i + 2
+                var len = 0; var shift = 0
+                while (j < frame.size) {
+                    val b = frame[j].toInt() and 0xFF; j++
+                    len = len or ((b and 0x7F) shl shift)
+                    if (b and 0x80 == 0) break
+                    shift += 7
+                }
+                val owner = frame.copyOfRange(j, minOf(j + len, frame.size))
+                var k = 0
+                while (k < owner.size) {
+                    val tag = owner[k].toInt() and 0xFF
+                    val f = tag shr 3
+                    k++
+                    var l = 0; var sh = 0
+                    while (k < owner.size) {
+                        val b = owner[k].toInt() and 0xFF; k++
+                        l = l or ((b and 0x7F) shl sh)
+                        if (b and 0x80 == 0) break
+                        sh += 7
+                    }
+                    if ((tag and 0x07) != 2) return null
+                    val value = owner.copyOfRange(k, minOf(k + l, owner.size))
+                    if (f == field) return value
+                    k += l
+                }
+                return null
+            }
+            i++
+        }
+        return null
+    }
+
+    @Test
+    fun `a long CJK name is clamped to 39 bytes, not 39 characters`() {
+        val cjk = "台".repeat(39) // 39 chars, 117 UTF-8 bytes
+        val frame = AdminMessageSerializer.buildSetOwner(myNodeNum, cjk, "TW")
+
+        val encoded = ownerFieldBytes(frame, field = 2)
+        requireNotNull(encoded) { "long_name not found in frame" }
+
+        assertTrue(
+            "long_name must fit the firmware's 39 usable bytes; got ${encoded.size}",
+            encoded.size <= 39,
+        )
+    }
+
+    @Test
+    fun `clamping lands on a character boundary`() {
+        val cjk = "台".repeat(39)
+        val frame = AdminMessageSerializer.buildSetOwner(myNodeNum, cjk, "TW")
+        val encoded = ownerFieldBytes(frame, field = 2)!!
+
+        // 3 bytes each — 13 whole characters is exactly 39 bytes.
+        assertEquals("台".repeat(13), String(encoded, Charsets.UTF_8))
+        assertEquals(
+            "a mid-character cut is invalid UTF-8 and nanopb drops the message",
+            encoded.toList(),
+            String(encoded, Charsets.UTF_8).toByteArray(Charsets.UTF_8).toList(),
+        )
+    }
+
+    @Test
+    fun `an emoji short name is not split across its surrogate pair`() {
+        val frame = AdminMessageSerializer.buildSetOwner(myNodeNum, "Drone Team", "🛩️X")
+        val encoded = ownerFieldBytes(frame, field = 3)!!
+
+        assertTrue("short_name must fit 4 bytes; got ${encoded.size}", encoded.size <= 4)
+        assertEquals(
+            encoded.toList(),
+            String(encoded, Charsets.UTF_8).toByteArray(Charsets.UTF_8).toList(),
+        )
+    }
+
+    @Test
+    fun `ascii names are unchanged`() {
+        val frame = AdminMessageSerializer.buildSetOwner(myNodeNum, "Pato Golf", "PATO")
+        assertEquals("Pato Golf", String(ownerFieldBytes(frame, 2)!!, Charsets.UTF_8))
+        assertEquals("PATO", String(ownerFieldBytes(frame, 3)!!, Charsets.UTF_8))
+    }
+}

--- a/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/PositionBroadcastFieldTest.kt
+++ b/app/src/test/kotlin/soy/engindearing/omnitak/mobile/data/PositionBroadcastFieldTest.kt
@@ -1,0 +1,64 @@
+package soy.engindearing.omnitak.mobile.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `PositionConfig.position_broadcast_secs` is field **1**, not field 4.
+ *
+ * Field 4 is the deprecated `gps_enabled` bool. Writing a seconds value there
+ * sets a boolean and leaves the broadcast interval untouched, so the operator
+ * changes the PLI cadence and nothing happens. iOS has always used field 1;
+ * Android's serializer and parser both used 4, which is why the two platforms
+ * disagreed. Canonical config.proto:
+ *
+ *   uint32 position_broadcast_secs = 1;
+ *   bool   position_broadcast_smart_enabled = 2;
+ *   bool   fixed_position = 3;
+ *   bool   gps_enabled = 4;
+ */
+class PositionBroadcastFieldTest {
+
+    private val myNodeNum = 0x12345678u
+
+    private fun ByteArray.hex(): String = joinToString("") { "%02x".format(it) }
+
+    private fun ByteArray.containsBytes(needle: ByteArray): Boolean {
+        if (needle.isEmpty() || needle.size > size) return false
+        outer@ for (start in 0..size - needle.size) {
+            for (i in needle.indices) if (this[start + i] != needle[i]) continue@outer
+            return true
+        }
+        return false
+    }
+
+    private fun hexBytes(s: String): ByteArray =
+        s.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    @Test
+    fun `position broadcast interval is written to field 1`() {
+        val frame = AdminMessageSerializer.buildSetPositionBroadcastSecs(myNodeNum, 900)
+
+        // set_config=34 (tag 92 02) { position=2 (tag 12) { field 1 varint 900 = 08 84 07 } }
+        val expected = hexBytes("9202051203088407")
+
+        assertTrue(
+            "position_broadcast_secs must be field 1; got ${frame.hex()}",
+            frame.containsBytes(expected),
+        )
+    }
+
+    @Test
+    fun `nothing is written to deprecated gps_enabled at field 4`() {
+        val frame = AdminMessageSerializer.buildSetPositionBroadcastSecs(myNodeNum, 900)
+
+        // The same envelope but with the inner tag 0x20 (field 4, varint).
+        val deprecated = hexBytes("9202051203208407")
+
+        assertFalse(
+            "writing seconds into gps_enabled (field 4) silently does nothing; got ${frame.hex()}",
+            frame.containsBytes(deprecated),
+        )
+    }
+}


### PR DESCRIPTION
Three verified bugs in the Meshtastic admin-write path, found while porting device config to iOS (OmniTAK-iOS #112). Together they are the likely root cause of #185 (in-app channel create/set does not take effect on the radio).

**1. Admin messages were broadcast, not addressed to the local radio.** `wrapToRadio` set `to = BROADCAST_ADDR`. The firmware's AdminModule only acts on packets addressed to the node itself, so every admin write (set_channel, set_owner, set_config, all the get requests) was silently ignored, and the frame went out over the air. For `set_channel` that also meant transmitting the new channel PSK under whatever key was currently in use. Now every builder takes `myNodeNum` and addresses the attached radio; `MeshtasticManager` refuses to build admin frames until the radio has reported its node number.

**2. `position_broadcast_secs` was written to PositionConfig field 4, which is the deprecated `gps_enabled` bool.** The canonical field is 1. Writing seconds to field 4 set a boolean and left the PLI cadence untouched, so the position-interval setting has never done anything. Serializer and parser both fixed.

**3. `longName.take(39)` / `shortName.take(4)` counted UTF-16 units, not bytes.** The firmware stores names in nanopb `char[40]` / `char[5]` buffers. A 39-character Chinese long name is ~117 bytes; nanopb rejects the field and drops the whole AdminMessage, so the rename silently no-ops. Hits zh-Hant users directly. New `clampUtf8` cuts on code-point boundaries within the byte budget.

Tests: `AdminAddressingTest` (every builder addresses myNodeNum, never broadcast), `PositionBroadcastFieldTest` (field 1 round-trip), `OwnerNameClampTest` (byte budgets, surrogate pairs, CJK), plus updated `ChannelApplyEncoderTest`.

After merge: ask PatoG to re-test in-app channel set on his radios (#185); this replaces the firmware-version theory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WAVhkGcMB2GxrkCjXbxKd