### PR TITLE
QoL: BLE auto-reconnect, mesh node age, floating map toolbar + top-bar toggle

### DIFF
--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/OmniTAKApp.kt
@@ -126,6 +126,14 @@ class OmniTAKApp : Application() {
                     server != null && meshUp -> "${server.serverName} + mesh"
                     server != null -> server.serverName
                     meshUp -> "mesh radio"
+                    // Field feedback (2026-08) — link dropped (radio power-off /
+                    // out of range) but the BLE auto-reconnect loop is still
+                    // trying every 20s. Keeping a label here is what keeps the
+                    // FGS alive below, which in turn is what keeps that retry
+                    // loop running once the screen locks — without it Doze
+                    // stalls the delay()/BLE calls and reconnect silently stops
+                    // working the moment the app leaves the foreground.
+                    meshtastic.autoReconnectPending.value -> "reconnecting to mesh radio…"
                     else -> null
                 }
             }
@@ -133,10 +141,15 @@ class OmniTAKApp : Application() {
                 serverManager.connectionState,
                 meshtastic.activeConnectionState,
                 meshcore.activeConnectionState,
-            ) { server, mesh, meshCore ->
+                meshtastic.autoReconnectPending,
+            ) { server, mesh, meshCore, meshReconnectPending ->
                 val states = listOf(server, mesh, meshCore)
                 when {
                     states.any { it is ConnectionState.Connected } -> FgsWant.START
+                    // A BLE radio dropped but we're still retrying it —
+                    // start (or keep) the FGS so the retry loop survives
+                    // Doze instead of stalling until the app is foregrounded.
+                    meshReconnectPending -> FgsWant.START
                     // Connecting / Failed hold the service as before — a
                     // transient reconnect must not bounce the FGS.
                     states.all { it is ConnectionState.Disconnected } -> FgsWant.STOP

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/data/UserPrefs.kt
@@ -133,6 +133,15 @@ data class UserPrefs(
     val toolbarItemIds: List<String> = emptyList(),
     /** One-time flag for the "press & hold to customize" coachmark. */
     val toolbarCoachmarkSeen: Boolean = false,
+    /** Auto-hide the bottom toolbar on the map tab after 3s of inactivity,
+     *  tap the bottom edge to reveal it again. Default on — favors map real
+     *  estate. Only applies on the map tab; every other tab always shows it
+     *  (it's the only way to navigate away). */
+    val autoHideToolbar: Boolean = true,
+    /** Show the top status row (server name, msg counters, GPS accuracy,
+     *  clock) on the map. When off, only the small TAK server connection
+     *  dot stays visible — that indicator is never hidden by this toggle. */
+    val topInfoBarVisible: Boolean = true,
     // Camera persistence — last map view the operator panned/zoomed to.
     // All three must be non-null together to constitute a valid saved view.
     // Null on first install (fresh device → self-fix or global fallback).
@@ -197,6 +206,8 @@ class UserPrefsStore(private val context: Context) {
     private val KEY_CESIUM_GLOBE = booleanPreferencesKey("cesium_globe_enabled")
     private val KEY_TOOLBAR_ITEMS = stringPreferencesKey("toolbar_item_ids")
     private val KEY_TOOLBAR_COACH = booleanPreferencesKey("toolbar_coachmark_seen")
+    private val KEY_AUTO_HIDE_TOOLBAR = booleanPreferencesKey("auto_hide_toolbar")
+    private val KEY_TOP_INFO_BAR = booleanPreferencesKey("top_info_bar_visible")
     // Camera persistence keys (issue: map resets to Spokane on cold start)
     private val KEY_CAMERA_LAT  = stringPreferencesKey("last_camera_lat")
     private val KEY_CAMERA_LON  = stringPreferencesKey("last_camera_lon")
@@ -245,6 +256,8 @@ class UserPrefsStore(private val context: Context) {
             p[KEY_CESIUM_GLOBE] = next.cesiumGlobeEnabled
             p[KEY_TOOLBAR_ITEMS] = next.toolbarItemIds.joinToString(",")
             p[KEY_TOOLBAR_COACH] = next.toolbarCoachmarkSeen
+            p[KEY_AUTO_HIDE_TOOLBAR] = next.autoHideToolbar
+            p[KEY_TOP_INFO_BAR] = next.topInfoBarVisible
             // Camera persistence — write only when the value is present so a
             // null (first install) doesn't clobber a previously saved view.
             if (next.lastCameraLat != null)  p[KEY_CAMERA_LAT]  = next.lastCameraLat.toString()
@@ -376,6 +389,8 @@ class UserPrefsStore(private val context: Context) {
         cesiumGlobeEnabled = p[KEY_CESIUM_GLOBE] ?: false,
         toolbarItemIds = p[KEY_TOOLBAR_ITEMS]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),
         toolbarCoachmarkSeen = p[KEY_TOOLBAR_COACH] ?: false,
+        autoHideToolbar = p[KEY_AUTO_HIDE_TOOLBAR] ?: true,
+        topInfoBarVisible = p[KEY_TOP_INFO_BAR] ?: true,
         lastCameraLat  = p[KEY_CAMERA_LAT]?.toDoubleOrNull(),
         lastCameraLon  = p[KEY_CAMERA_LON]?.toDoubleOrNull(),
         lastCameraZoom = p[KEY_CAMERA_ZOOM]?.toDoubleOrNull(),

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/domain/MeshtasticManager.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -86,6 +87,43 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
     private var bytesRx: Long = 0L
     @Volatile private var _myNodeNum: UInt? = null
     val myNodeNum: UInt? get() = _myNodeNum
+
+    /** BLE auto-reconnect — the address [connectBle] was last asked to
+     *  reach. Non-null keeps [ensureReconnectLoopStarted]'s loop retrying
+     *  every [BLE_RECONNECT_INTERVAL_MS] whenever we're not connected; cleared
+     *  by a user-initiated [disconnect] so tapping "Disconnect" doesn't
+     *  immediately reconnect. Survives an involuntary drop (radio
+     *  power-off / out of range) so it resumes once back in range. */
+    private val _reconnectTargetAddress = MutableStateFlow<String?>(null)
+    private var reconnectTargetAddress: String?
+        get() = _reconnectTargetAddress.value
+        set(value) { _reconnectTargetAddress.value = value }
+    private var reconnectLoopStarted = false
+
+    /** True whenever the BLE auto-reconnect loop has a radio it's trying
+     *  to reach. OmniTAKApp keeps the foreground service alive on this
+     *  signal alone — not just "Connected" — so Android's Doze mode
+     *  doesn't stall the reconnect loop's delay/BLE calls once the
+     *  screen turns off between retries. */
+    val autoReconnectPending: StateFlow<Boolean> =
+        _reconnectTargetAddress.map { it != null }
+            .stateIn(scope, SharingStarted.Eagerly, false)
+
+    private fun ensureReconnectLoopStarted() {
+        if (reconnectLoopStarted) return
+        reconnectLoopStarted = true
+        scope.launch {
+            while (true) {
+                delay(BLE_RECONNECT_INTERVAL_MS)
+                val target = reconnectTargetAddress ?: continue
+                if (_activeTransport.value != MeshConnectionType.BLUETOOTH) continue
+                val current = activeConnectionState.value
+                if (current is ConnectionState.Connected || current is ConnectionState.Connecting) continue
+                Log.i(TAG, "BLE auto-reconnect: retrying $target")
+                connectBle(target)
+            }
+        }
+    }
 
     /** #171 — last wall-clock ms a given marker uid was sent over mesh, for
      *  the per-uid send debounce. Guarded by its own monitor; the map can
@@ -178,6 +216,12 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
         if (_activeTransport.value == MeshConnectionType.TCP) disconnect()
         frameCollector?.cancel()
         _activeTransport.value = MeshConnectionType.BLUETOOTH
+        // Remember this address so the auto-reconnect loop keeps retrying
+        // it if the link drops (radio power-off / out of range) — covers
+        // both "was connected then lost" and "this very attempt failed
+        // because the radio isn't in range yet".
+        reconnectTargetAddress = deviceAddress
+        ensureReconnectLoopStarted()
         frameCollector = scope.launch {
             client.frames.collect { frame -> dispatchFrame(frame) }
         }
@@ -241,6 +285,11 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
         when (_activeTransport.value) {
             MeshConnectionType.TCP -> tcpClient.disconnect()
             MeshConnectionType.BLUETOOTH -> {
+                // User-initiated — stop the auto-reconnect loop from
+                // immediately reclaiming the link. An involuntary drop
+                // (radio power-off / out of range) never calls this, so
+                // reconnectTargetAddress stays set for that case.
+                reconnectTargetAddress = null
                 // Fire-and-forget — the BLE client's own scope handles
                 // the suspending teardown, and the connection observer
                 // flips state to Disconnected.
@@ -698,6 +747,9 @@ class MeshtasticManager(private val context: Context? = null) : MeshFrameworkMan
 
     companion object {
         private const val TAG = "MeshtasticManager"
+        /** How often the BLE auto-reconnect loop checks whether the last
+         *  radio is back in range. */
+        private const val BLE_RECONNECT_INTERVAL_MS: Long = 20_000
         private const val PORTNUM_TEXT_MESSAGE_APP = 1
         private const val PORTNUM_POSITION_APP = 3
         private const val PORTNUM_ADMIN_APP = 6

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ATAKStatusBar.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/components/ATAKStatusBar.kt
@@ -51,7 +51,25 @@ fun ATAKStatusBar(
     // "N/M ●●●" cluster so the operator can see at a glance how many of
     // their servers are live. Empty/size-1 falls back to the single dot.
     serverConnectedFlags: List<Boolean> = emptyList(),
+    // "Top info bar" settings toggle. False collapses this down to just the
+    // connection dot — the dot itself is never hidden by the toggle, only
+    // the server name / counters / GPS / clock / menu around it.
+    showDetails: Boolean = true,
 ) {
+    if (!showDetails) {
+        Row(
+            modifier = modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (serverConnectedFlags.size > 1) {
+                MultiServerIndicator(flags = serverConnectedFlags)
+            } else {
+                ConnectionDot(isConnected = isConnected)
+            }
+        }
+        return
+    }
+
     Row(
         modifier = modifier
             .fillMaxWidth()

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/navigation/AppNav.kt
@@ -1,7 +1,19 @@
 package soy.engindearing.omnitak.mobile.ui.navigation
 
 import android.view.WindowManager
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.graphics.Color
@@ -11,17 +23,21 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import soy.engindearing.omnitak.mobile.OmniTAKApp
 import soy.engindearing.omnitak.mobile.data.UserPrefs
@@ -96,6 +112,27 @@ fun AppNav() {
     var showAddPalette by remember { mutableStateOf(false) }
     var showKmlOverlays by remember { mutableStateOf(false) }
     var editing by remember { mutableStateOf(false) }
+
+    // Auto-hide toolbar (map tab only, default on) — favors map real
+    // estate. Shows on entering the map tab, hides after 3s; tapping the
+    // reveal strip at the bottom edge (added below, over the map content)
+    // bumps revealTrigger to show it again for another 3s. Every other
+    // tab always shows the toolbar unconditionally — it's the only way to
+    // navigate elsewhere, so hiding it there would strand the operator.
+    var toolbarVisible by remember { mutableStateOf(true) }
+    var revealTrigger by remember { mutableIntStateOf(0) }
+    val autoHideActive = prefs.autoHideToolbar && currentRoute == "map"
+    LaunchedEffect(autoHideActive, editing, revealTrigger) {
+        if (autoHideActive && !editing) {
+            toolbarVisible = true
+            delay(3_000)
+            toolbarVisible = false
+        } else {
+            // Off the map tab, feature disabled, or mid-customize edit —
+            // always visible, no hide timer.
+            toolbarVisible = true
+        }
+    }
 
     fun navigateTo(route: String) {
         nav.navigate(route) {
@@ -209,41 +246,60 @@ fun AppNav() {
         else -> Color(0xFF5A5F66)
     }
 
+    // Hoisted so it can render in two different places without repeating
+    // ten-odd parameters: reserving normal layout space in Scaffold's
+    // bottomBar on every non-map screen (so it doesn't cover their
+    // content), or floating as a non-space-reserving overlay on the map
+    // (below) so hiding/showing it never resizes — and therefore never
+    // re-layouts — the map surface underneath.
+    val toolbarContent: @Composable () -> Unit = {
+        CustomToolbar(
+            items = barItems,
+            currentRoute = currentRoute,
+            editing = editing,
+            coachmarkVisible = coachmarkVisible,
+            canAdd = workingIds.size < ToolbarCatalog.MAX_ITEMS,
+            canRemove = workingIds.size > ToolbarCatalog.MIN_ITEMS,
+            statusDots = mapOf("mesh" to meshDot),
+            onSelect = { dispatch(it) },
+            onEnterEdit = { enterEdit() },
+            onDoneEdit = {
+                editing = false
+                persistToolbar()
+            },
+            onRemove = { item ->
+                val next = workingIds.toMutableList().apply { remove(item.id) }
+                if (next.size >= ToolbarCatalog.MIN_ITEMS && ToolbarCatalog.hasDestination(next)) {
+                    workingIds.clear()
+                    workingIds.addAll(next)
+                }
+            },
+            onReorder = { from, to ->
+                if (from in workingIds.indices && to in workingIds.indices && from != to) {
+                    workingIds.add(to, workingIds.removeAt(from))
+                }
+            },
+            onAddTapped = { showAddPalette = true },
+            onDismissCoachmark = {
+                scope.launch { app.userPrefsStore.setToolbarCoachmarkSeen(true) }
+            },
+        )
+    }
+
     Scaffold(
         bottomBar = {
-            CustomToolbar(
-                items = barItems,
-                currentRoute = currentRoute,
-                editing = editing,
-                coachmarkVisible = coachmarkVisible,
-                canAdd = workingIds.size < ToolbarCatalog.MAX_ITEMS,
-                canRemove = workingIds.size > ToolbarCatalog.MIN_ITEMS,
-                statusDots = mapOf("mesh" to meshDot),
-                onSelect = { dispatch(it) },
-                onEnterEdit = { enterEdit() },
-                onDoneEdit = {
-                    editing = false
-                    persistToolbar()
-                },
-                onRemove = { item ->
-                    val next = workingIds.toMutableList().apply { remove(item.id) }
-                    if (next.size >= ToolbarCatalog.MIN_ITEMS && ToolbarCatalog.hasDestination(next)) {
-                        workingIds.clear()
-                        workingIds.addAll(next)
-                    }
-                },
-                onReorder = { from, to ->
-                    if (from in workingIds.indices && to in workingIds.indices && from != to) {
-                        workingIds.add(to, workingIds.removeAt(from))
-                    }
-                },
-                onAddTapped = { showAddPalette = true },
-                onDismissCoachmark = {
-                    scope.launch { app.userPrefsStore.setToolbarCoachmarkSeen(true) }
-                },
-            )
+            // The map route renders its own floating overlay copy below —
+            // nothing here, so Scaffold reserves zero bottom inset for it
+            // and the map always gets the full screen regardless of
+            // toolbar visibility. Every other route keeps the normal
+            // space-reserving bar so the toolbar never overlaps their
+            // (non-map, potentially scrollable-to-the-bottom) content.
+            if (currentRoute != "map") {
+                toolbarContent()
+            }
         },
     ) { inner: PaddingValues ->
+        Box(Modifier.fillMaxSize()) {
         NavHost(
             navController = nav,
             startDestination = "map",
@@ -351,6 +407,41 @@ fun AppNav() {
                     onBack = { nav.popBackStack() },
                 )
             }
+        }
+
+        // Floating overlay copy of the toolbar — map route only. Sits on
+        // top of the map instead of sharing layout space with it, so the
+        // auto-hide animation never changes the map's measured size (that
+        // resize was itself the visible "jump" — a translucent bar
+        // overlapping the map at the edge reads as intentional chrome,
+        // not a glitch).
+        if (currentRoute == "map") {
+            AnimatedVisibility(
+                visible = toolbarVisible,
+                modifier = Modifier.align(Alignment.BottomCenter),
+                enter = fadeIn(tween(150)) + slideInVertically(tween(150)) { it },
+                exit = fadeOut(tween(150)) + slideOutVertically(tween(150)) { it },
+            ) {
+                toolbarContent()
+            }
+        }
+
+        // Reveal strip — invisible tap target pinned to the bottom edge,
+        // live only while the toolbar is auto-hidden. No visual affordance
+        // by design: it IS the bit of extra map the feature exists to
+        // reveal, so drawing a hint over it would defeat the point.
+        if (autoHideActive && !toolbarVisible) {
+            Box(
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .height(40.dp)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { revealTrigger++ },
+            )
+        }
         }
     }
 

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MapScreen.kt
@@ -1436,6 +1436,7 @@ fun MapScreen(onOpenTab: (String) -> Unit = {}) {
                 // there). Hamburger goes to Settings.
                 onServerTap = { onOpenTab("servers") },
                 onMenuTap = { onOpenTab("settings") },
+                showDetails = userPrefs.topInfoBarVisible,
                 // One flag per enabled server → "N/M ●●●" multi-server badge.
                 serverConnectedFlags = allServers
                     .filter { it.enabled }

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshTopologyScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshTopologyScreen.kt
@@ -310,7 +310,7 @@ private fun hopColor(hops: Int): Color = when {
     else -> Color(0xFFFF3B30)        // red — distant
 }
 
-private fun relativeTime(epochSeconds: Long, nowMs: Long = System.currentTimeMillis()): String {
+fun relativeTime(epochSeconds: Long, nowMs: Long = System.currentTimeMillis()): String {
     if (epochSeconds <= 0) return "—"
     val seconds = (nowMs / 1_000) - epochSeconds
     return when {

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshtasticScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/MeshtasticScreen.kt
@@ -766,6 +766,7 @@ private fun NodeRow(node: MeshNode, onClick: () -> Unit = {}) {
             )
             Text(
                 "id ${node.idHex}" +
+                    " · ${relativeTime(node.lastHeardEpoch)}" +
                     (node.snr?.let { " · SNR ${"%.1f".format(it)}" } ?: "") +
                     (node.hopDistance?.let { " · hop $it" } ?: ""),
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),

--- a/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/soy/engindearing/omnitak/mobile/ui/screens/SettingsScreen.kt
@@ -682,6 +682,52 @@ fun SettingsScreen(
                     onCheckedChange = { v -> mutate { it.copy(keepScreenOn = v) } },
                 )
             }
+            // Auto-hide toolbar — map tab only
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Auto-hide toolbar",
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        "On the map tab, hide the bottom toolbar after 3s to show more map. " +
+                            "Tap the bottom edge to bring it back",
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = prefs.autoHideToolbar,
+                    onCheckedChange = { v -> mutate { it.copy(autoHideToolbar = v) } },
+                )
+            }
+            // Top info bar — server name, msg counters, GPS accuracy, clock
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Top info bar",
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        "Show server name, message counters, GPS accuracy, and the clock " +
+                            "above the map. The small TAK server connection dot stays visible either way",
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = prefs.topInfoBarVisible,
+                    onCheckedChange = { v -> mutate { it.copy(topInfoBarVisible = v) } },
+                )
+            }
             // #178 — staleness overlay: age label + fade on contact pins
             Row(
                 verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Summary

Three independent quality-of-life fixes/features, field-tested over BLE-connected Meshtastic radios:

1. **BLE auto-reconnect** — a paired radio that drops (power-off, out of range) never reconnected on its own; the app had to be reopened and the device manually re-scanned/tapped.
2. **Mesh node list: last-seen age** — the node list showed id/SNR/hop count but no indication of whether the last-heard data was 10 seconds or 10 minutes old.
3. **Map toolbar auto-hide + top info bar toggle** — the bottom toolbar and top status row are always on screen, eating map real estate with no way to reclaim it.

## 1. BLE auto-reconnect

`MeshtasticManager.connectBle()` now remembers the last address it was asked to reach, and a background loop retries it every 20s whenever BLE is the active transport but not currently `Connected`/`Connecting`. A user-initiated `disconnect()` clears the target so tapping "Disconnect" doesn't immediately fight the loop; an involuntary drop (radio power-off, out of range) leaves it set, so the loop keeps trying and reconnects automatically once the radio is back in range.

**Consideration — this alone wasn't enough with the screen off.** The existing foreground-service lifecycle in `OmniTAKApp` only kept the FGS alive while something was actually `Connected`; the moment the BLE link dropped, the FGS tore down too, and without it Android's Doze mode stalls the retry loop's `delay()`/BLE calls the instant the app leaves the foreground. Fixed by exposing `MeshtasticManager.autoReconnectPending: StateFlow<Boolean>` and having the FGS-driving logic in `OmniTAKApp` also treat "an auto-reconnect is pending" as a reason to keep the service (and its "reconnecting to mesh radio…" notification) alive, not just "currently connected". Verified live: radio power-cycled with the app backgrounded and the screen off reconnects on its own within a couple of 20s cycles.

## 2. Mesh node list: last-seen age

Reuses the `relativeTime()` formatter `MeshTopologyScreen` already had for the same field (widened from file-private to internal so both screens share it instead of duplicating the logic) and adds it to `NodeRow`'s subtitle line.

## 3. Map toolbar auto-hide + top info bar toggle

Two new `UserPrefs`, both default **on**:
- `autoHideToolbar` — on the map tab only, the bottom toolbar shows on entering the tab, hides after 3s, and a tap on a 40dp invisible strip at the very bottom edge reveals it again for another 3s. Suspended while the toolbar is in its long-press customize/edit mode. Every other tab is unaffected — the toolbar is the only way to navigate elsewhere there, so it always stays visible.
- `topInfoBarVisible` — toggles the server name / message counters / GPS accuracy / clock row above the map. The small TAK server connection dot is intentionally **not** gated by this toggle — `ATAKStatusBar` grew a `showDetails` param that collapses the bar down to just the dot rather than hiding it entirely.

**Consideration — the toolbar had to become a floating overlay, not a resizable bottom bar.** It originally lived in `Scaffold`'s `bottomBar` slot, so hiding it shrank the `Scaffold` content padding and the map view resized (a visible re-layout jump on the MapLibre surface) every time it hid/showed. It's now hoisted into a local `toolbarContent` composable rendered in two places: normally inside `bottomBar` (reserving layout space as before) on every route *except* map, and as a `BottomCenter`-aligned overlay on top of the map content on the map route specifically, wrapped in the same `AnimatedVisibility`. The map route's `Scaffold` padding is therefore always zero, so the map is always laid out full-screen and the toolbar just floats over the bottom edge of it — no resize, no re-layout, regardless of visibility state. Every other screen (Settings, Chat, etc.) keeps the original space-reserving behavior so the toolbar doesn't overlap their content.

## Testing

- `./gradlew assembleDebug` succeeds
- Manually verified on two physical devices (Pixel 9 Pro, Pixel 10 Pro) over real Meshtastic BLE radios:
  - Auto-reconnect: radio power-cycled with app backgrounded + screen off → reconnects unattended
  - Node age label renders and updates as expected in the mesh node list
  - Toolbar auto-hide/reveal cycle and floating-overlay (no map resize) confirmed in both portrait and landscape
  - Top info bar toggle collapses to just the connection dot; dot state (color) unaffected by the toggle
- Did not run the full unit test suite / lint for this PR — flagging per the contribution checklist so a maintainer can confirm before merge