### PR TITLE
chore(release): OmniTAK Android 0.42.2 (versionCode 107)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "soy.engindearing.omnitak.mobile"
         minSdk = 26
         targetSdk = 36
-        versionCode = 106
-        versionName = "0.42.1"
+        versionCode = 107
+        versionName = "0.42.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }


### PR DESCRIPTION
## Why 0.42.2 / vc107

The #185 root-cause fix (#191) is on main but not in any release. A field tester is waiting to re-test in-app channel set on his radios, and the fix also stops new channel PSKs going over the air during a broadcast set_channel.

## This PR
- `versionName` **0.42.1 → 0.42.2**, `versionCode` **106 → 107**
- Content delta over 0.42.1 = #191 (Meshtastic admin-write fixes) + PARITY.md audit (#194). targetSdk stays 36.

## Artifacts
Signed AAB staged at 0.42.2/vc107 for the Play track. Signed APK attaches to the GitHub v0.42.2 release for sideloaders.

Note: the vc107 AAB is 246M vs vc106's 60M — the delta is entirely `BUNDLE-METADATA` native debug symbols (`libmaplibre.so.dbg` x4 ABIs), extracted correctly for the first time now that NDK 28.2.13676358 is installed (the May config intended this all along). Device download size is unchanged; Play consumes the symbols for native crash reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WAVhkGcMB2GxrkCjXbxKd